### PR TITLE
add matplotlib to docs/requirements.txt for docs/conf.py

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,4 @@
+matplotlib
 sphinx<2.0.0
 sphinx_rtd_theme
 sphinxcontrib-bibtex


### PR DESCRIPTION
This is for #21 
- add `matplotlib` to `docs/requirements.txt` for `docs/conf.py`