### PR TITLE
Fixing handling of series inputs to meta learners

### DIFF
--- a/causalml/__init__.py
+++ b/causalml/__init__.py
@@ -1,5 +1,5 @@
 name = 'causalml'
-__version__ = '0.3.3'
+__version__ = '0.3.1'
 __all__ = ['dataset',
            'features',
            'inference',

--- a/causalml/__init__.py
+++ b/causalml/__init__.py
@@ -1,5 +1,5 @@
 name = 'causalml'
-__version__ = '0.3.0'
+__version__ = '0.3.3'
 __all__ = ['dataset',
            'features',
            'inference',

--- a/causalml/inference/meta/rlearner.py
+++ b/causalml/inference/meta/rlearner.py
@@ -7,7 +7,7 @@ import logging
 import pandas as pd
 import numpy as np
 from scipy.stats import norm
-from sklearn.model_selection import cross_val_predict, KFold
+from sklearn.model_selection import cross_val_predict, KFold, train_test_split
 from xgboost import XGBRegressor
 from .utils import check_control_in_treatment, check_p_conditions
 
@@ -58,6 +58,7 @@ class BaseRLearner(object):
         self.ate_alpha = ate_alpha
         self.control_name = control_name
 
+        self.random_state = random_state
         self.cv = KFold(n_splits=n_fold, shuffle=True, random_state=random_state)
 
     def __repr__(self):
@@ -381,6 +382,7 @@ class XGBRRegressor(BaseRRegressor):
                  early_stopping_rounds=30,
                  effect_learner_objective='rank:pairwise',
                  effect_learner_n_estimators=500,
+                 random_state=42,
                  *args,
                  **kwargs):
         """Initialize an R-learner regressor with XGBoost model using pairwise ranking objective.
@@ -394,6 +396,7 @@ class XGBRRegressor(BaseRRegressor):
         """
 
         assert (effect_learner_objective == 'rank:pairwise' or effect_learner_objective == 'reg:linear'), 'Effect learner objective has to be rank:pairwise or reg:linear'
+        assert isinstance(random_state, int), 'random_state should be int.'
 
         self.effect_learner_objective = effect_learner_objective
         if self.effect_learner_objective == 'rank:pairwise':
@@ -402,13 +405,18 @@ class XGBRRegressor(BaseRRegressor):
             self.effect_learner_eval_metric = 'rmse'
         self.effect_learner_n_estimators = effect_learner_n_estimators
         self.early_stopping = early_stopping
-        if self.early_stopping == True:
+        if self.early_stopping:
             self.test_size = test_size
             self.early_stopping_rounds = early_stopping_rounds
 
         super().__init__(
-            outcome_learner = XGBRegressor(*args, **kwargs),
-            effect_learner = XGBRegressor(objective=self.effect_learner_objective, n_estimators=self.effect_learner_n_estimators, *args, **kwargs))
+            outcome_learner=XGBRegressor(random_state=random_state, *args, **kwargs),
+            effect_learner=XGBRegressor(objective=self.effect_learner_objective,
+                                        n_estimators=self.effect_learner_n_estimators,
+                                        random_state=random_state,
+                                        *args,
+                                        **kwargs)
+        )
 
     def fit(self, X, p, treatment, y, verbose=True):
         """Fit the treatment effect and outcome models of the R learner.
@@ -437,63 +445,40 @@ class XGBRRegressor(BaseRRegressor):
             logger.info('generating out-of-fold CV outcome estimates')
         yhat = cross_val_predict(self.model_mu, X, y, cv=self.cv)
 
-        if self.early_stopping:
-            msk = np.random.rand(len(y)) < self.test_size
-            X_test = X[msk]
-            y_test = y[msk]
-            yhat_test = yhat[msk]
+        for group in self.t_groups:
+            treatment_mask = (treatment == group) | (treatment == self.control_name)
+            treatment_filt = treatment[treatment_mask]
+            w = (treatment_filt == group).astype(int)
 
-            X_train = X[~msk]
-            y_train = y[~msk]
-            yhat_train = yhat[~msk]
+            X_filt = X[treatment_mask]
+            y_filt = y[treatment_mask]
+            yhat_filt = yhat[treatment_mask]
+            p_filt = p[group][treatment_mask]
 
-            for group in self.t_groups:
-                treatment_mask = (treatment == group) | (treatment == self.control_name)
-                treatment_filt = treatment[treatment_mask]
+            if verbose:
+                logger.info('training the treatment effect model for {} with R-loss'.format(group))
 
-                X_test_filt = X_test[treatment_mask]
-                X_train_filt = X_train[treatment_mask]
-                y_test_filt = y_test[treatment_mask]
-                y_train_filt = y_train[treatment_mask]
-                yhat_test_filt = yhat_test[treatment_mask]
-                yhat_train_filt = yhat_train[treatment_mask]
+            if self.early_stopping:
+                X_train_filt, X_test_filt, y_train_filt, y_test_filt, yhat_train_filt, yhat_test_filt, \
+                    w_train, w_test, p_train_filt, p_test_filt = train_test_split(
+                        X_filt, y_filt, yhat_filt, w, p_filt,
+                        test_size=self.test_size, random_state=self.random_state
+                    )
 
-                w = (treatment_filt == group).astype(int)
-                w_test = w[msk]
-                w_train = w[~msk]
+                self.models_tau[group].fit(X=X_train_filt,
+                                           y=(y_train_filt - yhat_train_filt) / (w_train - p_train_filt),
+                                           sample_weight=(w_train - p_train_filt) ** 2,
+                                           eval_set=[(X_test_filt,
+                                                      (y_test_filt - yhat_test_filt) / (w_test - p_test_filt))],
+                                           sample_weight_eval_set=[(w_test - p_test_filt) ** 2],
+                                           eval_metric=self.effect_learner_eval_metric,
+                                           early_stopping_rounds=self.early_stopping_rounds,
+                                           verbose=verbose)
 
-                p_test_filt = p[group][treatment_mask][msk]
-                p_train_filt = p[group][treatment_mask][~msk]
-
-                if verbose:
-                    logger.info('training the treatment effect model for {} with R-loss'.format(group))
-                self.models_tau[group].fit(X = X_train_filt,
-                    y = (y_train_filt - yhat_train_filt) / (w_train - p_train_filt),
-                    sample_weight = (w_train - p_train_filt) ** 2,
-                    eval_set = [(X_test_filt, (y_test_filt - yhat_test_filt) / (w_test - p_test_filt))],
-                    sample_weight_eval_set = [(w_test - p_test_filt) ** 2],
-                    eval_metric = self.effect_learner_eval_metric,
-                    early_stopping_rounds = self.early_stopping_rounds,
-                    verbose = verbose)
-
-                self.vars_c[group] = (y_train_filt[w == 0] - yhat_train_filt[w == 0]).var()
-                self.vars_t[group] = (y_train_filt[w == 1] - yhat_train_filt[w == 1]).var()
-
-        else:
-            for group in self.t_groups:
-                treatment_mask = (treatment == group) | (treatment == self.control_name)
-                treatment_filt = treatment[treatment_mask]
-                X_filt = X[treatment_mask]
-                y_filt = y[treatment_mask]
-                yhat_filt = yhat[treatment_mask]
-                p_filt = p[group][treatment_mask]
-                w = (treatment_filt == group).astype(int)
-
-                if verbose:
-                    logger.info('training the treatment effect model for {} with R-loss'.format(group))
+            else:
                 self.models_tau[group].fit(X_filt, (y_filt - yhat_filt) / (w - p_filt),
-                                           sample_weight=(w - p_filt)** 2,
+                                           sample_weight=(w - p_filt) ** 2,
                                            eval_metric=self.effect_learner_eval_metric)
 
-                self.vars_c[group] = (y_filt[w == 0] - yhat_filt[w == 0]).var()
-                self.vars_t[group] = (y_filt[w == 1] - yhat_filt[w == 1]).var()
+            self.vars_c[group] = (y_filt[w == 0] - yhat_filt[w == 0]).var()
+            self.vars_t[group] = (y_filt[w == 1] - yhat_filt[w == 1]).var()

--- a/causalml/inference/meta/rlearner.py
+++ b/causalml/inference/meta/rlearner.py
@@ -307,8 +307,8 @@ class BaseRClassifier(BaseRLearner):
             n_fold=n_fold,
             random_state=random_state)
 
-        if (outcome_learner is None) and (effect_learner is None):
-            raise ValueError("Either the outcome learner or the effect learner must be specified.")
+        # if (outcome_learner is None) and (effect_learner is None):
+        #    raise ValueError("Either the outcome learner or the effect learner must be specified.")
 
     def fit(self, X, p, treatment, y, verbose=True):
         """Fit the treatment effect and outcome models of the R learner.

