### PR TITLE
Update Quickstart guide with missing import and array indexing

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,28 +68,29 @@ $ python setup.py install
 from causalml.inference.meta import LRSRegressor
 from causalml.inference.meta import XGBTRegressor, MLPTRegressor
 from causalml.inference.meta import BaseXRegressor
+from xgboost import XGBRegressor
 from causalml.dataset import synthetic_data
 
 y, X, treatment, _, _, e = synthetic_data(mode=1, n=1000, p=5, sigma=1.0)
 
 lr = LRSRegressor()
 te, lb, ub = lr.estimate_ate(X, treatment, y)
-logger.info('Average Treatment Effect (Linear Regression): {:.2f} ({:.2f}, {:.2f})'.format(te, lb, ub))
+logger.info('Average Treatment Effect (Linear Regression): {:.2f} ({:.2f}, {:.2f})'.format(te[0], lb[0], ub[0]))
 
 xg = XGBTRegressor(random_state=42)
 te, lb, ub = xg.estimate_ate(X, treatment, y)
-logger.info('Average Treatment Effect (XGBoost): {:.2f} ({:.2f}, {:.2f})'.format(te, lb, ub))
+logger.info('Average Treatment Effect (XGBoost): {:.2f} ({:.2f}, {:.2f})'.format(te[0], lb[0], ub[0]))
 
 nn = MLPTRegressor(hidden_layer_sizes=(10, 10),
                  learning_rate_init=.1,
                  early_stopping=True,
                  random_state=42)
 te, lb, ub = nn.estimate_ate(X, treatment, y)
-logger.info('Average Treatment Effect (Neural Network (MLP)): {:.2f} ({:.2f}, {:.2f})'.format(te, lb, ub))
+logger.info('Average Treatment Effect (Neural Network (MLP)): {:.2f} ({:.2f}, {:.2f})'.format(te[0], lb[0], ub[0]))
 
 xl = BaseXRegressor(learner=XGBRegressor(random_state=42))
 te, lb, ub = xl.estimate_ate(X, e, treatment, y)
-logger.info('Average Treatment Effect (XGBoost): {:.2f} ({:.2f}, {:.2f})'.format(te, lb, ub))
+logger.info('Average Treatment Effect (XGBoost): {:.2f} ({:.2f}, {:.2f})'.format(te[0], lb[0], ub[0]))
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -62,12 +62,13 @@ $ python setup.py install
 
 # Quick Start
 
-## Average Treatment Effect Estimation with S, T, and X Learners
+## Average Treatment Effect Estimation with S, T, X, and R Learners
 
 ```python
 from causalml.inference.meta import LRSRegressor
 from causalml.inference.meta import XGBTRegressor, MLPTRegressor
 from causalml.inference.meta import BaseXRegressor
+from causalml.inference.meta import BaseRRegressor
 from xgboost import XGBRegressor
 from causalml.dataset import synthetic_data
 
@@ -75,24 +76,29 @@ y, X, treatment, _, _, e = synthetic_data(mode=1, n=1000, p=5, sigma=1.0)
 
 lr = LRSRegressor()
 te, lb, ub = lr.estimate_ate(X, treatment, y)
-logger.info('Average Treatment Effect (Linear Regression): {:.2f} ({:.2f}, {:.2f})'.format(te[0], lb[0], ub[0]))
+print('Average Treatment Effect (Linear Regression): {:.2f} ({:.2f}, {:.2f})'.format(te[0], lb[0], ub[0]))
 
 xg = XGBTRegressor(random_state=42)
 te, lb, ub = xg.estimate_ate(X, treatment, y)
-logger.info('Average Treatment Effect (XGBoost): {:.2f} ({:.2f}, {:.2f})'.format(te[0], lb[0], ub[0]))
+print('Average Treatment Effect (XGBoost): {:.2f} ({:.2f}, {:.2f})'.format(te[0], lb[0], ub[0]))
 
 nn = MLPTRegressor(hidden_layer_sizes=(10, 10),
                  learning_rate_init=.1,
                  early_stopping=True,
                  random_state=42)
 te, lb, ub = nn.estimate_ate(X, treatment, y)
-logger.info('Average Treatment Effect (Neural Network (MLP)): {:.2f} ({:.2f}, {:.2f})'.format(te[0], lb[0], ub[0]))
+print('Average Treatment Effect (Neural Network (MLP)): {:.2f} ({:.2f}, {:.2f})'.format(te[0], lb[0], ub[0]))
 
 xl = BaseXRegressor(learner=XGBRegressor(random_state=42))
 te, lb, ub = xl.estimate_ate(X, e, treatment, y)
-logger.info('Average Treatment Effect (XGBoost): {:.2f} ({:.2f}, {:.2f})'.format(te[0], lb[0], ub[0]))
+print('Average Treatment Effect (BaseXRegressor using XGBoost): {:.2f} ({:.2f}, {:.2f})'.format(te[0], lb[0], ub[0]))
 
+rl = BaseRRegressor(learner=XGBRegressor(random_state=42))
+te, lb, ub =  rl.estimate_ate(X=X, p=e, treatment=treatment, y=y)
+print('Average Treatment Effect (BaseRRegressor using XGBoost): {:.2f} ({:.2f}, {:.2f})'.format(te[0], lb[0], ub[0]))
 ```
+
+See [Meta-Learner Example Notebook](./examples/meta_learners_with_synthetic_data.ipynb) for details
 
 
 # Contributing


### PR DESCRIPTION
1. Add missing XGBRegressor import and indexing of the returning ATE estimate arrays
2. Add R Learner too and include a link to the example notebook