### PR TITLE
fix uplift curve with normalization when ATE is negative

### DIFF
--- a/causalml/metrics/visualize.py
+++ b/causalml/metrics/visualize.py
@@ -139,7 +139,7 @@ def get_cumgain(df, outcome_col='y', treatment_col='w', treatment_effect_col='ta
     gain = lift.mul(lift.index.values, axis=0)
 
     if normalize:
-        gain = gain.div(gain.iloc[-1, :], axis=1)
+        gain = gain.div(np.abs(gain.iloc[-1, :]), axis=1)
 
     return gain
 
@@ -214,7 +214,7 @@ def get_qini(df, outcome_col='y', treatment_col='w', treatment_effect_col='tau',
     qini.drop(random_cols, axis=1, inplace=True)
 
     if normalize:
-        qini = qini.div(qini.iloc[-1, :], axis=1)
+        qini = qini.div(np.abs(qini.iloc[-1, :]), axis=1)
 
     return qini
 


### PR DESCRIPTION
This resolves #119:

When normalizing Qini and uplift curves, use absolute values of last rows to keep the sign the same.

Tested with an same example in the issue:
```python
import numpy as np
import pandas as pd
from causalml.metrics import *


y = np.random.normal(-0.5, 2, 1000)
x1 = np.random.normal(-10, 10, 1000)
x2 = np.random.normal(0, 10, 1000)
x3 = np.random.normal(10, 10 , 1000)
w = np.random.randint(2, size=1000)

df = pd.DataFrame([y, w, x1, x2, x3]).T
df.columns = ['y', 'w', 'model1', 'model2', 'model3']

plot_gain(df, outcome_col='y', treatment_col='w',
              normalize=False, random_seed=42, n=100, figsize=(8, 8))

plot_gain(df, outcome_col='y', treatment_col='w',
              normalize=True, random_seed=42, n=100, figsize=(8, 8))
```
