### PR TITLE
add causalml *.pyx, *.pxd, *.c, *.h to MANIFAST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,7 @@
 # Include the README
-include *.txt
-include *.md
+include *.txt *.md
+recursive-include docs *.txt
+recursive-include causalml *.pyx *.pxd *.c *.h
 
 # Include the license file
 include LICENSE

--- a/causalml/__init__.py
+++ b/causalml/__init__.py
@@ -1,2 +1,2 @@
 name = 'causalml'
-__version__ = '0.2.2'
+__version__ = '0.2.3'

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ packages = find_packages()
 
 setup(
     name="causalml",
-    version="0.2.2",
+    version="0.2.3",
     author="Huigang Chen, Totte Harinen, Jeong-Yoon Lee, Mike Yung, Zhenyu Zhao",
     author_email="",
     description="Python Package for Uplift Modeling and Causal Inference with Machine Learning Algorithms",


### PR DESCRIPTION
This PR is for #26:

PIP installation on LINUX is failing because it cannot find `'causalml/inference/tree/causaltree.pyx`.

- add `causalml/[*.pyx, *.pxd, *.c, *.h]` to `MANIFAST.in`