### PR TITLE
Implement propensity model abstraction for common interface

### DIFF
--- a/causalml/propensity.py
+++ b/causalml/propensity.py
@@ -1,3 +1,4 @@
+from abc import ABCMeta, abstractproperty
 import logging
 import numpy as np
 from pygam import LogisticGAM, s
@@ -5,42 +6,27 @@ from sklearn.metrics import roc_auc_score as auc
 from sklearn.linear_model import LogisticRegressionCV
 from sklearn.model_selection import StratifiedKFold, train_test_split
 import xgboost as xgb
-import multiprocessing
+
 
 logger = logging.getLogger('causalml')
 
 
-class ElasticNetPropensityModel(object):
-    """Propensity regression model based on the ElasticNet algorithm.
-
-    Attributes:
-        model (sklearn.linear_model.ElasticNetCV): a propensity model object
-    """
-
-    def __init__(self, n_fold=4, Cs=np.logspace(1e-3, 1 - 1e-3, 4), l1_ratios=np.linspace(1e-3, 1 - 1e-3, 4),
-                 clip_bounds=(1e-3, 1 - 1e-3), cv=None, random_state=None):
-        """Initialize a propensity model object.
-        Args:
-            n_fold (int): the number of cross-validation fold
-            Cs (int or array-like): Each of the values in Cs describes the inverse of regularization strength.
-                If Cs is as an int, then a grid of Cs values are chosen in a logarithmic scale between 1e-4 and 1e4.
-            l1_ratios (array-like): array of l1 ratios (0 <= value <= 1) to iterate through in CV estimator
-            clip_bounds (tuple): lower and upper bounds for clipping propensity scores. Bounds should be implemented
-                such that: 0 < lower < upper < 1, to avoid division by zero in BaseRLearner.fit_predict() step.
-            cv (int or cross-validation generator): The default cross-validation generator used is Stratified K-Folds.
-                If an integer is provided, then it is the number of folds used.
-            random_state (numpy.random.RandomState or int): RandomState or an int seed
-
-        Returns:
-            None
+class PropensityModel(metaclass=ABCMeta):
+    def __init__(self, clip_bounds=(1e-3, 1 - 1e-3), **model_kwargs):
         """
-        if cv is None:
-            self.cv = StratifiedKFold(n_splits=n_fold, shuffle=True, random_state=random_state)
-        else:
-            self.cv = cv
-        self.model = LogisticRegressionCV(penalty='elasticnet', solver='saga', Cs=Cs, l1_ratios=l1_ratios,
-                                          cv=self.cv, random_state=random_state)
+        Args:
+
+        clip_bounds (tuple): lower and upper bounds for clipping propensity scores. Bounds should be implemented
+                such that: 0 < lower < upper < 1, to avoid division by zero in BaseRLearner.fit_predict() step.
+        model_kwargs: Keyword arguments to be passed to the underlying classification model.
+        """
         self.clip_bounds = clip_bounds
+        self.model_kwargs = model_kwargs
+        self.model = self._model
+
+    @abstractproperty
+    def _model(self):
+        pass
 
     def __repr__(self):
         return self.model.__repr__()
@@ -65,95 +51,9 @@ class ElasticNetPropensityModel(object):
         Returns:
             (numpy.ndarray): Propensity scores between 0 and 1.
         """
