### PR TITLE
Require scikit-learn as a dependency of setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,8 @@ setup(
         # Setuptools 18.0 properly handles Cython extensions.
         'setuptools>=18.0',
         'cython',
-        'numpy'
+        'numpy',
+        'scikit-learn>=0.22.0'
     ],
     install_requires=requirements,
     ext_modules=cythonize(extensions),


### PR DESCRIPTION
## Proposed changes

Cython module[1] depends on scikit-learn, without it Cython compilation fails. Fixes https://github.com/uber/causalml/issues/321

[1] causalml/inference/tree/causaltree.pyx

## Types of changes

What types of changes does your code introduce to **CausalML**?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/uber/causalml/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/uber/causalml)
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
