### PR TITLE
Switching the joblib backend for UpliftRandomForestClassifier to threading

### DIFF
--- a/causalml/inference/tree/uplift.pyx
+++ b/causalml/inference/tree/uplift.pyx
@@ -1321,7 +1321,7 @@ class UpliftRandomForestClassifier:
         self.n_class = len(self.classes_)
 
         self.uplift_forest = (
-            Parallel(n_jobs=self.n_jobs)
+            Parallel(n_jobs=self.n_jobs, backend="threading")
             (delayed(self.bootstrap)(X, treatment, y, tree) for tree in self.uplift_forest)
         )
 


### PR DESCRIPTION
## Proposed changes

This PR fixes #442. By switching the `joblib` backend from default (locky) to threading, it uses shared memory and doesn't copy data across trees when `n_jobs > 1`.

References
- [joblib's documentation](https://joblib.readthedocs.io/en/latest/generated/joblib.Parallel.html)
- [Scikit-Learn's tree parallelization code](https://github.com/scikit-learn/scikit-learn/blob/00a39a3d1a1e79113abc70f296ae8bc0034be430/sklearn/ensemble/_forest.py#L476)

## Types of changes

What types of changes does your code introduce to **CausalML**?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/uber/causalml/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/uber/causalml)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

N/A.
