### PR TITLE
Add delta-delta-p (ddp) tree inference approach

### DIFF
--- a/causalml/inference/tree/models.py
+++ b/causalml/inference/tree/models.py
@@ -1022,7 +1022,7 @@ class UpliftTreeClassifier:
                     if self.control_name in leftNodeSummary and self.control_name in rightNodeSummary:
                         leftScore1 = evaluationFunction(leftNodeSummary, control_name=self.control_name)
                         rightScore2 = evaluationFunction(rightNodeSummary, control_name=self.control_name)
-                        gain = leftScore1 - rightScore2
+                        gain = np.abs(leftScore1 - rightScore2)
                         gain_for_imp = (len(X_l) * leftScore1 - len(X_r) * rightScore2)
                     else:
                         gain = 0

--- a/causalml/inference/tree/models.py
+++ b/causalml/inference/tree/models.py
@@ -116,7 +116,7 @@ class UpliftTreeClassifier:
     ----------
 
     evaluationFunction : string
-        Choose from one of the models: 'KL', 'ED', 'Chi', 'CTS'.
+        Choose from one of the models: 'KL', 'ED', 'Chi', 'CTS', 'DDP'.
 
     max_features: int, optional (default=None)
         The number of features to consider when looking for the best split.
@@ -156,6 +156,8 @@ class UpliftTreeClassifier:
             self.evaluationFunction = self.evaluate_ED
         elif evaluationFunction == 'Chi':
             self.evaluationFunction = self.evaluate_Chi
+        elif evaluationFunction == 'DDP':
+            self.evaluationFunction = self.evaluate_DDP
         else:
             self.evaluationFunction = self.evaluate_CTS
         self.fitted_uplift_tree = None
@@ -251,7 +253,7 @@ class UpliftTreeClassifier:
             The minimum gain required to make a tree node split. The children tree branches are trimmed if the actual
             split gain is less than the minimum gain.
         evaluationFunction : string, optional (default = None)
-            Choose from one of the models: 'KL', 'ED', 'Chi', 'CTS'.
+            Choose from one of the models: 'KL', 'ED', 'Chi', 'CTS', 'DDP'.
         notify: bool, optional (default = False)
         n_reg: int, optional (default=0)
             The regularization parameter defined in Rzepakowski et al. 2012, the weight (in terms of sample size) of the
@@ -673,6 +675,32 @@ class UpliftTreeClassifier:
         return d_res
 
     @staticmethod
