### PR TITLE
1. Use 'is not None' evaluation to avoid invocation of non-existent e…

### DIFF
--- a/causalml/inference/meta/rlearner.py
+++ b/causalml/inference/meta/rlearner.py
@@ -51,8 +51,8 @@ class BaseRLearner(BaseLearner):
         assert (learner is not None) or ((outcome_learner is not None) and (effect_learner is not None))
         assert propensity_learner is not None
 
-        self.model_mu = outcome_learner if outcome_learner else deepcopy(learner)
-        self.model_tau = effect_learner if outcome_learner else deepcopy(learner)
+        self.model_mu = outcome_learner if outcome_learner is not None else deepcopy(learner)
+        self.model_tau = effect_learner if effect_learner is not None else deepcopy(learner)
         self.model_p = propensity_learner
 
         self.ate_alpha = ate_alpha


### PR DESCRIPTION
…stimators_ attribute

2. Add basic unit test of passing in effect, outcome, treatment learners for X/T/R Learners

## Proposed changes

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

## Types of changes

What types of changes does your code introduce to **CausalML**?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/uber/causalml/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/uber/causalml)
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

`is not None` evaluation will safely not call `len()` for sklearn's models
![Screen Shot 2021-04-12 at 7 16 49 PM](https://user-images.githubusercontent.com/4966393/114487442-72644000-9bc4-11eb-99d5-80ecc97fe23b.png)

