### PR TITLE
Fix the issue with inconsistent cumlift for multiple models

### DIFF
--- a/causalml/metrics/visualize.py
+++ b/causalml/metrics/visualize.py
@@ -90,22 +90,22 @@ def get_cumlift(df, outcome_col='y', treatment_col='w', treatment_effect_col='ta
 
     lift = []
     for i, col in enumerate(model_names):
-        df = df.sort_values(col, ascending=False).reset_index(drop=True)
-        df.index = df.index + 1
+        sorted_df = df.sort_values(col, ascending=False).reset_index(drop=True)
+        sorted_df.index = sorted_df.index + 1
 
-        if treatment_effect_col in df.columns:
+        if treatment_effect_col in sorted_df.columns:
             # When treatment_effect_col is given, use it to calculate the average treatment effects
             # of cumulative population.
-            lift.append(df[treatment_effect_col].cumsum() / df.index)
+            lift.append(sorted_df[treatment_effect_col].cumsum() / sorted_df.index)
         else:
             # When treatment_effect_col is not given, use outcome_col and treatment_col
             # to calculate the average treatment_effects of cumulative population.
-            df['cumsum_tr'] = df[treatment_col].cumsum()
-            df['cumsum_ct'] = df.index.values - df['cumsum_tr']
-            df['cumsum_y_tr'] = (df[outcome_col] * df[treatment_col]).cumsum()
-            df['cumsum_y_ct'] = (df[outcome_col] * (1 - df[treatment_col])).cumsum()
+            sorted_df['cumsum_tr'] = sorted_df[treatment_col].cumsum()
+            sorted_df['cumsum_ct'] = sorted_df.index.values - sorted_df['cumsum_tr']
+            sorted_df['cumsum_y_tr'] = (sorted_df[outcome_col] * sorted_df[treatment_col]).cumsum()
+            sorted_df['cumsum_y_ct'] = (sorted_df[outcome_col] * (1 - sorted_df[treatment_col])).cumsum()
 
-            lift.append(df['cumsum_y_tr'] / df['cumsum_tr'] - df['cumsum_y_ct'] / df['cumsum_ct'])
+            lift.append(sorted_df['cumsum_y_tr'] / sorted_df['cumsum_tr'] - sorted_df['cumsum_y_ct'] / sorted_df['cumsum_ct'])
 
     lift = pd.concat(lift, join='inner', axis=1)
     lift.loc[0] = np.zeros((lift.shape[1], ))


### PR DESCRIPTION
## Proposed changes

Inside `get_cumlift()` do not overwrite the reference to the original data (`df`) when sorting by the uplift, but instead store the resulting sorted data frame into a new variable `sorted_df`. This seems to resolve the issue https://github.com/uber/causalml/issues/272 .

## Types of changes

What types of changes does your code introduce to **CausalML**?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [X] I have read the [CONTRIBUTING](https://github.com/uber/causalml/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/uber/causalml)
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc. This PR template is adopted from [appium](https://github.com/appium/appium).
