### PR TITLE
Fix FilterSelect:_filter_D_one_feature pd.qcut duplicate edges 

### DIFF
--- a/causalml/feature_selection/filters.py
+++ b/causalml/feature_selection/filters.py
@@ -324,6 +324,8 @@ class FilterSelect:
             evaluationFunction = self._evaluate_Chi
 
         totalSize = len(data.index)
+
+        # drop duplicate edges in pq.cut result to avoid issues
         x_bin = pd.qcut(data[feature_name].values, n_bins, labels=False, 
                         duplicates='drop')
         d_children = 0

--- a/causalml/feature_selection/filters.py
+++ b/causalml/feature_selection/filters.py
@@ -325,7 +325,7 @@ class FilterSelect:
 
         totalSize = len(data.index)
         x_bin = pd.qcut(data[feature_name].values, n_bins, labels=False, 
-                        duplicates='raise')
+                        duplicates='drop')
         d_children = 0
         for i_bin in range(x_bin.max() + 1): # range(n_bins):
             nodeSummary = self._GetNodeSummary(


### PR DESCRIPTION
## Proposed changes

When binning values, if the quantile values are the same i.e. duplicates exit in quantile values ex: quantiles =  [0, 0, 1, 1], ideally we are supposed to drop the duplicate edges i.e quantiles = [0, 1] or change the n_bins by reducing it. Since we are taking one single value for n_bins and this is being used for every feature in the data frame passed as input, better to drop duplicates else will throw an error. 

Why would duplicates exist?
There might be some feature that has 0 value for 75% of values but the last quantile may have a non-zero value. 


## Types of changes

What types of changes does your code introduce to **CausalML**?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/uber/causalml/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/uber/causalml)
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

Binning data using qcut raises an exception when it results in duplicate values for the bins. In this case, we are either supposed to drop the duplicates or change the values of n_bins to adjust the number of bins to avoid duplicity. This PR solve the issue reported in #270 