### PR TITLE
Fix incorrect binning of numeric features in UpliftTreeClassifier

### DIFF
--- a/causalml/inference/tree/models.py
+++ b/causalml/inference/tree/models.py
@@ -188,8 +188,9 @@ class UpliftTreeClassifier:
         self.feature_imp_dict = defaultdict(float)
 
         if self.evaluationFunction == self.evaluate_DDP and len(self.treatment_group) > 2:
-            raise ValueError("The DDP approach can only cope with two class problems, that is two different treatment options (e.g., control vs treatment)."
-                             "Please select another approach or only use a data set which employs two treatment options.")
+            raise ValueError("The DDP approach can only cope with two class problems, that is two different treatment "
+                             "options (e.g., control vs treatment). Please select another approach or only use a "
+                             "dataset which employs two treatment options.")
 
         self.fitted_uplift_tree = self.growDecisionTreeFrom(
             X, treatment, y, evaluationFunction=self.evaluationFunction,
@@ -981,8 +982,7 @@ class UpliftTreeClassifier:
             # unique values
             lsUnique = np.unique(columnValues)
 
-            if (isinstance(lsUnique[0], int) or
-                isinstance(lsUnique[0], float)):
+            if np.issubdtype(lsUnique.dtype, np.number):
                 if len(lsUnique) > 10:
                     lspercentile = np.percentile(columnValues, [3, 5, 10, 20, 30, 50, 70, 80, 90, 95, 97])
                 else:
@@ -1243,9 +1243,9 @@ class UpliftRandomForestClassifier:
         The normalization factor defined in Rzepakowski et al. 2012,
         correcting for tests with large number of splits and imbalanced
         treatment and control splits
-    
+
     n_jobs: int, optional (default=-1)
-        The parallelization parameter to define how many parallel jobs need to be created. 
+        The parallelization parameter to define how many parallel jobs need to be created.
         This is passed on to joblib library for parallelizing uplift-tree creation.
 
     Outputs
@@ -1361,7 +1361,7 @@ class UpliftRandomForestClassifier:
         y_pred_list : ndarray, shape = (num_samples, num_treatments])
             An ndarray  containing the predicted delta in each treatment group,
             the best treatment group and the maximum delta.
-        
+
         df_res : DataFrame, shape = [num_samples, (num_treatments + 1)]
             If full_output, a DataFrame containing the predicted delta in each treatment group,
             the best treatment group and the maximum delta.


### PR DESCRIPTION
## Proposed changes

This PR addresses @Dvirbeno's comment in #54 regarding the `if` statement in `UpliftTreeClassifier.growDecisionTreeFrom` not capturing intended cases (numeric features).

## Types of changes

What types of changes does your code introduce to **CausalML**?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/uber/causalml/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/uber/causalml)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

N/A.
