### PR TITLE
Fix unreproducible UpliftRandomForestClassifier

### DIFF
--- a/causalml/inference/tree/models.py
+++ b/causalml/inference/tree/models.py
@@ -1288,8 +1288,7 @@ class UpliftRandomForestClassifier:
         self.feature_importances_ = np.mean(all_importances, axis=0)
         self.feature_importances_ /= self.feature_importances_.sum()  # normalize to add to 1
 
-    @staticmethod
-    def bootstrap(X, treatment, y, tree):
+    def bootstrap(self, X, treatment, y, tree):
         np.random.seed(self.random_state)
         bt_index = np.random.choice(len(X), len(X))
         x_train_bt = X[bt_index]

--- a/causalml/inference/tree/models.py
+++ b/causalml/inference/tree/models.py
@@ -136,10 +136,12 @@ class UpliftTreeClassifier:
         The normalization factor defined in Rzepakowski et al. 2012, correcting for tests with large number of splits
         and imbalanced treatment and control splits
 
+    random_state: int, optional (default=2019)
+        The seed used by the random number generator.
     """
     def __init__(self, max_features=None, max_depth=3, min_samples_leaf=100,
                  min_samples_treatment=10, n_reg=100, evaluationFunction='KL',
-                 control_name=None, normalization=True):
+                 control_name=None, normalization=True, random_state=2019):
         self.max_depth = max_depth
         self.min_samples_leaf = min_samples_leaf
         self.min_samples_treatment = min_samples_treatment
@@ -156,6 +158,7 @@ class UpliftTreeClassifier:
         self.fitted_uplift_tree = None
         self.control_name = control_name
         self.normalization = normalization
+        self.random_state = random_state
 
     def fit(self, X, treatment, y):
         """ Fit the uplift model.
@@ -938,6 +941,7 @@ class UpliftTreeClassifier:
         else:
             max_features = columnCount
 
+        np.random.seed(self.random_state)
         for col in list(np.random.choice(a=range(columnCount), size=max_features, replace=False)):
             columnValues = X[:, col]
             # unique values
@@ -1243,7 +1247,8 @@ class UpliftRandomForestClassifier:
                 n_reg=self.n_reg,
                 evaluationFunction=self.evaluationFunction,
                 control_name=self.control_name,
-                normalization=normalization)
+                normalization=normalization,
+                random_state=self.random_state)
 
             self.uplift_forest.append(uplift_tree)
 

--- a/causalml/inference/tree/models.py
+++ b/causalml/inference/tree/models.py
@@ -1270,7 +1270,6 @@ class UpliftRandomForestClassifier:
         y : array-like, shape = [num_samples]
             An array containing the outcome of interest for each unit.
         """
-        np.random.seed(self.random_state)
 
         # Get treatment group keys
         treatment_group_keys = list(set(treatment))

--- a/causalml/inference/tree/models.py
+++ b/causalml/inference/tree/models.py
@@ -1286,6 +1286,7 @@ class UpliftRandomForestClassifier:
 
     @staticmethod
     def bootstrap(X, treatment, y, tree):
+        np.random.seed(self.random_state)
         bt_index = np.random.choice(len(X), len(X))
         x_train_bt = X[bt_index]
         y_train_bt = y[bt_index]

--- a/tests/test_uplift_trees.py
+++ b/tests/test_uplift_trees.py
@@ -65,7 +65,7 @@ def test_UpliftRandomForestClassifier(generate_classification_data):
 
     # Check if the cumulative gain of UpLift Random Forest is higher than
     # random
-    assert cumgain['uplift_tree'].sum() > cumgain['Random'].sum()
+    assert cumgain['uplift_tree'].max() > cumgain['Random'].max()
 
 
 def test_UpliftTreeClassifier(generate_classification_data):


### PR DESCRIPTION
## Proposed changes
issue #275

UpliftRandomForestClassifier doesn't give the same results when runs with the same data and the same params (seed fixed). Now it's reproducible (wasn't fix random seed in bootstrap).

## Types of changes

What types of changes does your code introduce to **CausalML**?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/uber/causalml/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/uber/causalml)
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc. This PR template is adopted from [appium](https://github.com/appium/appium).