+    def evaluate_DDP(nodeSummary, control_name):
+        '''
+        Calculate Delta P as split evaluation criterion for a given node.
+
+        Args
+        ----
+        nodeSummary : dictionary
+            The tree node summary statistics, produced by tree_node_summary() method.
+
+        control_name : string
+            The control group name.
+
+        Returns
+        -------
+        d_res : Delta P
+        '''
+        if control_name not in nodeSummary:
+            return 0
+        pc = nodeSummary[control_name][0]
+        d_res = 0
+        for treatment_group in nodeSummary:
+            if treatment_group != control_name:
+                d_res += nodeSummary[treatment_group][0] - pc
+        return d_res
+
+    @staticmethod
     def evaluate_CTS(currentNodeSummary):
         '''
         Calculate CTS (conditional treatment selection) as split evaluation criterion for a given node.
@@ -865,7 +893,7 @@ class UpliftTreeClassifier:
         y : array-like, shape = [num_samples]
             An array containing the outcome of interest for each unit.
         evaluationFunction : string
-            Choose from one of the models: 'KL', 'ED', 'Chi', 'CTS'.
+            Choose from one of the models: 'KL', 'ED', 'Chi', 'CTS', 'DDP'.
         max_depth: int, optional (default=10)
             The maximum depth of the tree.
         min_samples_leaf: int, optional (default=100)
@@ -990,6 +1018,14 @@ class UpliftTreeClassifier:
                     rightScore2 = evaluationFunction(rightNodeSummary)
                     gain = (currentScore - p * leftScore1 - (1 - p) * rightScore2)
                     gain_for_imp = (len(X) * currentScore - len(X_l) * leftScore1 - len(X_r) * rightScore2)
+                elif evaluationFunction == self.evaluate_DDP:
+                    if self.control_name in leftNodeSummary and self.control_name in rightNodeSummary:
+                        leftScore1 = evaluationFunction(leftNodeSummary, control_name=self.control_name)
+                        rightScore2 = evaluationFunction(rightNodeSummary, control_name=self.control_name)
+                        gain = leftScore1 - rightScore2
+                        gain_for_imp = (len(X_l) * leftScore1 - len(X_r) * rightScore2)
+                    else:
+                        gain = 0
                 else:
                     if (self.control_name in leftNodeSummary and
                         self.control_name in rightNodeSummary):
@@ -1172,7 +1208,7 @@ class UpliftRandomForestClassifier:
         The number of trees in the uplift random forest.
 
     evaluationFunction : string
-        Choose from one of the models: 'KL', 'ED', 'Chi', 'CTS'.
+        Choose from one of the models: 'KL', 'ED', 'Chi', 'CTS', 'DDP'.
 
     max_features: int, optional (default=10)
         The number of features to consider when looking for the best split.

--- a/causalml/inference/tree/models.py
+++ b/causalml/inference/tree/models.py
@@ -187,6 +187,10 @@ class UpliftTreeClassifier:
         self.treatment_group = list(set(treatment))
         self.feature_imp_dict = defaultdict(float)
 
+        if self.evaluationFunction == self.evaluate_DDP and len(self.treatment_group) > 2:
+            raise ValueError("The DDP approach can only cope with two class problems, that is two different treatment options (e.g., control vs treatment)."
+                             "Please select another approach or only use a data set which employs two treatment options.")
+
         self.fitted_uplift_tree = self.growDecisionTreeFrom(
             X, treatment, y, evaluationFunction=self.evaluationFunction,
             max_depth=self.max_depth, min_samples_leaf=self.min_samples_leaf,
@@ -1023,7 +1027,7 @@ class UpliftTreeClassifier:
                         leftScore1 = evaluationFunction(leftNodeSummary, control_name=self.control_name)
                         rightScore2 = evaluationFunction(rightNodeSummary, control_name=self.control_name)
                         gain = np.abs(leftScore1 - rightScore2)
-                        gain_for_imp = (len(X_l) * leftScore1 - len(X_r) * rightScore2)
+                        gain_for_imp = np.abs(len(X_l) * leftScore1 - len(X_r) * rightScore2)
                     else:
                         gain = 0
                 else:

--- a/docs/about.rst
+++ b/docs/about.rst
@@ -15,6 +15,7 @@ The package currently supports the following methods:
 - Tree-based algorithms
     - :ref:`Uplift Random Forests` on KL divergence, Euclidean Distance, and Chi-Square
     - :ref:`Uplift Random Forests` on Contextual Treatment Selection
+    - :ref:`Uplift Random Forests` on delta-delta-p (:math:`\Delta\Delta P`) criterion (only for binary trees and two-class problems)
 - Meta-learner algorithms
     - :ref:`S-learner`
     - :ref:`T-learner`

--- a/docs/methodology.rst
+++ b/docs/methodology.rst
@@ -151,6 +151,18 @@ Finally, the :math:`\chi^2`-divergence is given by:
 
 where the notation is again the same as above.
 
+DDP
+~~~
+
+Another Uplift Tree algorithm that is implemented is the delta-delta-p (:math:`\Delta\Delta P`) approach by :cite:`hansotia2002ddp`, where the sample splitting criterion is defined as follows:
+
+.. math::
+    \Delta\Delta P=|(P^T(y|a_0)-P^C(y|a_0) - (P^T(y|a_1)-P^C(y|a_1)))|
+
+where :math:`a_0` and :math:`a_1` are the outcomes of a Split A, :math:`y` is the selected class, and :math:`P^T` and :math:`P^C` are the response rates of treatment and control group, respectively. In other words, we first calculate the difference in the response rate in each branch (:math:`\Delta P_{left}` and :math:`\Delta P_{right}`), and subsequently, calculate their differences (:math:`\Delta\Delta P = |\Delta P_{left} - \Delta P_{right}|`).
+
+
+
 CTS
 ~~~
 

--- a/docs/refs.bib
+++ b/docs/refs.bib
@@ -350,6 +350,15 @@
   publisher={NIH Public Access}
 }
 
+@article{hansotia2002ddp,
+  title={Incremental value modeling},
+  author={Behram, Hansotia and Brad, Rukstales},
+  journal={Journal of Interactive Marketing},
+  volume={16},
+  pages={35-46},
+  year={2002},
+}
+
 @article{https://doi.org/10.1111/1468-0262.00442,
 author = {Hirano, Keisuke and Imbens, Guido W. and Ridder, Geert},
 title = {Efficient Estimation of Average Treatment Effects Using the Estimated Propensity Score},

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -38,3 +38,20 @@ def generate_classification_data():
         return data
 
     yield _generate_data
+
+@pytest.fixture(scope='module')
+def generate_classification_data_two_treatments():
+
+    generated = False
+
+    def _generate_data():
+        if not generated:
+            np.random.seed(RANDOM_SEED)
+            data = make_uplift_classification(n_samples=N_SAMPLE,
+                                              treatment_name=TREATMENT_NAMES[0:2],
+                                              y_name=CONVERSION,
+                                              random_seed=RANDOM_SEED)
+
+        return data
+
+    yield _generate_data


### PR DESCRIPTION
## Proposed changes

As suggested in #300  I implemented the delta-delta-p (in short: DDP) tree based inference method originally proposed in Hansotia and Rukstales: Incremental value modeling (2002). I simply added another evaluationFunction in _causalml/inference/tree/models.py_ called 'DDP'.

## Types of changes

- [ ]  Bugfix (non-breaking change which fixes an issue)
- [x]  New feature (non-breaking change which adds functionality)
- [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ]  Documentation Update (if none of the other choices apply)

## Checklist

- [x]  I have read the [CONTRIBUTING](https://github.com/uber/causalml/blob/master/CONTRIBUTING.md) doc
- [x]  I have signed the [CLA](https://cla-assistant.io/uber/causalml)
- [x]  Lint and unit tests pass locally with my changes
- [ ]  I have added tests that prove my fix is effective or that my feature works
- [x]  I have added necessary documentation (if appropriate)
- [x]  Any dependent changes have been merged and published in downstream modules

## Further comments

There was no need to add an additional test for proving that the new tree based inference method works. You can simply use the _test_uplift_trees.py_ test and provide _evaluationFunction='DDP'_ when creating the _UpliftRandomForestClassifier_ and _UpliftTreeClassifier_ instances. I noticed that my test does not pass if _N_SAMPLE = 1000_ because the performance of random targeting was better than the DDP approach. However increasing _IN_SAMPLE_ to, for example, 10.000 worked.

If you need additional information, don't hesitate to ask me!