--- a/causalml/inference/meta/rlearner.py
+++ b/causalml/inference/meta/rlearner.py
@@ -92,7 +92,7 @@ class BaseRLearner(object):
 
         if verbose:
             logger.info('generating out-of-fold CV outcome estimates')
-        yhat = cross_val_predict(self.model_mu, X, y, cv=self.cv)
+        yhat = cross_val_predict(self.model_mu, X, y, cv=self.cv, n_jobs=-1)
 
         for group in self.t_groups:
             mask = (treatment == group) | (treatment == self.control_name)
@@ -339,7 +339,7 @@ class BaseRClassifier(BaseRLearner):
 
         if verbose:
             logger.info('generating out-of-fold CV outcome estimates')
-        yhat = cross_val_predict(self.model_mu, X, y, cv=self.cv, method='predict_proba')[:, 1]
+        yhat = cross_val_predict(self.model_mu, X, y, cv=self.cv, method='predict_proba', n_jobs=-1)[:, 1]
 
         for group in self.t_groups:
             mask = (treatment == group) | (treatment == self.control_name)
@@ -443,7 +443,7 @@ class XGBRRegressor(BaseRRegressor):
 
         if verbose:
             logger.info('generating out-of-fold CV outcome estimates')
-        yhat = cross_val_predict(self.model_mu, X, y, cv=self.cv)
+        yhat = cross_val_predict(self.model_mu, X, y, cv=self.cv, n_jobs=-1)
 
         for group in self.t_groups:
             treatment_mask = (treatment == group) | (treatment == self.control_name)

