### PR TITLE
Enhance tree plot with node colors indicating positive and negative uplifts (#86)

### DIFF
--- a/causalml/inference/tree/plot.py
+++ b/causalml/inference/tree/plot.py
@@ -113,14 +113,12 @@ def uplift_tree_plot(decisionTree, x_names):
              ]
     i_node = 0
     dcParent = {}
-    totalSample = -1
+    totalSample = decisionTree.summary.get('samples')  # initialize the value with the total sample size at root
     for nSplit in range(len(dcNodes.items())):
         lsY = dcNodes[nSplit]
         indexOfLevel = 0
         for lsX in lsY:
             iSplit, decision, szParent, bBranch, szImpurity, szSamples, szGroup, upliftScore, matchScore, indexParent = lsX
-            if totalSample == -1:  # initialize the value with the total sample size at root
-                totalSample = int(szSamples)
             sampleProportion = round(int(szSamples)*100./totalSample, 1)
             if type(iSplit) == int:
                 szSplit = '%d-%d' % (iSplit, indexOfLevel)

--- a/causalml/inference/tree/plot.py
+++ b/causalml/inference/tree/plot.py
@@ -75,17 +75,18 @@ def uplift_tree_plot(decisionTree, x_names):
     for i, szY in enumerate(x_names + ['treatment_group_key']):
         szCol = 'Column %d' % i
         dcHeadings[szCol] = str(szY)
- 
+
     dcNodes = defaultdict(list)
     """Plots the obtained decision tree. """
 
-    def toString(iSplit, decisionTree, bBranch, szParent="null", indent='', indexParent=0):
+    def toString(iSplit, decisionTree, bBranch, szParent="null", indent='', indexParent=0, upliftScores=list()):
         if decisionTree.results != None:  # leaf node
             lsY = []
             for szX, n in decisionTree.results.items():
                 lsY.append('%s:%.2f' % (szX, n))
             dcY = {"name": "%s" % ', '.join(lsY), "parent": szParent}
             dcSummary = decisionTree.summary
+            upliftScores += [dcSummary['matchScore']]
             dcNodes[iSplit].append(['leaf', dcY['name'], szParent, bBranch, str(-round(float(decisionTree.summary['impurity']),3)),
                                     dcSummary['samples'], dcSummary['group_size'], dcSummary['upliftScore'], dcSummary['matchScore'],
                                     indexParent])
@@ -99,21 +100,45 @@ def uplift_tree_plot(decisionTree, x_names):
                 decision = '%s == %s' % (szCol, decisionTree.value)
 
             indexOfLevel = len(dcNodes[iSplit])
-            toString(iSplit + 1, decisionTree.trueBranch, True, decision, indent + '\t\t', indexOfLevel)
-            toString(iSplit + 1, decisionTree.falseBranch, False, decision, indent + '\t\t', indexOfLevel)
+            toString(iSplit + 1, decisionTree.trueBranch, True, decision, indent + '\t\t', indexOfLevel, upliftScores)
+            toString(iSplit + 1, decisionTree.falseBranch, False, decision, indent + '\t\t', indexOfLevel, upliftScores)
             dcSummary = decisionTree.summary
+            upliftScores += [dcSummary['matchScore']]
             dcNodes[iSplit].append([iSplit + 1, decision, szParent, bBranch, str(-round(float(decisionTree.summary['impurity']),3)),
                                     dcSummary['samples'], dcSummary['group_size'], dcSummary['upliftScore'], dcSummary['matchScore'],
                                     indexParent])
 
