### PR TITLE
Add line break to math expressions lacking it

### DIFF
--- a/docs/methodology.rst
+++ b/docs/methodology.rst
@@ -46,7 +46,7 @@ T-learner :cite:`kunzel2019metalearners` consists of two stages as follows:
 Estimate the average outcomes :math:`\mu_0(x)` and :math:`\mu_1(x)`:
 
 .. math::
-   \mu_0(x) = E[Y(0)|X=x]
+   \mu_0(x) = E[Y(0)|X=x] \\
    \mu_1(x) = E[Y(1)|X=x]
 
 using machine learning models.
@@ -68,9 +68,9 @@ X-learner :cite:`kunzel2019metalearners` is an extension of T-learner, and consi
 Estimate the average outcomes :math:`\mu_0(x)` and :math:`\mu_1(x)`:
 
 .. math::
-   \mu_0(x) = E[Y(0)|X=x]
+   \mu_0(x) = E[Y(0)|X=x] \\
    \mu_1(x) = E[Y(1)|X=x]
-   
+
 using machine learning models.
 
 **Stage 2**
@@ -78,7 +78,7 @@ using machine learning models.
 Impute the user level treatment effects, :math:`D^1_i` and :math:`D^0_j` for user :math:`i` in the treatment group based on :math:`\mu_0(x)`, and user :math:`j` in the control groups based on :math:`\mu_1(x)`:
 
 .. math::
-   D^1_i = Y^1_i - \hat\mu_0(X^1_i)
+   D^1_i = Y^1_i - \hat\mu_0(X^1_i) \\
    D^0_i = \hat\mu_1(X^0_i) - Y^0_i
 
 then estimate :math:`\tau_1(x) = E[D^1|X=x]`, and :math:`\tau_0(x) = E[D^0|X=x]` using machine learning models.
@@ -242,7 +242,7 @@ See :cite:`stuart2010matching` for a discussion of the strengths and weaknesses 
 Inverse probability of treatment weighting
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The inverse probability of treatment weighting (IPTW) approach uses the propensity score :math:`e` to weigh the treated and non-treated populations by the inverse of the probability of the actual treatment :math:`W`. For a binary treatment :math:`W \in \{1, 0\}`: 
+The inverse probability of treatment weighting (IPTW) approach uses the propensity score :math:`e` to weigh the treated and non-treated populations by the inverse of the probability of the actual treatment :math:`W`. For a binary treatment :math:`W \in \{1, 0\}`:
 
 .. math::
    \frac{W}{e} + \frac{1 - W}{1 - e}


### PR DESCRIPTION
## Proposed changes
There are three expressions in the methodology session without the line break intended by the original author. This PR just adds the "\\" to perform it. 

## Types of changes

What types of changes does your code introduce to **CausalML**?

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/uber/causalml/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/uber/causalml)
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc. This PR template is adopted from [appium](https://github.com/appium/appium).
