### PR TITLE
Xgboost objective names

### DIFF
--- a/causalml/inference/meta/rlearner.py
+++ b/causalml/inference/meta/rlearner.py
@@ -552,11 +552,12 @@ class XGBRRegressor(BaseRRegressor):
             'rank:pairwise': 'auc',
             'reg:squarederror': 'rmse',
         })
+
+        effect_learner_objective = clean_xgboost_objective(effect_learner_objective)
+
         assert (effect_learner_objective in metric_mapping), \
             'Effect learner objective must be one of: ' + ", ".join(metric_mapping)
         assert isinstance(random_state, int), 'random_state should be int.'
-
-        effect_learner_objective = clean_xgboost_objective(effect_learner_objective)
 
         self.effect_learner_objective = effect_learner_objective
         self.effect_learner_eval_metric = metric_mapping[effect_learner_objective]

--- a/causalml/inference/meta/utils.py
+++ b/causalml/inference/meta/utils.py
@@ -57,16 +57,3 @@ def clean_xgboost_objective(objective):
         if objective in compat_v83_or_later:
             objective = compat_v83_or_later[objective]
     return objective
-
-
-def xgb_with_valid_objective(xgb_constructor=XGBRegressor):
-    """
-    Wrapper for xgboost constructors that avoids warnings from deprecated default arguments
-    that exist in some version 0.90.
-
-    Returns
-    -------
-    A new xgboost object
-    """
-    valid_objective = clean_xgboost_objective('reg:squarederror')
-    return xgb_constructor(objective=valid_objective)

--- a/causalml/inference/meta/utils.py
+++ b/causalml/inference/meta/utils.py
@@ -1,10 +1,7 @@
 import numpy as np
 
 from packaging import version
-from xgboost import (
-    __version__ as xgboost_version,
-    XGBRegressor
-)
+from xgboost import __version__ as xgboost_version
 
 
 def check_control_in_treatment(treatment, control_name):
@@ -57,3 +54,32 @@ def clean_xgboost_objective(objective):
         if objective in compat_v83_or_later:
             objective = compat_v83_or_later[objective]
     return objective
+
+
+def get_xgboost_objective_metric(objective):
+    """
+    Get the xgboost version-compatible objective and evaluation metric from a potentially version-incompatible input.
+
+    Args
+    ----
+
+    objective : string
+        An xgboost objective that may be incompatible with the installed version.
+
+    Returns
+    -------
+    A tuple with the translated objective and evaluation metric.
+    """
+    def clean_dict_keys(orig):
+        return {clean_xgboost_objective(k): v for (k, v) in orig.items()}
+
+    metric_mapping = clean_dict_keys({
+        'rank:pairwise': 'auc',
+        'reg:squarederror': 'rmse',
+    })
+
+    objective = clean_xgboost_objective(objective)
+
+    assert (objective in metric_mapping), \
+        'Effect learner objective must be one of: ' + ", ".join(metric_mapping)
+    return objective, metric_mapping[objective]

--- a/causalml/inference/meta/utils.py
+++ b/causalml/inference/meta/utils.py
@@ -1,5 +1,11 @@
 import numpy as np
 
+from packaging import version
+from xgboost import (
+    __version__ as xgboost_version,
+    XGBRegressor
+)
+
 
 def check_control_in_treatment(treatment, control_name):
     if np.unique(treatment).shape[0] == 2:
@@ -26,3 +32,41 @@ def check_explain_conditions(method, models, X=None, treatment=None, y=None):
     if method in ('permutation', 'shapley'):
         assert all([arr is not None for arr in (X, treatment, y)]), \
                 "X, treatment, and y must be provided if method = {}".format(method)
+
+
+def clean_xgboost_objective(objective):
+    """
+    Translate objective to be compatible with loaded xgboost version
+
+    Args
+    ----
+
+    objective : string
+        The objective to translate.
+
+    Returns
+    -------
+    The translated objective, or original if no translation was required.
+    """
+    compat_before_v83 = {'reg:squarederror': 'reg:linear'}
+    compat_v83_or_later = {'reg:linear': 'reg:squarederror'}
+    if version.parse(xgboost_version) < version.parse('0.83'):
+        if objective in compat_before_v83:
+            objective = compat_before_v83[objective]
+    else:
+        if objective in compat_v83_or_later:
+            objective = compat_v83_or_later[objective]
+    return objective
+
+
+def xgb_with_valid_objective(xgb_constructor=XGBRegressor):
+    """
+    Wrapper for xgboost constructors that avoids warnings from deprecated default arguments
+    that exist in some version 0.90.
+
+    Returns
+    -------
+    A new xgboost object
+    """
+    valid_objective = clean_xgboost_objective('reg:squarederror')
+    return xgb_constructor(objective=valid_objective)

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,3 +17,4 @@ shap
 dill
 lightgbm
 pygam