-    toString(0, decisionTree, None)
+    upliftScores = list()
+    toString(0, decisionTree, None, upliftScores=upliftScores)
+
+    upliftScoreToColor = dict()
+    try:
+        # calculate colors for nodes based on uplifts
+        minUplift = min(upliftScores)
+        maxUplift = max(upliftScores)
+        upliftLevels = [(uplift-minUplift)/(maxUplift-minUplift) for uplift in upliftScores]  # min max scaler
+        baseUplift = float(decisionTree.summary.get('matchScore'))
+        baseUpliftLevel = (baseUplift - minUplift) / (maxUplift - minUplift)  # min max scaler normalization
+        white = np.array([255., 255., 255.])
+        blue = np.array([31., 119., 180.])
+        green = np.array([0., 128., 0.])
+        for i, upliftLevel in enumerate(upliftLevels):
+            if upliftLevel >= baseUpliftLevel:  # go blue
+                color = upliftLevel * blue + (1 - upliftLevel) * white
+            else:  # go green
+                color = (1 - upliftLevel) * green + upliftLevel * white
+            color = [int(c) for c in color]
+            upliftScoreToColor[upliftScores[i]] = ('#%2x%2x%2x' % tuple(color)).replace(' ', '0')  # color code
+    except Exception as e:
+        print(e)
+
     lsDot = ['digraph Tree {',
              'node [shape=box, style="filled, rounded", color="black", fontname=helvetica] ;',
              'edge [fontname=helvetica] ;'
              ]
     i_node = 0
     dcParent = {}
-    totalSample = decisionTree.summary.get('samples')  # initialize the value with the total sample size at root
+    totalSample = int(decisionTree.summary.get('samples'))  # initialize the value with the total sample size at root
     for nSplit in range(len(dcNodes.items())):
         lsY = dcNodes[nSplit]
         indexOfLevel = 0
@@ -123,7 +148,7 @@ def uplift_tree_plot(decisionTree, x_names):
             if type(iSplit) == int:
                 szSplit = '%d-%d' % (iSplit, indexOfLevel)
                 dcParent[szSplit] = i_node
-                lsDot.append('%d [label=<%s<br/> impurity %s<br/> total_sample %s (%s&#37;)<br/>group_sample %s <br/> uplift score: %s <br/> uplift p_value %s <br/> validation uplift score %s>, fillcolor="#e5813900"] ;' % (i_node,
+                lsDot.append('%d [label=<%s<br/> impurity %s<br/> total_sample %s (%s&#37;)<br/>group_sample %s <br/> uplift score: %s <br/> uplift p_value %s <br/> validation uplift score %s>, fillcolor="%s"] ;' % (i_node,
                                                                                                           decision.replace(
                                                                                                               '>=',
                                                                                                               '&ge;').replace(
@@ -134,9 +159,10 @@ def uplift_tree_plot(decisionTree, x_names):
                                                                                                           szGroup,
                                                                                                           str(upliftScore[0]), 
                                                                                                           str(upliftScore[1]),
-                                                                                                          str(matchScore)))
+                                                                                                          str(matchScore),
+                                                                                                          upliftScoreToColor.get(matchScore, '#e5813900')))
             else:
-                lsDot.append('%d [label=< impurity %s<br/> total_sample %s (%s&#37;)<br/>group_sample %s <br/> uplift score: %s <br/> uplift p_value %s <br/> validation uplift score %s <br/> mean %s>, fillcolor="#e5813900"] ;' % (i_node,
+                lsDot.append('%d [label=< impurity %s<br/> total_sample %s (%s&#37;)<br/>group_sample %s <br/> uplift score: %s <br/> uplift p_value %s <br/> validation uplift score %s <br/> mean %s>, fillcolor="%s"] ;' % (i_node,
                                                                                                                 szImpurity,
                                                                                                                 szSamples,
                                                                                                                 str(sampleProportion),
@@ -144,7 +170,8 @@ def uplift_tree_plot(decisionTree, x_names):
                                                                                                                 str(upliftScore[0]),
                                                                                                                 str(upliftScore[1]),
                                                                                                                 str(matchScore),
-                                                                                                                decision))
+                                                                                                                decision,
+                                                                                                                upliftScoreToColor.get(matchScore, '#e5813900')))
 
             if szParent != 'null':
                 if bBranch:


### PR DESCRIPTION
For #86. Also, simplify a bit on the _totalSample_ value initiation on line 141

(sample output 1)
![1115](https://user-images.githubusercontent.com/4966393/69003176-86622000-08b2-11ea-9a07-b05fb3be1d9d.png)
(sample output 2)
![1116_v](https://user-images.githubusercontent.com/4966393/69003177-86622000-08b2-11ea-9a68-5b39bd27ec9e.png)
