### PR TITLE
update match.py (scale matching distances) and propensity.py (address issue #156)

### DIFF
--- a/causalml/match.py
+++ b/causalml/match.py
@@ -148,9 +148,9 @@ class NearestNeighborMatch(object):
             treatment_scaled = pd.concat([treatment_scaled] * self.ratio,
                                          axis=0)
 
-            cond = (distances / len(score_cols) ) < sdcal
+            cond = (distances / np.sqrt(len(score_cols)) ) < sdcal
             # Deduplicate the indices of the treatment group
-            t_idx_matched = np.array(treatment_scaled.loc[cond].index)
+            t_idx_matched = np.unique(treatment_scaled.loc[cond].index)
             # XXX: Should we deduplicate the indices of the control group too?
             c_idx_matched = np.array(control_scaled.iloc[indices[cond]].index)
         else:

--- a/causalml/match.py
+++ b/causalml/match.py
@@ -148,7 +148,7 @@ class NearestNeighborMatch(object):
             treatment_scaled = pd.concat([treatment_scaled] * self.ratio,
                                          axis=0)
 
-            cond = (distances / np.square(len(score_cols)) ) < sdcal
+            cond = (distances / len(score_cols) ) < sdcal
             # Deduplicate the indices of the treatment group
             t_idx_matched = np.array(treatment_scaled.loc[cond].index)
             # XXX: Should we deduplicate the indices of the control group too?

--- a/causalml/match.py
+++ b/causalml/match.py
@@ -148,13 +148,11 @@ class NearestNeighborMatch(object):
             treatment_scaled = pd.concat([treatment_scaled] * self.ratio,
                                          axis=0)
 
-            cond = distances < sdcal
+            cond = (distances / np.square(len(score_cols)) ) < sdcal
             # Deduplicate the indices of the treatment group
-            t_idx_matched = list(set(
-                treatment_scaled.loc[cond].index.tolist()
-            ))
+            t_idx_matched = np.array(treatment_scaled.loc[cond].index)
             # XXX: Should we deduplicate the indices of the control group too?
-            c_idx_matched = control_scaled.iloc[indices[cond]].index.tolist()
+            c_idx_matched = np.array(control_scaled.iloc[indices[cond]].index)
         else:
             assert len(score_cols) == 1, (
                 'Matching on multiple columns is only supported using the '

--- a/causalml/propensity.py
+++ b/causalml/propensity.py
@@ -52,9 +52,6 @@ class ElasticNetPropensityModel(object):
             X (numpy.ndarray): a feature matrix
             y (numpy.ndarray): a binary target vector
         """
-        if self.check_if_randomized(X, y):
-            logger.warning('Propensity AUC close to 0.5. This may suggest your data is already randomized.')
-            self.model = LogisticRegression()
         self.model.fit(X, y)
 
     def predict(self, X):
@@ -84,16 +81,6 @@ class ElasticNetPropensityModel(object):
         ps = self.predict(X)
         logger.info('AUC score: {:.6f}'.format(auc(y, ps)))
         return ps
-
-    def check_if_randomized(self, X, y, max_auc=0.51):
-        """Checks if the underlying data is already randomized by fitting a single LogisticRegression.
-        """
-        lr = LogisticRegression()
-        lr.fit(X, y)
-        score = auc(y, lr.predict_proba(X)[:, 1])
-        if score < max_auc:
-            return True
-        return False
 
 def calibrate(ps, treatment):
     """Calibrate propensity scores with logistic GAM.
@@ -134,7 +121,7 @@ def compute_propensity_score(X, treatment, X_pred=None, treatment_pred=None, cv=
 
     p = np.zeros_like(treatment_pred, dtype=float)
     p_fold = np.zeros_like(treatment_pred, dtype=float)
-    p_model = ElasticNetPropensityModel()
+    p_model = ElasticNetPropensityModel(cv=cv)
     p_model_dict = dict()
 
     p_model.fit(X, treatment)


### PR DESCRIPTION
**match.py changes:**
- adjust matching distances by a factor of the number of matching columns (otherwise user has to tune caliper according to how many matching columns they provide)
- use np.array instead of lists for matched idxs

**propensity.py changes**
- add function that checks if data is randomized using AUC (if close to 0.5, bypasses LogisticRegressionCV to prevent repeated non-convergence warnings)
- removed redundant manual cv code in compute_propensity_score (cv is already implemented inside LogisticRegressionCV)