### PR TITLE
Making Tensorflow an optional extra to save unnecessary download

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.5, 3.6, 3.7, 3.8]
+        python-version: [3.7, 3.8]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -41,7 +41,6 @@ jobs:
       with:
         python-versions: 'cp37-cp37m'
     - name: Create Release
-      id: create release
       uses: actions/create-release@v1
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -55,4 +55,5 @@ jobs:
         upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps 
         asset_path: dist/*-manylinux*.whl
         asset_name: causalml-${{ github.ref }}-cp37-cp37m-manylinux_x86_64.whl
+        asset_content_type: application/whl
 

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install flake8 pytest cmake numpy
+        pip install flake8 pytest cmake numpy wheel
         if [ -f requirements-test.txt ]; then pip install -r requirements-test.txt; fi
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
     - name: Build extensions

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -36,10 +36,6 @@ jobs:
     - name: Test with pytest
       run: |
         pytest -vs tests/
-    - name: Build wheel
-      uses: RalfG/python-wheels-manylinux-build@v0.2.2
-      with:
-        python-versions: 'cp37-cp37m'
     - name: Create Release
       uses: actions/create-release@v1
       env:
@@ -56,4 +52,4 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps 
-        asset_path: wheelhouse/*-manylinux*.whl
+        asset_path: dist/*-manylinux*.whl

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -1,0 +1,38 @@
+# This workflow will install Python dependencies, run tests and lint with a variety of Python versions
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
+
+name: Python package
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.5, 3.6, 3.7, 3.8]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install flake8 pytest cmake numpy
+        if [ -f requirements-test.txt ]; then pip install -r requirements-test.txt; fi
+        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+    - name: Build extensions
+      run: |
+        python setup.py build_ext --inplace
+        python setup.py bdist_wheel
+    - name: Test with pytest
+      run: |
+        pytest -vs tests/

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -37,6 +37,7 @@ jobs:
       run: |
         pytest -vs tests/
     - name: Create Release
+      id: create_release
       uses: actions/create-release@v1
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -54,3 +54,5 @@ jobs:
       with:
         upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps 
         asset_path: dist/*-manylinux*.whl
+        asset_name: causalml-${{ github.ref }}-cp37-cp37m-manylinux_x86_64.whl
+

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8]
+        python-version: [3.7]
 
     steps:
     - uses: actions/checkout@v2
@@ -36,3 +36,25 @@ jobs:
     - name: Test with pytest
       run: |
         pytest -vs tests/
+    - name: Build wheel
+      uses: RalfG/python-wheels-manylinux-build@v0.2.2
+      with:
+        python-versions: 'cp37-cp37m'
+    - name: Create Release
+      id: create release
+      uses: actions/create-release@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        tag_name: ${{ github.ref }}
+        release_name: Release ${{ github.ref }}
+        draft: true
+        prerelease: true
+    - name: Upload Release Asset
+      id: upload-release-asset 
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps 
+        asset_path: wheelhouse/*-manylinux*.whl

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,4 +17,3 @@ lightgbm
 pygam
 packaging
 keras
-tensorflow>=1.15.2

--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,9 @@ setup(
     long_description_content_type="text/markdown",
     url="https://github.com/uber/causalml",
     packages=packages,
+    extras_require={
+        "tensorflow": ["tensorflow>=1.15.2"],
+    },
     python_requires=">=3.6",
     classifiers=[
         "Programming Language :: Python",


### PR DESCRIPTION
I am operating in a very low disk space environment, and Tensorflow as a dependency is giving me an extra 500 MB of download I don't need. I have moved it here to an optional extra, so a 'pip install causalml[tensorflow]' will still get it, but an installation of causalml without specifying tensorflow will only require xgboost.

All existing tests run when following CONTRIBUTING.md guidelines.

@ppstacy @paullo0106 @waltherg @jeongyoonlee @ccrndn and please tag anyone else I missed.