### PR TITLE
Add synthetic dataset from CEVAE paper

### DIFF
--- a/causalml/dataset/__init__.py
+++ b/causalml/dataset/__init__.py
@@ -3,6 +3,7 @@ from .regression import simulate_nuisance_and_easy_treatment
 from .regression import simulate_randomized_trial
 from .regression import simulate_easy_propensity_difficult_baseline
 from .regression import simulate_unrelated_treatment_control
+from .regression import simulate_hidden_confounder
 from .classification import make_uplift_classification
 
 from .synthetic import get_synthetic_preds, get_synthetic_preds_holdout

--- a/causalml/dataset/regression.py
+++ b/causalml/dataset/regression.py
@@ -37,7 +37,7 @@ def synthetic_data(mode=1, n=1000, p=5, sigma=1.0, adj=0.):
                2: simulate_randomized_trial,
                3: simulate_easy_propensity_difficult_baseline,
                4: simulate_unrelated_treatment_control,
-               5: simulate_hidden_counfounder}
+               5: simulate_hidden_confounder}
 
     assert mode in catalog, 'Invalid mode {}. Should be one of {}'.format(mode, set(catalog))
     return catalog[mode](n, p, sigma, adj)

--- a/causalml/dataset/regression.py
+++ b/causalml/dataset/regression.py
@@ -14,7 +14,8 @@ def synthetic_data(mode=1, n=1000, p=5, sigma=1.0, adj=0.):
             1 for difficult nuisance components and an easy treatment effect. \
             2 for a randomized trial. \
             3 for an easy propensity and a difficult baseline. \
-            4 for unrelated treatment and control groups.
+            4 for unrelated treatment and control groups. \
+            5 for a hidden confounder biasing treatment.
         n (int, optional): number of observations
         p (int optional): number of covariates (>=5)
         sigma (float): standard deviation of the error term
@@ -31,13 +32,14 @@ def synthetic_data(mode=1, n=1000, p=5, sigma=1.0, adj=0.):
             - b ((n,)-array): expected outcome.
             - e ((n,)-array): propensity of receiving treatment.
     '''
-    assert mode in (1, 2, 3, 4), 'Invalid mode {}. Should be between 1 and 4'.format(mode)
 
     catalog = {1: simulate_nuisance_and_easy_treatment,
                2: simulate_randomized_trial,
                3: simulate_easy_propensity_difficult_baseline,
-               4: simulate_unrelated_treatment_control}
+               4: simulate_unrelated_treatment_control,
+               5: simulate_hidden_counfounder}
 
+    assert mode in catalog, 'Invalid mode {}. Should be one of {}'.format(mode, set(catalog))
     return catalog[mode](n, p, sigma, adj)
 
 
@@ -171,4 +173,38 @@ def simulate_unrelated_treatment_control(n=1000, p=5, sigma=1.0, adj=0.):
     w = np.random.binomial(1, e, size=n)
     y = b + (w - 0.5) * tau + sigma * np.random.normal(size=n)
 
+    return y, X, w, tau, b, e
+
+
+def simulate_hidden_confounder(n=10000, p=5, sigma=1.0, adj=0.):
+    ''' Synthetic dataset with a hidden confounder biasing treatment.
+        From Louizos et al. (2018) "Causal Effect Inference with Deep Latent-Variable Models"
+
+    Args:
+        n (int, optional): number of observations
+        p (int optional): number of covariates (>=3)
+        sigma (float): standard deviation of the error term
+        adj (float): no effect. added for consistency
+
+    Returns:
+        (tuple): Synthetically generated samples with the following outputs:
+
+            - y ((n,)-array): outcome variable.
+            - X ((n,p)-ndarray): independent variables.
+            - w ((n,)-array): treatment flag with value 0 or 1.
+            - tau ((n,)-array): individual treatment effect.
+            - b ((n,)-array): expected outcome.
+            - e ((n,)-array): propensity of receiving treatment.
+    '''
+    z = np.random.binomial(1, 0.5, size=n).astype(np.double)
+    X = np.random.normal(z, 5 * z + 3 * (1 - z), size=(p, n)).T
+    e = 0.75 * z + 0.25 * (1 - z)
+    w = np.random.binomial(1, e)
+    b = expit(3 * (z + 2 * (2 * w - 2)))
+    y = np.random.binomial(1, b)
+
+    # Compute true ite tau for evaluation (via Monte Carlo approximation).
+    t0_t1 = np.array([[0.], [1.]])
+    y_t0, y_t1 = expit(3 * (z + 2 * (2 * t0_t1 - 2)))
+    tau = y_t1 - y_t0
     return y, X, w, tau, b, e

--- a/examples/meta_learners_with_synthetic_data.ipynb
+++ b/examples/meta_learners_with_synthetic_data.ipynb
@@ -1157,7 +1157,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.9"
+   "version": "3.7.2"
   },
   "toc": {
    "base_numbering": 1,

--- a/examples/meta_learners_with_synthetic_data.ipynb
+++ b/examples/meta_learners_with_synthetic_data.ipynb
@@ -1157,7 +1157,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.2"
+   "version": "3.6.9"
   },
   "toc": {
    "base_numbering": 1,

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -1,11 +1,15 @@
-from causalml.dataset import simulate_nuisance_and_easy_treatment
+import pytest
+
+from causalml.dataset import simulate_nuisance_and_easy_treatment, simulate_hidden_confounder
 from causalml.dataset import get_synthetic_preds, get_synthetic_summary, get_synthetic_auuc
 from causalml.dataset import get_synthetic_preds_holdout, get_synthetic_summary_holdout
 from causalml.inference.meta import LRSRegressor, XGBTRegressor
 
 
-def test_get_synthetic_preds():
-    preds_dict = get_synthetic_preds(synthetic_data_func=simulate_nuisance_and_easy_treatment,
+@pytest.mark.parametrize('synthetic_data_func', [simulate_nuisance_and_easy_treatment,
+                                                 simulate_hidden_confounder])
+def test_get_synthetic_preds(synthetic_data_func):
+    preds_dict = get_synthetic_preds(synthetic_data_func=synthetic_data_func,
                                      n=1000,
                                      estimators={'S Learner (LR)': LRSRegressor(), 'T Learner (XGB)': XGBTRegressor()})
 


### PR DESCRIPTION
Resolves #120 

This adds the synthetic dataset from [Luizos et al. 2018](http://papers.nips.cc/paper/7223-causal-effect-inference-with-deep-latent-variable-models.pdf):

![image](https://user-images.githubusercontent.com/648532/74291325-68f1f600-4ce9-11ea-9b10-235fa8989d0e.png)
![image](https://user-images.githubusercontent.com/648532/74291343-74ddb800-4ce9-11ea-80e3-556de9b27ad5.png)

## Tested
- added a cheap unit test to tests/test_datasets.py

