### PR TITLE
Uplift tree plot contains edges connecting to wrong parent node

### DIFF
--- a/causalml/inference/tree/plot.py
+++ b/causalml/inference/tree/plot.py
@@ -79,7 +79,7 @@ def uplift_tree_plot(decisionTree, x_names):
     dcNodes = defaultdict(list)
     """Plots the obtained decision tree. """
 
-    def toString(iSplit, decisionTree, bBranch, szParent="null", indent='', branchParent=None):
+    def toString(iSplit, decisionTree, bBranch, szParent="null", indent='', indexParent=0):
         if decisionTree.results != None:  # leaf node
             lsY = []
             for szX, n in decisionTree.results.items():
@@ -88,8 +88,7 @@ def uplift_tree_plot(decisionTree, x_names):
             dcSummary = decisionTree.summary
             dcNodes[iSplit].append(['leaf', dcY['name'], szParent, bBranch, str(-round(float(decisionTree.summary['impurity']),3)),
                                     dcSummary['samples'], dcSummary['group_size'], dcSummary['upliftScore'], dcSummary['matchScore'],
-                                    branchParent])
-            return dcY
+                                    indexParent])
         else:
             szCol = 'Column %s' % decisionTree.col
             if szCol in dcHeadings:
@@ -98,12 +97,14 @@ def uplift_tree_plot(decisionTree, x_names):
                 decision = '%s >= %s' % (szCol, decisionTree.value)
             else:
                 decision = '%s == %s' % (szCol, decisionTree.value)
-            toString(iSplit + 1, decisionTree.trueBranch, True, decision, indent + '\t\t', bBranch)
-            toString(iSplit + 1, decisionTree.falseBranch, False, decision, indent + '\t\t', bBranch)
+
+            indexOfLevel = len(dcNodes[iSplit])
+            toString(iSplit + 1, decisionTree.trueBranch, True, decision, indent + '\t\t', indexOfLevel)
+            toString(iSplit + 1, decisionTree.falseBranch, False, decision, indent + '\t\t', indexOfLevel)
             dcSummary = decisionTree.summary
             dcNodes[iSplit].append([iSplit + 1, decision, szParent, bBranch, str(-round(float(decisionTree.summary['impurity']),3)),
                                     dcSummary['samples'], dcSummary['group_size'], dcSummary['upliftScore'], dcSummary['matchScore'],
-                                    branchParent])
+                                    indexParent])
 
     toString(0, decisionTree, None)
     lsDot = ['digraph Tree {',
@@ -114,10 +115,11 @@ def uplift_tree_plot(decisionTree, x_names):
     dcParent = {}
     for nSplit in range(len(dcNodes.items())):
         lsY = dcNodes[nSplit]
+        indexOfLevel = 0
         for lsX in lsY:
-            iSplit, decision, szParent, bBranch, szImpurity, szSamples, szGroup, upliftScore, matchScore, branchParent = lsX
+            iSplit, decision, szParent, bBranch, szImpurity, szSamples, szGroup, upliftScore, matchScore, indexParent = lsX
             if type(iSplit) == int:
-                szSplit = '%d-%s-%s' % (iSplit, decision, str(bBranch))
+                szSplit = '%d-%d' % (iSplit, indexOfLevel)
                 dcParent[szSplit] = i_node
                 lsDot.append('%d [label=<%s<br/> impurity %s<br/> total_sample %s <br/>group_sample %s <br/> uplift score: %s <br/> uplift p_value %s <br/> validation uplift score %s>, fillcolor="#e5813900"] ;' % (i_node,
                                                                                                           decision.replace(
@@ -147,7 +149,7 @@ def uplift_tree_plot(decisionTree, x_names):
                 else:
                     szAngle = '-45'
                     szHeadLabel = 'False'
-                szSplit = '%d-%s-%s' % (nSplit, szParent, str(branchParent))
+                szSplit = '%d-%d' % (nSplit, indexParent)
                 p_node = dcParent[szSplit]
                 if nSplit == 1:
                     lsDot.append('%d -> %d [labeldistance=2.5, labelangle=%s, headlabel="%s"] ;' % (p_node,
@@ -156,6 +158,7 @@ def uplift_tree_plot(decisionTree, x_names):
                 else:
                     lsDot.append('%d -> %d ;' % (p_node, i_node))
             i_node += 1
+            indexOfLevel += 1
     lsDot.append('}')
     dot_data = '\n'.join(lsDot)
     graph = pydotplus.graph_from_dot_data(dot_data)


### PR DESCRIPTION
Use the index of the node as the unique dict key rather than level+decision to avoid duplicates, so it wouldn't misuse the last node when the actual parent is another one

After fix
![uplift_tree_correct copy](https://user-images.githubusercontent.com/4966393/68450662-a7cf5780-01a0-11ea-8206-db59ef685c5a.png)

Before fix

![uplift_tree_validate copy](https://user-images.githubusercontent.com/4966393/68450700-c59cbc80-01a0-11ea-9a0e-16db02df00b5.png)
(example 1)

![uplift_tree_v2_d7 copy](https://user-images.githubusercontent.com/4966393/68450590-735b9b80-01a0-11ea-8c3f-b57be059b28d.png)
(example 2)