--- a/causalml/inference/meta/rlearner.py
+++ b/causalml/inference/meta/rlearner.py
@@ -307,8 +307,11 @@ class BaseRClassifier(BaseRLearner):
             n_fold=n_fold,
             random_state=random_state)
 
-        # if (outcome_learner is None) and (effect_learner is None):
-        #    raise ValueError("Either the outcome learner or the effect learner must be specified.")
+        if (outcome_learner is None) or (effect_learner is None):
+            raise ValueError("Both the outcome learner and the effect learner must be specified.")
+
+        if ('predict_proba' not in dir(outcome_learner)):
+            raise ValueError("Outcome learner must be a classification model (have predict_proba method).")
 
     def fit(self, X, p, treatment, y, verbose=True):
         """Fit the treatment effect and outcome models of the R learner.

--- a/causalml/inference/meta/utils.py
+++ b/causalml/inference/meta/utils.py
@@ -3,7 +3,7 @@ import numpy as np
 
 def check_control_in_treatment(treatment, control_name):
     if np.unique(treatment).shape[0] == 2:
-        assert control_name in treatment, \
+        assert np.isin(control_name, treatment).all(), \
             'If treatment vector has 2 unique values, one of them must be the control (specify in init step).'
 
 

--- a/causalml/inference/meta/xlearner.py
+++ b/causalml/inference/meta/xlearner.py
@@ -363,9 +363,14 @@ class BaseXClassifier(BaseXLearner):
             ate_alpha=ate_alpha,
             control_name=control_name)
 
-        #if ((control_outcome_learner is None) or (treatment_outcome_learner is None)) and (
-        #        (control_effect_learner is None) or (treatment_effect_learner is None)):
-        #    raise ValueError("Either the outcome learner or the effect learner pair must be specified.")
+        if ((control_outcome_learner is None) or (treatment_outcome_learner is None) or 
+                (control_effect_learner is None) or (treatment_effect_learner is None)):
+            raise ValueError("All outcome and effect learners must be specified.")
+
+        if (('predict_proba' not in dir(control_outcome_learner)) or 
+            ('predict_proba' not in dir(treatment_outcome_learner))):
+            raise ValueError("Outcome learners must be a classification model (have predict_proba method).")
+
 
     def fit(self, X, treatment, y):
         """Fit the inference model.

