### PR TITLE
Update DGP for regression with an option for imbalanced propensity

### DIFF
--- a/causalml/dataset/regression.py
+++ b/causalml/dataset/regression.py
@@ -1,14 +1,12 @@
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 import logging
 import numpy as np
+from scipy.special import expit, logit
 
 
 logger = logging.getLogger('causalml')
 
 
-def synthetic_data(mode=1, n=1000, p=5, sigma=1.0):
+def synthetic_data(mode=1, n=1000, p=5, sigma=1.0, adj=0.):
     ''' Synthetic data in Nie X. and Wager S. (2018) 'Quasi-Oracle Estimation of Heterogeneous Treatment Effects'
 
     Args:
@@ -20,6 +18,8 @@ def synthetic_data(mode=1, n=1000, p=5, sigma=1.0):
         n (int, optional): number of observations
         p (int optional): number of covariates (>=5)
         sigma (float): standard deviation of the error term
+        adj (float): adjustment term for the distribution of propensity, e. Higher values shift the distribution to 0.
+                     It does not apply to mode == 2 or 3.
 
     Returns:
         (tuple): Synthetically generated samples with the following outputs:
@@ -38,10 +38,10 @@ def synthetic_data(mode=1, n=1000, p=5, sigma=1.0):
                3: simulate_easy_propensity_difficult_baseline,
                4: simulate_unrelated_treatment_control}
 
-    return catalog[mode](n, p, sigma)
+    return catalog[mode](n, p, sigma, adj)
 
 
-def simulate_nuisance_and_easy_treatment(n=1000, p=5, sigma=1.0):
+def simulate_nuisance_and_easy_treatment(n=1000, p=5, sigma=1.0, adj=0.):
     ''' Synthetic data with a diffult nuisance components and an easy treatment effect
         From Setup A in Nie X. and Wager S. (2018) 'Quasi-Oracle Estimation of Heterogeneous Treatment Effects'
 
@@ -49,6 +49,7 @@ def simulate_nuisance_and_easy_treatment(n=1000, p=5, sigma=1.0):
         n (int, optional): number of observations
         p (int optional): number of covariates (>=5)
         sigma (float): standard deviation of the error term
+        adj (float): adjustment term for the distribution of propensity, e. Higher values shift the distribution to 0.
 
     Returns:
         (tuple): Synthetically generated samples with the following outputs:
@@ -61,11 +62,12 @@ def simulate_nuisance_and_easy_treatment(n=1000, p=5, sigma=1.0):
             - e ((n,)-array): propensity of receiving treatment.
     '''
 
-    X = np.random.uniform(size=n*p).reshape((n,-1))
-    b = np.sin(np.pi * X[:,0] * X[:,1]) + 2 * (X[:,2] - 0.5) ** 2 + X[:,3] + 0.5 * X[:,4]
+    X = np.random.uniform(size=n*p).reshape((n, -1))
+    b = np.sin(np.pi * X[:, 0] * X[:, 1]) + 2 * (X[:, 2] - 0.5) ** 2 + X[:, 3] + 0.5 * X[:, 4]
     eta = 0.1
-    e = np.maximum(np.repeat(eta, n), np.minimum(np.sin(np.pi * X[:,0] * X[:,1]), np.repeat(1-eta, n)))
-    tau = (X[:,0] + X[:,1]) / 2
+    e = np.maximum(np.repeat(eta, n), np.minimum(np.sin(np.pi * X[:, 0] * X[:, 1]), np.repeat(1-eta, n)))
+    e = expit(logit(e) - adj)
+    tau = (X[:, 0] + X[:, 1]) / 2
 
     w = np.random.binomial(1, e, size=n)
     y = b + (w - 0.5) * tau + sigma * np.random.normal(size=n)
@@ -73,7 +75,7 @@ def simulate_nuisance_and_easy_treatment(n=1000, p=5, sigma=1.0):
     return y, X, w, tau, b, e
 
 
-def simulate_randomized_trial(n=1000, p=5, sigma=1.0):
+def simulate_randomized_trial(n=1000, p=5, sigma=1.0, adj=0.):
     ''' Synthetic data of a randomized trial
         From Setup B in Nie X. and Wager S. (2018) 'Quasi-Oracle Estimation of Heterogeneous Treatment Effects'
 
@@ -81,6 +83,8 @@ def simulate_randomized_trial(n=1000, p=5, sigma=1.0):
         n (int, optional): number of observations
         p (int optional): number of covariates (>=5)
         sigma (float): standard deviation of the error term
+        adj (float): no effect. added for consistency
+
 
     Returns:
         (tuple): Synthetically generated samples with the following outputs:
@@ -93,10 +97,10 @@ def simulate_randomized_trial(n=1000, p=5, sigma=1.0):
             - e ((n,)-array): propensity of receiving treatment.
     '''
 
-    X = np.random.normal(size=n*p).reshape((n,-1))
-    b = np.maximum(np.repeat(0.0, n), X[:,0] + X[:,1] + X[:,2]) + np.maximum(np.repeat(0.0, n), X[:,3] + X[:,4])
+    X = np.random.normal(size=n*p).reshape((n, -1))
+    b = np.maximum(np.repeat(0.0, n), X[:, 0] + X[:, 1] + X[:, 2]) + np.maximum(np.repeat(0.0, n), X[:, 3] + X[:, 4])
     e = np.repeat(0.5, n)
-    tau = X[:,0] + np.log1p(np.exp(X[:,1]))
+    tau = X[:, 0] + np.log1p(np.exp(X[:, 1]))
 
     w = np.random.binomial(1, e, size=n)
     y = b + (w - 0.5) * tau + sigma * np.random.normal(size=n)
@@ -104,7 +108,7 @@ def simulate_randomized_trial(n=1000, p=5, sigma=1.0):
     return y, X, w, tau, b, e
 
 
-def simulate_easy_propensity_difficult_baseline(n=1000, p=5, sigma=1.0):
+def simulate_easy_propensity_difficult_baseline(n=1000, p=5, sigma=1.0, adj=0.):
     ''' Synthetic data with easy propensity and a difficult baseline
         From Setup C in Nie X. and Wager S. (2018) 'Quasi-Oracle Estimation of Heterogeneous Treatment Effects'
 
@@ -112,6 +116,7 @@ def simulate_easy_propensity_difficult_baseline(n=1000, p=5, sigma=1.0):
         n (int, optional): number of observations
         p (int optional): number of covariates (>=3)
         sigma (float): standard deviation of the error term
+        adj (float): no effect. added for consistency
 
     Returns:
         (tuple): Synthetically generated samples with the following outputs:
@@ -124,9 +129,9 @@ def simulate_easy_propensity_difficult_baseline(n=1000, p=5, sigma=1.0):
             - e ((n,)-array): propensity of receiving treatment.
     '''
 
-    X = np.random.normal(size=n*p).reshape((n,-1))
-    b = 2 * np.log1p(np.exp(X[:,0] + X[:,1] + X[:,2]))
-    e = 1/(1 + np.exp(X[:,1] + X[:,2]))
+    X = np.random.normal(size=n*p).reshape((n, -1))
+    b = 2 * np.log1p(np.exp(X[:, 0] + X[:, 1] + X[:, 2]))
+    e = 1/(1 + np.exp(X[:, 1] + X[:, 2]))
     tau = np.repeat(1.0, n)
 
     w = np.random.binomial(1, e, size=n)
@@ -135,7 +140,7 @@ def simulate_easy_propensity_difficult_baseline(n=1000, p=5, sigma=1.0):
     return y, X, w, tau, b, e
 
 
-def simulate_unrelated_treatment_control(n=1000, p=5, sigma=1.0):
+def simulate_unrelated_treatment_control(n=1000, p=5, sigma=1.0, adj=0.):
     ''' Synthetic data with unrelated treatment and control groups.
         From Setup D in Nie X. and Wager S. (2018) 'Quasi-Oracle Estimation of Heterogeneous Treatment Effects'
 
@@ -143,6 +148,7 @@ def simulate_unrelated_treatment_control(n=1000, p=5, sigma=1.0):
         n (int, optional): number of observations
         p (int optional): number of covariates (>=3)
         sigma (float): standard deviation of the error term
+        adj (float): adjustment term for the distribution of propensity, e. Higher values shift the distribution to 0.
 
     Returns:
         (tuple): Synthetically generated samples with the following outputs:
@@ -155,13 +161,14 @@ def simulate_unrelated_treatment_control(n=1000, p=5, sigma=1.0):
             - e ((n,)-array): propensity of receiving treatment.
     '''
 
-    X = np.random.normal(size=n*p).reshape((n,-1))
-    b = (np.maximum(np.repeat(0.0, n), X[:,0] + X[:,1] + X[:,2]) + np.maximum(np.repeat(0.0, n), X[:,3] + X[:,4])) / 2
-    e = 1/(1 + np.exp(-X[:,0]) + np.exp(-X[:,1]))
-    tau = np.maximum(np.repeat(0.0, n), X[:,0] + X[:,1] + X[:,2]) - np.maximum(np.repeat(0.0, n), X[:,3] + X[:,4])
+    X = np.random.normal(size=n*p).reshape((n, -1))
+    b = (np.maximum(np.repeat(0.0, n), X[:, 0] + X[:, 1] + X[:, 2])
+         + np.maximum(np.repeat(0.0, n), X[:, 3] + X[:, 4])) / 2
+    e = 1/(1 + np.exp(-X[:, 0]) + np.exp(-X[:, 1]))
+    e = expit(logit(e) - adj)
+    tau = np.maximum(np.repeat(0.0, n), X[:, 0] + X[:, 1] + X[:, 2]) - np.maximum(np.repeat(0.0, n), X[:, 3] + X[:, 4])
 
     w = np.random.binomial(1, e, size=n)
     y = b + (w - 0.5) * tau + sigma * np.random.normal(size=n)
 
     return y, X, w, tau, b, e
-


### PR DESCRIPTION
This PR is for #89. 

- add an `adj` option to DGPs for regression to simulate imbalanced propensity distribution - by @huigangchen 