### PR TITLE
This fix #460 by using the correct treatment_idx for fillTree

### DIFF
--- a/causalml/inference/tree/uplift.pyx
+++ b/causalml/inference/tree/uplift.pyx
@@ -340,7 +340,7 @@ class UpliftTreeClassifier:
 
         # Get treatment group keys. self.classes_[0] is reserved for the control group.
         treatment_idx = np.zeros_like(treatment)
-        for i, tr in enumerate(self.classes_, 1):
+        for i, tr in enumerate(self.classes_[1:], 1):
             treatment_idx[treatment == tr] = i
 
         self.pruneTree(X, treatment_idx, y,
@@ -528,7 +528,7 @@ class UpliftTreeClassifier:
 
         # Get treatment group keys. self.classes_[0] is reserved for the control group.
         treatment_idx = np.zeros_like(treatment)
-        for i, tr in enumerate(self.classes_, 1):
+        for i, tr in enumerate(self.classes_[1:], 1):
             treatment_idx[treatment == tr] = i
 
         self.fillTree(X, treatment_idx, y, tree=self.fitted_uplift_tree)


### PR DESCRIPTION
## Proposed changes

1. `self.classes_` has 'control' in the first position, so we should skip that when constructing `treatment_idx` array in `fill()`, similar to what we do in [fit()](https://github.com/uber/causalml/blob/master/causalml/inference/tree/uplift.pyx#L289) function. The tree plot attached in #460 was resulted from that where the observation count in the control group becomes 0  
2. Add a basic unit-test to validate this behavior

## Types of changes

What types of changes does your code introduce to **CausalML**?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/uber/causalml/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/uber/causalml)
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc. This PR template is adopted from [appium](https://github.com/appium/appium).