--- a/causalml/inference/meta/xlearner.py
+++ b/causalml/inference/meta/xlearner.py
@@ -363,9 +363,9 @@ class BaseXClassifier(BaseXLearner):
             ate_alpha=ate_alpha,
             control_name=control_name)
 
-        if ((control_outcome_learner is None) or (treatment_outcome_learner is None)) and (
-                (control_effect_learner is None) or (treatment_effect_learner is None)):
-            raise ValueError("Either the outcome learner or the effect learner pair must be specified.")
+        #if ((control_outcome_learner is None) or (treatment_outcome_learner is None)) and (
+        #        (control_effect_learner is None) or (treatment_effect_learner is None)):
+        #    raise ValueError("Either the outcome learner or the effect learner pair must be specified.")
 
     def fit(self, X, treatment, y):
         """Fit the inference model.

--- a/causalml/inference/meta/xlearner.py
+++ b/causalml/inference/meta/xlearner.py
@@ -151,7 +151,7 @@ class BaseXLearner(object):
             dhat_cs[group] = model_tau_c.predict(X)
             dhat_ts[group] = model_tau_t.predict(X)
 
-            _te = (p[group] * dhat_cs[group] + (1 - p[group]) * dhat_cs[group]).reshape(-1, 1)
+            _te = (p[group] * dhat_cs[group] + (1 - p[group]) * dhat_ts[group]).reshape(-1, 1)
             te[:, i] = np.ravel(_te)
 
             if (y is not None) and (treatment is not None) and verbose:
@@ -442,7 +442,7 @@ class BaseXClassifier(BaseXLearner):
             dhat_cs[group] = model_tau_c.predict(X)
             dhat_ts[group] = model_tau_t.predict(X)
 
-            _te = (p[group] * dhat_cs[group] + (1 - p[group]) * dhat_cs[group]).reshape(-1, 1)
+            _te = (p[group] * dhat_cs[group] + (1 - p[group]) * dhat_ts[group]).reshape(-1, 1)
             te[:, i] = np.ravel(_te)
 
             if (y is not None) and (treatment is not None) and verbose:

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -3,11 +3,13 @@
 Changelog
 =========
 
-0.3.0 (unreleased)
+0.3.0 (2019-09-17)
 ------------------
 
-- Extend meta-learners to support classification
-- Fix a bug in uplift curves (`get_cumgain()` and `plot_cumgain()` in `metrics`)
+- Extend meta-learners to support classification by @t-tte
+- Extend meta-learners to support multiple treatments by @yungmsh
+- Fix a bug in uplift curves and add Qini curves/scores to `metrics` by @jeongyoonlee
+- Add `inference.meta.XGBRRegressor` with early stopping and ranking optimizatino by @yluogit
 
 0.2.0 (2019-08-12)
 ------------------

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -9,7 +9,7 @@ Changelog
 - Extend meta-learners to support classification by @t-tte
 - Extend meta-learners to support multiple treatments by @yungmsh
 - Fix a bug in uplift curves and add Qini curves/scores to `metrics` by @jeongyoonlee
-- Add `inference.meta.XGBRRegressor` with early stopping and ranking optimizatino by @yluogit
+- Add `inference.meta.XGBRRegressor` with early stopping and ranking optimization by @yluogit
 
 0.2.0 (2019-08-12)
 ------------------

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 from setuptools.extension import Extension
 from Cython.Build import cythonize
 import numpy as np
-
+import causalml
 
 with open("README.md", "r") as f:
     long_description = f.read()
@@ -24,7 +24,7 @@ packages = find_packages()
 
 setup(
     name="causalml",
-    version="0.3.0",
+    version=causalml.__version__,
     author="Huigang Chen, Totte Harinen, Jeong-Yoon Lee, Mike Yung, Zhenyu Zhao",
     author_email="",
     description="Python Package for Uplift Modeling and Causal Inference with Machine Learning Algorithms",


### PR DESCRIPTION
For your consideration. The meta learners have a check `check_control_in_treatment` which breaks on Pandas Series (which are a handy way to organize data) as `in` doesn't work directly on Series objects. 

- Also dropped assert for r and x learner as the assert should (I believe) be handled in the base (just commented out, can remove)
- Also changed version in setup to be pulled from __init.py__ to keep version recorded in one and only one place.

Happy to iterate. 