### PR TITLE
Making UTF-8 encoding explicit when reading README.md

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ except ImportError:
     from numpy import get_include as np_get_include
 
 
-with open("README.md", "r") as f:
+with open("README.md", "r", encoding="utf-8") as f:
     long_description = f.read()
 
 


### PR DESCRIPTION
"pip install causalml" fails (decoding error) when the system encoding is not UTF8 (e.g ASCII).

```
Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-build-ccs_s93d/causalml/setup.py", line 17, in <module>
        long_description = f.read()
      File "/usr/lib64/python3.6/encodings/ascii.py", line 26, in decode
        return codecs.ascii_decode(input, self.errors)[0]
    UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 8370: ordinal not in range(128)
```