-        ps = np.clip(self.model.predict_proba(X)[:, 1], *self.clip_bounds)
-        return ps
-
-    def fit_predict(self, X, y):
-        """Fit a propensity model and predict propensity scores.
-
-        Args:
-            X (numpy.ndarray): a feature matrix
-            y (numpy.ndarray): a binary target vector
-
-        Returns:
-            (numpy.ndarray): Propensity scores between 0 and 1.
-        """
-        self.fit(X, y)
-        ps = self.predict(X)
-        logger.info('AUC score: {:.6f}'.format(auc(y, ps)))
-        return ps
-
-
-class GradientBoostedPropensityModel(object):
-    """
-    Fits a simple gradient boosted propensity score model with optional early stopping.
-
-    Notes
-    -----
-    Please see the xgboost documentation for more information on gradient boosting tuning parameters:
-    https://xgboost.readthedocs.io/en/latest/python/python_api.html
-    """
-
-    cpu_count = multiprocessing.cpu_count()
-
-    def __init__(self, max_depth=8, learning_rate=0.1, n_estimators=100, objective='binary:logistic',
-                 n_thread=cpu_count, colsample_bytree=0.8, early_stop=False, stop_val_size=0.2, n_stop_rounds=10,
-                 clip_bounds=(1e-3, 1 - 1e-3), random_state=None):
-        self.max_depth = max_depth
-        self.learning_rate = learning_rate
-        self.n_estimators = n_estimators
-        self.objective = objective
-        self.n_thread = n_thread
-        self.colsample_bytree = colsample_bytree
-        self.early_stop = early_stop
-        self.stop_val_size = stop_val_size
-        self.n_stop_rounds=n_stop_rounds
-        self.clip_bounds = clip_bounds
-        self.random_state = random_state
-
-    def fit(self, X, y):
-        """
-        Fit a propensity model.
-
-        Args:
-            X (numpy.ndarray): a feature matrix
-            y (numpy.ndarray): a binary target vector
-        """
-        gbmc = xgb.XGBClassifier(max_depth=self.max_depth,
-                                 learning_rate=self.learning_rate,
-                                 n_estimators=self.n_estimators,
-                                 objective=self.objective,
-                                 nthread=self.n_thread,
-                                 colsample_bytree = self.colsample_bytree,
-                                 random_state=self.random_state)
-
-        if self.early_stop:
-            X_train, X_val, y_train, y_val = train_test_split(X, y, test_size=self.stop_val_size)
-            self.gbmc_fit = gbmc.fit(X_train,
-                                     y_train,
-                                     eval_set=[(X_val, y_val)],
-                                     early_stopping_rounds=self.n_stop_rounds)
-        else:
-            self.gbmc_fit = gbmc.fit(X, y)
-
-    def predict(self, X):
-        """
-        Predict propensity scores.
-
-        Args:
-            X (numpy.ndarray): a feature matrix
-
-        Returns:
-            (numpy.ndarray): Propensity scores between 0 and 1.
-        """
-        if self.early_stop:
-            ps = self.gbmc_fit.predict_proba(X, ntree_limit=self.gbmc_fit.best_ntree_limit)[:, 1]
-        else:
-            ps = self.gbmc_fit.predict_proba(X)[:, 1]
-
-        ps = np.clip(ps, *self.clip_bounds)
-
-        return ps
+        return np.clip(
+            self.model.predict_proba(X)[:, 1], *self.clip_bounds
+        )
 
     def fit_predict(self, X, y):
         """
@@ -167,9 +67,116 @@ class GradientBoostedPropensityModel(object):
             (numpy.ndarray): Propensity scores between 0 and 1.
         """
         self.fit(X, y)
-        ps = self.predict(X)
-        logger.info('AUC score: {:.6f}'.format(auc(y, ps)))
-        return ps
+        propensity_scores = self.predict(X)
+        logger.info('AUC score: {:.6f}'.format(auc(y, propensity_scores)))
+        return propensity_scores
+
+
+class LogisticRegressionPropensityModel(PropensityModel):
+    """
+    Propensity regression model based on the LogisticRegression algorithm.
+    """
+
+    @property
+    def _model(self):
+        kwargs = {
+            'penalty': 'elasticnet',
+            'solver': 'saga',
+            'Cs': np.logspace(1e-3, 1 - 1e-3, 4),
+            'l1_ratios': np.linspace(1e-3, 1 - 1e-3, 4),
+            'cv': StratifiedKFold(
+                n_splits=4,
+                shuffle=True,
+                random_state=42
+            ),
+            'random_state': 42,
+        }
+        kwargs.update(self.model_kwargs)
+
+        return LogisticRegressionCV(**kwargs)
+
+
+class ElasticNetPropensityModel(LogisticRegressionPropensityModel):
+    pass
+
+
+class GradientBoostedPropensityModel(PropensityModel):
+    """
+    Gradient boosted propensity score model with optional early stopping.
+
+    Notes
+    -----
+    Please see the xgboost documentation for more information on gradient boosting tuning parameters:
+    https://xgboost.readthedocs.io/en/latest/python/python_api.html
+    """
+
+    def __init__(
+        self,
+        early_stop=False,
+        clip_bounds=(1e-3, 1 - 1e-3),
+        **model_kwargs
+    ):
+        super(GradientBoostedPropensityModel, self).__init__(clip_bounds, **model_kwargs)
+        self.early_stop = early_stop
+
+    @property
+    def _model(self):
+        kwargs = {
+            'max_depth': 8,
+            'learning_rate': 0.1,
+            'n_estimators': 100,
+            'objective': 'binary:logistic',
+            'nthread': -1,
+            'colsample_bytree': 0.8,
+            'random_state': 42,
+        }
+        kwargs.update(self.model_kwargs)
+
+        return xgb.XGBClassifier(**kwargs)
+
+    def fit(self, X, y, early_stopping_rounds=10, stop_val_size=0.2):
+        """
+        Fit a propensity model.
+
+        Args:
+            X (numpy.ndarray): a feature matrix
+            y (numpy.ndarray): a binary target vector
+        """
+
+        if self.early_stop:
+            X_train, X_val, y_train, y_val = train_test_split(
+                X, y, test_size=stop_val_size
+            )
+
+            self.model.fit(
+                X_train,
+                y_train,
+                eval_set=[(X_val, y_val)],
+                early_stopping_rounds=early_stopping_rounds
+            )
+        else:
+            super(GradientBoostedPropensityModel, self).fit(X, y)
+
+    def predict(self, X):
+        """
+        Predict propensity scores.
+
+        Args:
+            X (numpy.ndarray): a feature matrix
+
+        Returns:
+            (numpy.ndarray): Propensity scores between 0 and 1.
+        """
+        if self.early_stop:
+            return np.clip(
+                self.model.predict_proba(
+                    X,
+                    ntree_limit=self.model.best_ntree_limit
+                )[:, 1],
+                *self.clip_bounds
+            )
+        else:
+            return super(GradientBoostedPropensityModel, self).predict(X)
 
 
 def calibrate(ps, treatment):

