### PR TITLE
Fix X-Learner example docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ te, lb, ub = nn.estimate_ate(X, treatment, y)
 print('Average Treatment Effect (Neural Network (MLP)): {:.2f} ({:.2f}, {:.2f})'.format(te[0], lb[0], ub[0]))
 
 xl = BaseXRegressor(learner=XGBRegressor(random_state=42))
-te, lb, ub = xl.estimate_ate(X, e, treatment, y)
+te, lb, ub = xl.estimate_ate(X, treatment, y, e)
 print('Average Treatment Effect (BaseXRegressor using XGBoost): {:.2f} ({:.2f}, {:.2f})'.format(te[0], lb[0], ub[0]))
 
 rl = BaseRRegressor(learner=XGBRegressor(random_state=42))

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -62,7 +62,7 @@ Average Treatment Effect (ATE) Estimation
     print('Average Treatment Effect (Neural Network (MLP)): {:.2f} ({:.2f}, {:.2f})'.format(te[0], lb[0], ub[0]))
 
     xl = BaseXRegressor(learner=XGBRegressor(random_state=42))
-    te, lb, ub = xl.estimate_ate(X, p, treatment, y)
+    te, lb, ub = xl.estimate_ate(X, treatment, y, e)
     print('Average Treatment Effect (BaseXRegressor using XGBoost): {:.2f} ({:.2f}, {:.2f})'.format(te[0], lb[0], ub[0]))
 
     rl = BaseRRegressor(learner=XGBRegressor(random_state=42))


### PR DESCRIPTION
## Proposed changes

This fix #371 to pass in parameters to X-Learner's `estimate_ate()` in the correct sequence to avoid errors

tested with the updated code as below 
```
from causalml.inference.meta import BaseXRegressor
from xgboost import XGBRegressor
from causalml.dataset import synthetic_data

y, X, treatment, _, _, e = synthetic_data(mode=1, n=1000, p=5, sigma=1.0)
xl = BaseXRegressor(learner=XGBRegressor(random_state=42))
te, lb, ub = xl.estimate_ate(X, treatment, y, e)
print('Average Treatment Effect (BaseXRegressor using XGBoost): {:.2f} ({:.2f}, {:.2f})'.format(te[0], lb[0], ub[0]))
```

output
```
Average Treatment Effect (BaseXRegressor using XGBoost): 0.55 (0.46, 0.64)
```

## Types of changes

What types of changes does your code introduce to **CausalML**?

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/uber/causalml/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/uber/causalml)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
