### PR TITLE
Make tensorflow optional

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,4 +17,3 @@ lightgbm
 pygam
 packaging
 keras
-tensorflow>=1.15.2

--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,9 @@ setup(
     long_description_content_type="text/markdown",
     url="https://github.com/uber/causalml",
     packages=packages,
+    extras_require={
+        "tensorflow": ["tensorflow>=1.15.2"],
+    },
     python_requires=">=3.6",
     classifiers=[
         "Programming Language :: Python",


### PR DESCRIPTION
I am operating in a very low disk space environment, and Tensorflow as a dependency is giving me an extra 500 MB of download I don't need. I have moved it here to an optional extra, so a 'pip install causalml[tensorflow]' will still get it, but an installation of causalml without specifying tensorflow will only require xgboost.

All existing tests run when following CONTRIBUTING.md guidelines.

@ppstacy @paullo0106 @waltherg @jeongyoonlee @ccrndn @zhenyuz0500 and please tag anyone else I missed.