### PR TITLE
This fix 362 by 1. fixing the position of feature importance calculation so it's consistent with the act…

### DIFF
--- a/causalml/inference/tree/models.py
+++ b/causalml/inference/tree/models.py
@@ -1053,7 +1053,6 @@ class UpliftTreeClassifier:
                     bestAttribute = (col, value)
                     best_set_left = [X_l, w_l, y_l]
                     best_set_right = [X_r, w_r, y_r]
-                    self.feature_imp_dict[bestAttribute[0]] += gain_for_imp
 
         dcY = {'impurity': '%.3f' % currentScore, 'samples': '%d' % len(X)}
         # Add treatment size
@@ -1064,6 +1063,7 @@ class UpliftTreeClassifier:
         dcY['matchScore'] = round(upliftScore[0], 4)
 
         if bestGain > 0 and depth < max_depth:
+            self.feature_imp_dict[bestAttribute[0]] += gain_for_imp
             trueBranch = self.growDecisionTreeFrom(
                 *best_set_left, evaluationFunction, max_depth, min_samples_leaf,
                 depth + 1, min_samples_treatment=min_samples_treatment,


### PR DESCRIPTION
…ual uplift tree growth and 2. adding unit test for feature importance



## Proposed changes

Move the position of the feature importance calculation so we only add the importance score for the feature when we are actually growing the tree (e.g.  `bestGain > 0 and depth < max_depth`). The issue was described in #362 

## Types of changes

What types of changes does your code introduce to **CausalML**?

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/uber/causalml/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/uber/causalml)
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

*example output*: correctly reflect the features being used in the node in the feature importance plot, tree plot and importance plot are now consistent

<img width="1355" alt="Screen Shot 2021-07-27 at 12 27 01 PM" src="https://user-images.githubusercontent.com/4966393/127215923-858bff94-c0f1-48d4-95eb-cc65022c0e8e.png">
<img width="1385" alt="Screen Shot 2021-07-27 at 12 25 02 PM" src="https://user-images.githubusercontent.com/4966393/127215930-a05d1ec9-a26d-4c38-979d-0d358aee67c6.png">



*tests/test_uplift_trees.py::test_UpliftTreeClassifier_feature_importance PASSED*
<img width="916" alt="Screen Shot 2021-07-27 at 10 01 56 AM" src="https://user-images.githubusercontent.com/4966393/127215233-4924f527-d79a-48b6-b6d8-b51e14ba891d.png">