--- a/causalml/propensity.py
+++ b/causalml/propensity.py
@@ -15,10 +15,9 @@ class PropensityModel(metaclass=ABCMeta):
     def __init__(self, clip_bounds=(1e-3, 1 - 1e-3), **model_kwargs):
         """
         Args:
-
-        clip_bounds (tuple): lower and upper bounds for clipping propensity scores. Bounds should be implemented
-                such that: 0 < lower < upper < 1, to avoid division by zero in BaseRLearner.fit_predict() step.
-        model_kwargs: Keyword arguments to be passed to the underlying classification model.
+            clip_bounds (tuple): lower and upper bounds for clipping propensity scores. Bounds should be implemented
+                    such that: 0 < lower < upper < 1, to avoid division by zero in BaseRLearner.fit_predict() step.
+            model_kwargs: Keyword arguments to be passed to the underlying classification model.
         """
         self.clip_bounds = clip_bounds
         self.model_kwargs = model_kwargs

--- a/causalml/propensity.py
+++ b/causalml/propensity.py
@@ -1,4 +1,4 @@
-from abc import ABCMeta, abstractproperty
+from abc import ABCMeta, abstractmethod
 import logging
 import numpy as np
 from pygam import LogisticGAM, s
@@ -24,7 +24,8 @@ class PropensityModel(metaclass=ABCMeta):
         self.model_kwargs = model_kwargs
         self.model = self._model
 
-    @abstractproperty
+    @property
+    @abstractmethod
     def _model(self):
         pass
 

--- a/tests/test_propensity.py
+++ b/tests/test_propensity.py
@@ -1,8 +1,29 @@
-from causalml.propensity import ElasticNetPropensityModel, GradientBoostedPropensityModel
+from causalml.propensity import (
+    ElasticNetPropensityModel,
+    GradientBoostedPropensityModel,
+    LogisticRegressionPropensityModel
+)
 from causalml.metrics import roc_auc_score
 
 
 from .const import RANDOM_SEED
+
+
+def test_logistic_regression_propensity_model(generate_regression_data):
+    y, X, treatment, tau, b, e = generate_regression_data()
+
+    pm = LogisticRegressionPropensityModel(random_state=RANDOM_SEED)
+    ps = pm.fit_predict(X, treatment)
+
+    assert roc_auc_score(treatment, ps) > .5
+
+
+def test_logistic_regression_propensity_model_model_kwargs(generate_regression_data):
+    y, X, treatment, tau, b, e = generate_regression_data()
+
+    pm = LogisticRegressionPropensityModel(random_state=123)
+
+    assert pm.model.random_state == 123
 
 
 def test_elasticnet_propensity_model(generate_regression_data):


### PR DESCRIPTION
This PR intends to provide a common interface for propensity models and tidy up some stuff in the corresponding module.

Also, renames former ElasticNet propensity model while providing backwards-compatible synonym.