+packaging

--- a/tests/test_meta_learners.py
+++ b/tests/test_meta_learners.py
@@ -12,6 +12,7 @@ from causalml.inference.meta import BaseSLearner, BaseSRegressor, BaseSClassifie
 from causalml.inference.meta import BaseTLearner, BaseTRegressor, BaseTClassifier, XGBTRegressor, MLPTRegressor
 from causalml.inference.meta import BaseXLearner, BaseXClassifier, BaseXRegressor
 from causalml.inference.meta import BaseRLearner, BaseRClassifier, BaseRRegressor
+from causalml.inference.meta.utils import xgb_with_valid_objective
 from causalml.metrics import ape, gini, get_cumgain
 
 from .const import RANDOM_SEED, N_SAMPLE, ERROR_THRESHOLD, CONTROL_NAME, CONVERSION
@@ -57,7 +58,7 @@ def test_BaseSLearner(generate_regression_data):
 def test_BaseSRegressor(generate_regression_data):
     y, X, treatment, tau, b, e = generate_regression_data()
 
-    learner = BaseSRegressor(learner=XGBRegressor())
+    learner = BaseSRegressor(learner=xgb_with_valid_objective(XGBRegressor))
 
     # check the accuracy of the ATE estimation
     ate_p, lb, ub = learner.estimate_ate(X=X, treatment=treatment, y=y, return_ci=True, n_bootstraps=10)
@@ -83,7 +84,7 @@ def test_LRSRegressor(generate_regression_data):
 def test_BaseTLearner(generate_regression_data):
     y, X, treatment, tau, b, e = generate_regression_data()
 
-    learner = BaseTLearner(learner=XGBRegressor())
+    learner = BaseTLearner(learner=xgb_with_valid_objective(XGBRegressor))
 
     # check the accuracy of the ATE estimation
     ate_p, lb, ub = learner.estimate_ate(X=X, treatment=treatment, y=y)
@@ -98,7 +99,7 @@ def test_BaseTLearner(generate_regression_data):
 def test_BaseTRegressor(generate_regression_data):
     y, X, treatment, tau, b, e = generate_regression_data()
 
-    learner = BaseTRegressor(learner=XGBRegressor())
+    learner = BaseTRegressor(learner=xgb_with_valid_objective(XGBRegressor))
 
     # check the accuracy of the ATE estimation
     ate_p, lb, ub = learner.estimate_ate(X=X, treatment=treatment, y=y)
@@ -128,7 +129,7 @@ def test_MLPTRegressor(generate_regression_data):
 def test_XGBTRegressor(generate_regression_data):
     y, X, treatment, tau, b, e = generate_regression_data()
 
-    learner = XGBTRegressor()
+    learner = xgb_with_valid_objective(XGBTRegressor)
 
     # check the accuracy of the ATE estimation
     ate_p, lb, ub = learner.estimate_ate(X=X, treatment=treatment, y=y)
@@ -143,7 +144,7 @@ def test_XGBTRegressor(generate_regression_data):
 def test_BaseXLearner(generate_regression_data):
     y, X, treatment, tau, b, e = generate_regression_data()
 
-    learner = BaseXLearner(learner=XGBRegressor())
+    learner = BaseXLearner(learner=xgb_with_valid_objective(XGBRegressor))
 
     # check the accuracy of the ATE estimation
     ate_p, lb, ub = learner.estimate_ate(X=X, p=e, treatment=treatment, y=y)
@@ -158,7 +159,7 @@ def test_BaseXLearner(generate_regression_data):
 def test_BaseXRegressor(generate_regression_data):
     y, X, treatment, tau, b, e = generate_regression_data()
 
-    learner = BaseXRegressor(learner=XGBRegressor())
+    learner = BaseXRegressor(learner=xgb_with_valid_objective(XGBRegressor))
 
     # check the accuracy of the ATE estimation
     ate_p, lb, ub = learner.estimate_ate(X=X, p=e, treatment=treatment, y=y)
@@ -173,7 +174,7 @@ def test_BaseXRegressor(generate_regression_data):
 def test_BaseRLearner(generate_regression_data):
     y, X, treatment, tau, b, e = generate_regression_data()
 
