### PR TITLE
Pass in the optional n_fold and random_state arguments to StratifiedK…

### DIFF
--- a/causalml/propensity.py
+++ b/causalml/propensity.py
@@ -85,9 +85,9 @@ class LogisticRegressionPropensityModel(PropensityModel):
             'Cs': np.logspace(1e-3, 1 - 1e-3, 4),
             'l1_ratios': np.linspace(1e-3, 1 - 1e-3, 4),
             'cv': StratifiedKFold(
-                n_splits=4,
+                n_splits=self.model_kwargs.pop('n_fold') if 'n_fold' in self.model_kwargs else 4,
                 shuffle=True,
-                random_state=42
+                random_state=self.model_kwargs.get('random_state', 42)
             ),
             'random_state': 42,
         }


### PR DESCRIPTION
…Fold in LogisticRegressionCV properly, this is for #261 

## Proposed changes

Pass in the optional `n_fold` and `random_state` arguments to `StratifiedKFold` in `LogisticRegressionCV` properly, this is for #261 

## Types of changes

What types of changes does your code introduce to **CausalML**?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/uber/causalml/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/uber/causalml)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments

The following [Propensity score estimation use case](https://causalml.readthedocs.io/en/latest/examples.html#propensity-score-estimation) would throw an error during `kwargs.update(self.model_kwargs)`, this was  because `LogisticRegressionCV` does not have `n_fold` parameter

```
from causalml.propensity import ElasticNetPropensityModel

pm = ElasticNetPropensityModel(n_fold=5, random_state=42)
ps = pm.fit_predict(X, y)
```