### PR TITLE
Fixed bug in simulate_randomized_trial

### DIFF
--- a/causalml/dataset/regression.py
+++ b/causalml/dataset/regression.py
@@ -100,7 +100,7 @@ def simulate_randomized_trial(n=1000, p=5, sigma=1.0, adj=0.):
     '''
 
     X = np.random.normal(size=n*p).reshape((n, -1))
-    b = np.maximum(np.repeat(0.0, n), X[:, 0] + X[:, 1] + X[:, 2]) + np.maximum(np.repeat(0.0, n), X[:, 3] + X[:, 4])
+    b = np.maximum(np.repeat(0.0, n), X[:, 0] + X[:, 1], X[:, 2]) + np.maximum(np.repeat(0.0, n), X[:, 3] + X[:, 4])
     e = np.repeat(0.5, n)
     tau = X[:, 0] + np.log1p(np.exp(X[:, 1]))
 

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -1,13 +1,14 @@
 import pytest
 
-from causalml.dataset import simulate_nuisance_and_easy_treatment, simulate_hidden_confounder
+from causalml.dataset import simulate_nuisance_and_easy_treatment, simulate_hidden_confounder, simulate_randomized_trial
 from causalml.dataset import get_synthetic_preds, get_synthetic_summary, get_synthetic_auuc
 from causalml.dataset import get_synthetic_preds_holdout, get_synthetic_summary_holdout
 from causalml.inference.meta import LRSRegressor, XGBTRegressor
 
 
 @pytest.mark.parametrize('synthetic_data_func', [simulate_nuisance_and_easy_treatment,
-                                                 simulate_hidden_confounder])
+                                                 simulate_hidden_confounder,
+                                                 simulate_randomized_trial])
 def test_get_synthetic_preds(synthetic_data_func):
     preds_dict = get_synthetic_preds(synthetic_data_func=synthetic_data_func,
                                      n=1000,


### PR DESCRIPTION
## Proposed changes

Fixed bug in simulated_randomized_trial (Issue #361) . Changed b*(X) from `max{Xi1 +Xi2 + Xi3,0} + max{Xi4 +Xi5,0}` to
`max{Xi1 +Xi2 , Xi3,0} + max{Xi4 +Xi5,0}`. I also added the `simulate_randomized_trial` method in `test_get_synthetic_preds`.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/uber/causalml/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/uber/causalml)
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules