### PR TITLE
x learner had typo (dhat_cs should be dhat_ts)

### DIFF
--- a/causalml/inference/meta/xlearner.py
+++ b/causalml/inference/meta/xlearner.py
@@ -151,7 +151,7 @@ class BaseXLearner(object):
             dhat_cs[group] = model_tau_c.predict(X)
             dhat_ts[group] = model_tau_t.predict(X)
 
-            _te = (p[group] * dhat_cs[group] + (1 - p[group]) * dhat_cs[group]).reshape(-1, 1)
+            _te = (p[group] * dhat_cs[group] + (1 - p[group]) * dhat_ts[group]).reshape(-1, 1)
             te[:, i] = np.ravel(_te)
 
             if (y is not None) and (treatment is not None) and verbose:
@@ -437,7 +437,7 @@ class BaseXClassifier(BaseXLearner):
             dhat_cs[group] = model_tau_c.predict(X)
             dhat_ts[group] = model_tau_t.predict(X)
 
-            _te = (p[group] * dhat_cs[group] + (1 - p[group]) * dhat_cs[group]).reshape(-1, 1)
+            _te = (p[group] * dhat_cs[group] + (1 - p[group]) * dhat_ts[group]).reshape(-1, 1)
             te[:, i] = np.ravel(_te)
 
             if (y is not None) and (treatment is not None) and verbose:


### PR DESCRIPTION
hotfix: x learner had a typo where we were doing a weighted average of dhat_cs with dhat_cs (which is basically just dhat_cs). Fixed to dhat_ts. 