### PR TITLE
Undefined names: from xgboost import XGBRegressor for line 877

### DIFF
--- a/causalml/inference/iv/drivlearner.py
+++ b/causalml/inference/iv/drivlearner.py
@@ -14,6 +14,7 @@ from causalml.propensity import compute_propensity_score
 from scipy.stats import norm
 from sklearn.model_selection import cross_val_predict, KFold
 from tqdm import tqdm
+from xgboost import XGBRegressor
 
 logger = logging.getLogger("causalml")
 
@@ -432,7 +433,7 @@ class BaseDRIVLearner(object):
         treatment,
         y,
         p=None,
-        pz=None,
+        pZ=None,
         bootstrap_ci=False,
         n_bootstraps=1000,
         bootstrap_size=10000,

--- a/causalml/inference/meta/drlearner.py
+++ b/causalml/inference/meta/drlearner.py
@@ -5,6 +5,7 @@ import pandas as pd
 from scipy.stats import norm
 from sklearn.model_selection import cross_val_predict, KFold
 from tqdm import tqdm
+from xgboost import XGBRegressor
 
 from causalml.inference.meta.base import BaseLearner
 from causalml.inference.meta.explainer import Explainer


### PR DESCRIPTION
Like #68 1.

Also many functions use the parameter `pZ` (capital Z) but `estimate_ate()` uses `pz` (lowercase z) which leads to an _undefined name_ on line 574.

## Proposed changes

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

## Types of changes

What types of changes does your code introduce to **CausalML**?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/uber/causalml/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/uber/causalml)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc. This PR template is adopted from [appium](https://github.com/appium/appium).
