### PR TITLE
Fix #241 by putting back pandas Series as an acceptable format for pr…

### DIFF
--- a/causalml/inference/meta/rlearner.py
+++ b/causalml/inference/meta/rlearner.py
@@ -237,7 +237,7 @@ class BaseRLearner(object):
         else:
             check_p_conditions(p, self.t_groups)
 
-        if isinstance(p, np.ndarray):
+        if isinstance(p, (np.ndarray, pd.Series)):
             treatment_name = self.t_groups[0]
             p = {treatment_name: convert_pd_to_np(p)}
         elif isinstance(p, dict):

--- a/causalml/inference/meta/xlearner.py
+++ b/causalml/inference/meta/xlearner.py
@@ -245,7 +245,7 @@ class BaseXLearner(object):
             p = self.propensity
 
         check_p_conditions(p, self.t_groups)
-        if isinstance(p, np.ndarray):
+        if isinstance(p, (np.ndarray, pd.Series)):
             treatment_name = self.t_groups[0]
             p = {treatment_name: convert_pd_to_np(p)}
         elif isinstance(p, dict):
@@ -305,7 +305,7 @@ class BaseXLearner(object):
             p = self.propensity
         else:
             check_p_conditions(p, self.t_groups)
-        if isinstance(p, np.ndarray):
+        if isinstance(p, (np.ndarray, pd.Series)):
             treatment_name = self.t_groups[0]
             p = {treatment_name: convert_pd_to_np(p)}
         elif isinstance(p, dict):


### PR DESCRIPTION
…opensity score parameter

For issue #241, some checks were added back in with this commit https://github.com/uber/causalml/commit/900df2de0e5a3e999c290f5849c2cb3367f5ad5a , I assume the previous removal was not valid anymore, would be great to get some confirmation from Mike

pytest result with this update:  52 passed, 9 warnings in 229.32s (0:03:49) 
(warnings are _FutureWarning: The sklearn.utils.testing module is  deprecated in version 0.22 and will be removed in version 0.24. The corresponding classes / functions should instead be imported from sklearn.utils_)
