### PR TITLE
Add GradientBoostedPropensityModel (from IIA)

### DIFF
--- a/causalml/inference/meta/rlearner.py
+++ b/causalml/inference/meta/rlearner.py
@@ -98,7 +98,7 @@ class BaseRLearner(object):
                 w_filt = (treatment_filt == group).astype(int)
                 w = (treatment == group).astype(int)
                 p[group], p_model[group] = compute_propensity_score(X=X_filt, treatment=w_filt,
-                                                                    X_pred=X, treatment_pred=w, cv=self.cv)
+                                                                    X_pred=X, treatment_pred=w)
             self.propensity_model = p_model
             self.propensity = p
         else:
@@ -542,7 +542,7 @@ class BaseRClassifier(BaseRLearner):
                 w_filt = (treatment_filt == group).astype(int)
                 w = (treatment == group).astype(int)
                 p[group], p_model[group] = compute_propensity_score(X=X_filt, treatment=w_filt,
-                                                                    X_pred=X, treatment_pred=w, cv=self.cv)
+                                                                    X_pred=X, treatment_pred=w)
             self.propensity_model = p_model
             self.propensity = p
         else:
@@ -667,7 +667,7 @@ class XGBRRegressor(BaseRRegressor):
                 w_filt = (treatment_filt == group).astype(int)
                 w = (treatment == group).astype(int)
                 p[group], p_model[group] = compute_propensity_score(X=X_filt, treatment=w_filt,
-                                                                    X_pred=X, treatment_pred=w, cv=self.cv)
+                                                                    X_pred=X, treatment_pred=w)
             self.propensity_model = p_model
             self.propensity = p
         else:

--- a/tests/test_propensity.py
+++ b/tests/test_propensity.py
@@ -1,4 +1,4 @@
-from causalml.propensity import ElasticNetPropensityModel
+from causalml.propensity import ElasticNetPropensityModel, GradientBoostedPropensityModel
 from causalml.metrics import roc_auc_score
 
 
@@ -9,6 +9,22 @@ def test_elasticnet_propensity_model(generate_regression_data):
     y, X, treatment, tau, b, e = generate_regression_data()
 
     pm = ElasticNetPropensityModel(random_state=RANDOM_SEED)
+    ps = pm.fit_predict(X, treatment)
+
+    assert roc_auc_score(treatment, ps) > .5
+
+def test_gradientboosted_propensity_model(generate_regression_data):
+    y, X, treatment, tau, b, e = generate_regression_data()
+
+    pm = GradientBoostedPropensityModel(random_state=RANDOM_SEED)
+    ps = pm.fit_predict(X, treatment)
+
+    assert roc_auc_score(treatment, ps) > .5
+
+def test_gradientboosted_propensity_model_earlystopping(generate_regression_data):
+    y, X, treatment, tau, b, e = generate_regression_data()
+
+    pm = GradientBoostedPropensityModel(random_state=RANDOM_SEED, early_stop=True)
     ps = pm.fit_predict(X, treatment)
 
     assert roc_auc_score(treatment, ps) > .5


### PR DESCRIPTION
- migrate IIA's GradientBoostedPropensityModel to causalml
- remove cv arg when rlearner generates p scores. cv is now passed within the model in compute_propensity_score
- add GradientBoostedPropensityModel to tests