### PR TITLE
Do not pip install xgboost if already installed

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,12 @@ with open("README.md", "r") as f:
 
 with open("requirements.txt") as f:
     requirements = f.readlines()
+# workaround to avoid installing xgboost if already installed
+try:
+    import xgboost
+    requirements = [r for r in requirements if not r.startswith("xgboost")]
+except ModuleNotFoundError:
+    pass
 
 extensions = [
     Extension("causalml.inference.tree.causaltree",


### PR DESCRIPTION
Addresses #100 

This adds a workaround to setup.py to avoid pip installing xgboost if it can already be imported. This works for me when creating a new conda env, e.g.
```sh
conda create -n my_env python=3.6
conda activate my_env
conda install -c conda-forge xgboost
cd causalml
pip install -e .  # works after this PR
```

I am unsure whether this messes up the requirements `pypi` requirements, i.e. when releasing. This may only work when installing locally via `pip install .`.