### PR TITLE
Make control validation consistent across all metalearners

### DIFF
--- a/causalml/inference/meta/rlearner.py
+++ b/causalml/inference/meta/rlearner.py
@@ -10,7 +10,7 @@ from scipy.stats import norm
 from sklearn.model_selection import cross_val_predict, KFold, train_test_split
 from xgboost import XGBRegressor
 
-from causalml.inference.meta.utils import check_control_in_treatment, check_p_conditions
+from causalml.inference.meta.utils import check_treatment_vector, check_p_conditions
 from causalml.inference.meta.explainer import Explainer
 
 logger = logging.getLogger('causalml')
@@ -78,7 +78,7 @@ class BaseRLearner(object):
             treatment (np.array): a treatment vector
             y (np.array): an outcome vector
         """
-        check_control_in_treatment(treatment, self.control_name)
+        check_treatment_vector(treatment, self.control_name)
         self.t_groups = np.unique(treatment[treatment != self.control_name])
         self.t_groups.sort()
         check_p_conditions(p, self.t_groups)
@@ -471,7 +471,7 @@ class BaseRClassifier(BaseRLearner):
             treatment (np.array): a treatment vector
             y (np.array): an outcome vector
         """
-        check_control_in_treatment(treatment, self.control_name)
+        check_treatment_vector(treatment, self.control_name)
         self.t_groups = np.unique(treatment[treatment != self.control_name])
         self.t_groups.sort()
         check_p_conditions(p, self.t_groups)
@@ -579,7 +579,7 @@ class XGBRRegressor(BaseRRegressor):
             treatment (np.array): a treatment vector
             y (np.array): an outcome vector
         """
-        check_control_in_treatment(treatment, self.control_name)
+        check_treatment_vector(treatment, self.control_name)
         self.t_groups = np.unique(treatment[treatment != self.control_name])
         self.t_groups.sort()
         check_p_conditions(p, self.t_groups)

--- a/causalml/inference/meta/slearner.py
+++ b/causalml/inference/meta/slearner.py
@@ -77,6 +77,8 @@ class BaseSLearner(object):
             treatment (np.array): a treatment vector
             y (np.array): an outcome vector
         """
+
+        check_treatment_vector(treatment, self.control_name)
         self.t_groups = np.unique(treatment[treatment != self.control_name])
         self.t_groups.sort()
         self._classes = {group: i for i, group in enumerate(self.t_groups)}

--- a/causalml/inference/meta/slearner.py
+++ b/causalml/inference/meta/slearner.py
@@ -11,6 +11,7 @@ import statsmodels.api as sm
 from copy import deepcopy
 
 from causalml.inference.meta.explainer import Explainer
+from causalml.inference.meta.utils import check_treatment_vector
 from causalml.metrics import regression_metrics, classification_metrics
 
 

--- a/causalml/inference/meta/tlearner.py
+++ b/causalml/inference/meta/tlearner.py
@@ -67,6 +67,7 @@ class BaseTLearner(object):
             treatment (np.array): a treatment vector
             y (np.array): an outcome vector
         """
+        check_treatment_vector(treatment, self.control_name)
         self.t_groups = np.unique(treatment[treatment != self.control_name])
         self.t_groups.sort()
         self._classes = {group: i for i, group in enumerate(self.t_groups)}

--- a/causalml/inference/meta/tlearner.py
+++ b/causalml/inference/meta/tlearner.py
@@ -14,6 +14,7 @@ from xgboost import XGBRegressor
 import shap
 
 from causalml.inference.meta.explainer import Explainer
+from causalml.inference.meta.utils import check_treatment_vector
 from causalml.metrics import regression_metrics, classification_metrics
 
 

--- a/causalml/inference/meta/tmle.py
+++ b/causalml/inference/meta/tmle.py
@@ -5,7 +5,7 @@ from scipy.special import expit, logit
 from scipy.stats import norm
 from sklearn.preprocessing import MinMaxScaler
 
-from causalml.inference.meta.utils import check_control_in_treatment, check_p_conditions
+from causalml.inference.meta.utils import check_treatment_vector, check_p_conditions
 from causalml.propensity import calibrate
 
 
@@ -107,7 +107,7 @@ class TMLELearner(object):
         Returns:
             (tuple): The ATE and its confidence interval (LB, UB) for each treatment, t and segment, s
         """
-        check_control_in_treatment(treatment, self.control_name)
+        check_treatment_vector(treatment, self.control_name)
         self.t_groups = np.unique(treatment[treatment != self.control_name])
         self.t_groups.sort()
 

--- a/causalml/inference/meta/utils.py
+++ b/causalml/inference/meta/utils.py
@@ -1,10 +1,13 @@
 import numpy as np
 
 
-def check_control_in_treatment(treatment, control_name):
-    if np.unique(treatment).shape[0] == 2:
+def check_treatment_vector(treatment, control_name=None):
+    n_unique_treatments = np.unique(treatment).shape[0]
+    assert n_unique_treatments > 1, \
+        'Treatment vector must have at least two levels.'
+    if control_name is not None:
         assert control_name in treatment, \
-            'If treatment vector has 2 unique values, one of them must be the control (specify in init step).'
+            'Control group level {} not found in treatment vector.'.format(control_name)
 
 
 def check_p_conditions(p, t_groups):

--- a/causalml/inference/meta/xlearner.py
+++ b/causalml/inference/meta/xlearner.py
@@ -8,7 +8,7 @@ import numpy as np
 from tqdm import tqdm
 from scipy.stats import norm
 
-from causalml.inference.meta.utils import check_control_in_treatment, check_p_conditions
+from causalml.inference.meta.utils import check_treatment_vector, check_p_conditions
 from causalml.inference.meta.explainer import Explainer
 from causalml.metrics import regression_metrics, classification_metrics
 
@@ -90,7 +90,7 @@ class BaseXLearner(object):
             treatment (np.array): a treatment vector
             y (np.array): an outcome vector
         """
-        check_control_in_treatment(treatment, self.control_name)
+        check_treatment_vector(treatment, self.control_name)
         self.t_groups = np.unique(treatment[treatment != self.control_name])
         self.t_groups.sort()
         self._classes = {group: i for i, group in enumerate(self.t_groups)}
@@ -531,7 +531,7 @@ class BaseXClassifier(BaseXLearner):
             treatment (np.array): a treatment vector
             y (np.array): an outcome vector
         """
-        check_control_in_treatment(treatment, self.control_name)
+        check_treatment_vector(treatment, self.control_name)
         self.t_groups = np.unique(treatment[treatment != self.control_name])
         self.t_groups.sort()
         self._classes = {group: i for i, group in enumerate(self.t_groups)}


### PR DESCRIPTION
Fixes #101 

This tweaks the treatment/control validation logic to:

- ensure that control_name appears in the treatment vector (if control_name is not None)
- ensure that the treatment vector has more than one level

and added the check to the two metalearners that didn't have validation (S-Learner and T-Learner).

There was previously a more limited check in the R and X learners, but only if the treatment vector had two levels. This PR generalizes that and uses the same validator across all the learners.

Note that the tree methods don't have similar validation, but they might successfully throw errors if passed invalid treatment inputs. I haven't tried to address those models here.