### PR TITLE
Avoid Error When There Is No Positive Class In Certain Bins for KL Divergence Calculation

### DIFF
--- a/causalml/feature_selection/filters.py
+++ b/causalml/feature_selection/filters.py
@@ -208,9 +208,9 @@ class FilterSelect:
         # Probability of conversion and group size by treatment group
         nodeSummary = {}
         for treatment_group_key in results: 
-            n_1 = results[treatment_group_key][1]
-            n_total = (results[treatment_group_key][1] 
-                       + results[treatment_group_key][0])
+            n_1 = results[treatment_group_key].get(1, 0)
+            n_total = (results[treatment_group_key].get(1, 0) 
+                       + results[treatment_group_key].get(0, 0))
             y_mean = 1.0 * n_1 / n_total
             nodeSummary[treatment_group_key] = [y_mean, n_total]
         


### PR DESCRIPTION
## Proposed changes

For KL Divergence, we will calculate the probability of conversion in each bin first in `_GetNodeSummary()`, in order to do that we will need to know the number of positive population under each treatment or control group, [here](https://github.com/uber/causalml/blob/f54b8cc96b68b7a1ffee70d7ceb4e09a417fce80/causalml/feature_selection/filters.py#L211) is how the code currently gets the number:
```python
n_1 = results[treatment_group_key][1]
```
However, there are rare cases when there is no positive population within a bin for a given treatment or control group and the code above will break, so I propose to change it to the following so that when there is no positive population then `n_1` will be 0:
```python
n_1 = results[treatment_group_key].get(1, 0)
```

## Types of changes

What types of changes does your code introduce to **CausalML**?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
