### PR TITLE
add cython instructions to contributor docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,10 +17,16 @@ If you added a new inference method, add test code to the `tests/` folder.
 
 ## Prerequisites
 
-Causal ML uses `pytest` for tests. Install `pytest` and `pytest-cov`:
+Causal ML uses `pytest` for tests. Install `pytest` and `pytest-cov`, and the package dependencies:
 ```bash
-$ pip install pytest
-$ pip install pytest-cov
+$ pip install pytest pytest-cov -r requirements.txt
+```
+
+## Building Cython
+
+In order to run tests, you need to build the Cython modules
+```bash
+$ python setup.py build_ext --inplace
 ```
 
 ## Testing


### PR DESCRIPTION
Fixes #98. With these changes, the code in CONTRIBUTING.md will run end-to-end by a newcomer with a fresh environment. 

I tested it out using a new conda environment and a fresh pull from github in a temp directory:
```bash
cd $(mktemp -d)
git clone https://github.com/uber/causalml.git
cd causalml
conda env remove --name causalml_devcheck || true
conda create -y --name causalml_devcheck python=3.7
conda run -n causalml_devcheck pip install pytest pytest-cov -r requirements.txt
conda run -n causalml_devcheck python setup.py build_ext --inplace
conda run -n causalml_devcheck pytest -vs tests/ --cov causalml/
```