### PR TITLE
Causaltree refactor

### DIFF
--- a/causalml/inference/tree/causaltree.pyx
+++ b/causalml/inference/tree/causaltree.pyx
@@ -96,7 +96,6 @@ cdef class CausalMSE(RegressionCriterion):
         cdef double tr_var
         cdef double ct_var
         cdef double one_over_eps = 1e5
-        cdef double big_number = 1e10
 
         for p in range(start, end):
             i = samples[p]
@@ -119,7 +118,7 @@ cdef class CausalMSE(RegressionCriterion):
         ct_var = ((node_sq_sum - node_tr_sq_sum) / node_ct -
                   (node_sum - node_tr_sum) * (node_sum - node_tr_sum) / (node_ct * node_ct))
 
-        return big_number - (node_tau * node_tau - (tr_var / node_tr + ct_var / node_ct))
+        return  (tr_var / node_tr + ct_var / node_ct) - node_tau * node_tau
 
 
     cdef void children_impurity(self, double* impurity_left, double* impurity_right) nogil:
@@ -160,7 +159,6 @@ cdef class CausalMSE(RegressionCriterion):
         cdef double left_ct_var
 
         cdef double one_over_eps = 1e5
-        cdef double big_number = 1e10
 
         for p in range(start, end):
             i = samples[p]
@@ -197,8 +195,8 @@ cdef class CausalMSE(RegressionCriterion):
         left_ct_var = ((left_sq_sum - left_tr_sq_sum) / left_ct -
                         (left_sum - left_tr_sum) * (left_sum - left_tr_sum) / (left_ct * left_ct))
 
-        impurity_left[0] = big_number - (left_tau * left_tau - (left_tr_var / left_tr + left_ct_var / left_ct))
-        impurity_right[0] = big_number - (right_tau * right_tau - (right_tr_var / right_tr + right_ct_var / right_ct))
+        impurity_left[0] = (left_tr_var / left_tr + left_ct_var / left_ct) - left_tau * left_tau
+        impurity_right[0] = (right_tr_var / right_tr + right_ct_var / right_ct) - right_tau * right_tau
 
 
 class CausalTreeRegressor(object):

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ numpy>=0.16.0
 scipy
 matplotlib
 pandas>=0.24.1
-scikit-learn>=0.21.0
+scikit-learn>=0.22.0
 statsmodels>=0.9.0
 seaborn
 Cython


### PR DESCRIPTION
Fixes #106. Replicates a subset of the checks from [sklearn's BaseDecisionTree fit method](https://github.com/scikit-learn/scikit-learn/blob/master/sklearn/tree/_classes.py#L140).

I'd like a second set of eyes to look over the validation checks that I've included/excluded. Most of the excluded ones are either specifically not desired, or they're related to parameters that had previously used default values of `DecisionTreeRegressor`'s constructor and are now hardcoded. 

It passes tests, but I haven't dug into performance vs master yet.