### PR TITLE
Fix TravisCI FOSSA stage fail for PRs from forked repos

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,12 +16,14 @@ jobs:
           name: test
           script: pytest -sv
         - stage: fossa
+          # FOSSA_API_KEY unavailable for pull requests
+          # https://docs.travis-ci.com/user/pull-requests/#pull-requests-and-security-restrictions
+          if: fork = false
           name: fossa
           script:
               # NOTE: before running `fossa` make sure to save your FOSSA_API_KEY in your
               # environment variable in Travis see below.
               - fossa init
               - fossa analyze
-
 after_success:
-    - cd <SOURCE_DIR> && fossa test
+    - cd causalml && fossa test


### PR DESCRIPTION
Resolves #130

[TravisCI's pull request security settings](https://docs.travis-ci.com/user/pull-requests/#pull-requests-and-security-restrictions) prevents access to encrypted variables such as `FOSSA_API_KEY` when running the build jobs. Thus, any PRs made by forked repositories results in an error in the `fossa` stage.

In this PR, I updated `fossa` stage to be ignored if the PR is coming from a forked repository to avoid the exception. This doesn't change the current behavior, just the error reporting.

Alternatively, according to the [fossa documentation on TravisCI](https://docs.fossa.com/docs/travisci), you could set the API key to a [push-only token](https://docs.fossa.com/docs/api-reference#section-push-only-api-token), and expose directly in the `.travis.yml` file. Using this alternative will change the behavior so that forked repositories can also run the `fossa` stage.