-    learner = BaseRLearner(learner=XGBRegressor())
+    learner = BaseRLearner(learner=xgb_with_valid_objective(XGBRegressor))
 
     # check the accuracy of the ATE estimation
     ate_p, lb, ub = learner.estimate_ate(X=X, p=e, treatment=treatment, y=y)
@@ -188,7 +189,7 @@ def test_BaseRLearner(generate_regression_data):
 def test_BaseRRegressor(generate_regression_data):
     y, X, treatment, tau, b, e = generate_regression_data()
 
-    learner = BaseRRegressor(learner=XGBRegressor())
+    learner = BaseRRegressor(learner=xgb_with_valid_objective(XGBRegressor))
 
     # check the accuracy of the ATE estimation
     ate_p, lb, ub = learner.estimate_ate(X=X, p=e, treatment=treatment, y=y)
@@ -285,9 +286,9 @@ def test_BaseXClassifier(generate_classification_data):
                                          random_state=RANDOM_SEED)
 
     uplift_model = BaseXClassifier(control_outcome_learner=XGBClassifier(),
-                                   control_effect_learner=XGBRegressor(),
+                                   control_effect_learner=xgb_with_valid_objective(XGBRegressor),
                                    treatment_outcome_learner=XGBClassifier(),
-                                   treatment_effect_learner=XGBRegressor())
+                                   treatment_effect_learner=xgb_with_valid_objective(XGBRegressor))
 
     uplift_model.fit(X=df_train[x_names].values,
                      treatment=df_train['treatment_group_key'].values,
@@ -326,7 +327,7 @@ def test_BaseRClassifier(generate_classification_data):
                                          random_state=RANDOM_SEED)
 
     uplift_model = BaseRClassifier(outcome_learner=XGBClassifier(),
-                                   effect_learner=XGBRegressor())
+                                   effect_learner=xgb_with_valid_objective(XGBRegressor))
 
     uplift_model.fit(X=df_train[x_names].values,
                      p=df_train['propensity_score'].values,

--- a/tests/test_meta_learners.py
+++ b/tests/test_meta_learners.py
@@ -12,7 +12,6 @@ from causalml.inference.meta import BaseSLearner, BaseSRegressor, BaseSClassifie
 from causalml.inference.meta import BaseTLearner, BaseTRegressor, BaseTClassifier, XGBTRegressor, MLPTRegressor
 from causalml.inference.meta import BaseXLearner, BaseXClassifier, BaseXRegressor
 from causalml.inference.meta import BaseRLearner, BaseRClassifier, BaseRRegressor
-from causalml.inference.meta.utils import xgb_with_valid_objective
 from causalml.metrics import ape, gini, get_cumgain
 
 from .const import RANDOM_SEED, N_SAMPLE, ERROR_THRESHOLD, CONTROL_NAME, CONVERSION
@@ -58,7 +57,7 @@ def test_BaseSLearner(generate_regression_data):
 def test_BaseSRegressor(generate_regression_data):
     y, X, treatment, tau, b, e = generate_regression_data()
 
-    learner = BaseSRegressor(learner=xgb_with_valid_objective(XGBRegressor))
+    learner = BaseSRegressor(learner=XGBRegressor())
 
     # check the accuracy of the ATE estimation
     ate_p, lb, ub = learner.estimate_ate(X=X, treatment=treatment, y=y, return_ci=True, n_bootstraps=10)
@@ -84,7 +83,7 @@ def test_LRSRegressor(generate_regression_data):
 def test_BaseTLearner(generate_regression_data):
     y, X, treatment, tau, b, e = generate_regression_data()
 
-    learner = BaseTLearner(learner=xgb_with_valid_objective(XGBRegressor))
+    learner = BaseTLearner(learner=XGBRegressor())
 
     # check the accuracy of the ATE estimation
     ate_p, lb, ub = learner.estimate_ate(X=X, treatment=treatment, y=y)
@@ -99,7 +98,7 @@ def test_BaseTLearner(generate_regression_data):
 def test_BaseTRegressor(generate_regression_data):
     y, X, treatment, tau, b, e = generate_regression_data()
 
-    learner = BaseTRegressor(learner=xgb_with_valid_objective(XGBRegressor))
+    learner = BaseTRegressor(learner=XGBRegressor())
 
     # check the accuracy of the ATE estimation
     ate_p, lb, ub = learner.estimate_ate(X=X, treatment=treatment, y=y)
@@ -129,7 +128,7 @@ def test_MLPTRegressor(generate_regression_data):
 def test_XGBTRegressor(generate_regression_data):
     y, X, treatment, tau, b, e = generate_regression_data()
 
-    learner = xgb_with_valid_objective(XGBTRegressor)
+    learner = XGBTRegressor()
 
     # check the accuracy of the ATE estimation
     ate_p, lb, ub = learner.estimate_ate(X=X, treatment=treatment, y=y)
@@ -144,7 +143,7 @@ def test_XGBTRegressor(generate_regression_data):
 def test_BaseXLearner(generate_regression_data):
     y, X, treatment, tau, b, e = generate_regression_data()
 
-    learner = BaseXLearner(learner=xgb_with_valid_objective(XGBRegressor))
+    learner = BaseXLearner(learner=XGBRegressor())
 
     # check the accuracy of the ATE estimation
     ate_p, lb, ub = learner.estimate_ate(X=X, p=e, treatment=treatment, y=y)
@@ -159,7 +158,7 @@ def test_BaseXLearner(generate_regression_data):
 def test_BaseXRegressor(generate_regression_data):
     y, X, treatment, tau, b, e = generate_regression_data()
 
-    learner = BaseXRegressor(learner=xgb_with_valid_objective(XGBRegressor))
+    learner = BaseXRegressor(learner=XGBRegressor())
 
     # check the accuracy of the ATE estimation
     ate_p, lb, ub = learner.estimate_ate(X=X, p=e, treatment=treatment, y=y)
@@ -174,7 +173,7 @@ def test_BaseXRegressor(generate_regression_data):
 def test_BaseRLearner(generate_regression_data):
     y, X, treatment, tau, b, e = generate_regression_data()
 
-    learner = BaseRLearner(learner=xgb_with_valid_objective(XGBRegressor))
+    learner = BaseRLearner(learner=XGBRegressor())
 
     # check the accuracy of the ATE estimation
     ate_p, lb, ub = learner.estimate_ate(X=X, p=e, treatment=treatment, y=y)
@@ -189,7 +188,7 @@ def test_BaseRLearner(generate_regression_data):
 def test_BaseRRegressor(generate_regression_data):
     y, X, treatment, tau, b, e = generate_regression_data()
 
-    learner = BaseRRegressor(learner=xgb_with_valid_objective(XGBRegressor))
+    learner = BaseRRegressor(learner=XGBRegressor())
 
     # check the accuracy of the ATE estimation
     ate_p, lb, ub = learner.estimate_ate(X=X, p=e, treatment=treatment, y=y)
@@ -286,9 +285,9 @@ def test_BaseXClassifier(generate_classification_data):
                                          random_state=RANDOM_SEED)
 
     uplift_model = BaseXClassifier(control_outcome_learner=XGBClassifier(),
-                                   control_effect_learner=xgb_with_valid_objective(XGBRegressor),
+                                   control_effect_learner=XGBRegressor(),
                                    treatment_outcome_learner=XGBClassifier(),
-                                   treatment_effect_learner=xgb_with_valid_objective(XGBRegressor))
+                                   treatment_effect_learner=XGBRegressor())
 
     uplift_model.fit(X=df_train[x_names].values,
                      treatment=df_train['treatment_group_key'].values,
@@ -327,7 +326,7 @@ def test_BaseRClassifier(generate_classification_data):
                                          random_state=RANDOM_SEED)
 
     uplift_model = BaseRClassifier(outcome_learner=XGBClassifier(),
-                                   effect_learner=xgb_with_valid_objective(XGBRegressor))
+                                   effect_learner=XGBRegressor())
 
     uplift_model.fit(X=df_train[x_names].values,
                      p=df_train['propensity_score'].values,


### PR DESCRIPTION
This fixes #96 by translating some xgboost objective names based on the xgboost version installed to avoid deprecation warnings. Current pip and github versions of xgboost want `reg:squarederror` in place of `reg:linear`, but `reg:squarederror` isn't compatible with old versions. 

For xgboost < 0.83, this PR translates `reg:squarederror` into `reg:linear`, and vice versa for xgboost >= 0.83 (including 0.90 and current master). When you run 
```py
>>> [XGBRRegressor(effect_learner_objective=x).effect_learner_objective 
...     for x in ['reg:linear','rank:pairwise','reg:squarederror']]
```
using xgboost==0.82, you get this:
```py
['reg:linear', 'rank:pairwise', 'reg:linear']
```
and for 0.90, you get
```py
['reg:squarederror', 'rank:pairwise', 'reg:squarederror']
```

This PR does not prevent all warnings that appear during causalml tests that use xgboost 0.90. Some of the warnings are based on a bug in 0.90 where the default constructor arguments still used `reg:linear`. Fixes for those warnings were originally implemented but created a lot of clutter for little gain, so I rolled them back in 065d018.
