### PR TITLE
Merely define preferred backend for joblib instead of hard-coding it

### DIFF
--- a/causalml/inference/tree/uplift.pyx
+++ b/causalml/inference/tree/uplift.pyx
@@ -1321,7 +1321,7 @@ class UpliftRandomForestClassifier:
         self.n_class = len(self.classes_)
 
         self.uplift_forest = (
-            Parallel(n_jobs=self.n_jobs, backend="threading")
+            Parallel(n_jobs=self.n_jobs, prefer="threads")
             (delayed(self.bootstrap)(X, treatment, y, tree) for tree in self.uplift_forest)
         )
 

--- a/tests/test_uplift_trees.py
+++ b/tests/test_uplift_trees.py
@@ -1,7 +1,9 @@
 import cProfile
 import numpy as np
 import pandas as pd
+import pytest
 import pstats
+from joblib import parallel_backend
 from sklearn.model_selection import train_test_split
 
 from causalml.inference.tree import UpliftTreeClassifier, UpliftRandomForestClassifier
@@ -15,57 +17,59 @@ def test_make_uplift_classification(generate_classification_data):
     assert df.shape[0] == N_SAMPLE * len(TREATMENT_NAMES)
 
 
-def test_UpliftRandomForestClassifier(generate_classification_data):
+@pytest.mark.parametrize("backend", ['loky', 'threading', 'multiprocessing'])
+def test_UpliftRandomForestClassifier(generate_classification_data, backend):
     df, x_names = generate_classification_data()
     df_train, df_test = train_test_split(df,
                                          test_size=0.2,
                                          random_state=RANDOM_SEED)
 
-    # Train the UpLift Random Forest classifier
-    uplift_model = UpliftRandomForestClassifier(
-        min_samples_leaf=50,
-        control_name=TREATMENT_NAMES[0],
-        random_state=RANDOM_SEED
-    )
+    with parallel_backend(backend):
+        # Train the UpLift Random Forest classifier
+        uplift_model = UpliftRandomForestClassifier(
+            min_samples_leaf=50,
+            control_name=TREATMENT_NAMES[0],
+            random_state=RANDOM_SEED
+        )
 
-    uplift_model.fit(df_train[x_names].values,
-                     treatment=df_train['treatment_group_key'].values,
-                     y=df_train[CONVERSION].values)
+        uplift_model.fit(df_train[x_names].values,
+                         treatment=df_train['treatment_group_key'].values,
+                         y=df_train[CONVERSION].values)
 
-    y_pred = uplift_model.predict(df_test[x_names].values)
-    result = pd.DataFrame(y_pred, columns=uplift_model.classes_[1:])
+        y_pred = uplift_model.predict(df_test[x_names].values)
+        result = pd.DataFrame(y_pred, columns=uplift_model.classes_[1:])
 
-    best_treatment = np.where((result < 0).all(axis=1),
-                              CONTROL_NAME,
-                              result.idxmax(axis=1))
+        best_treatment = np.where((result < 0).all(axis=1),
+                                  CONTROL_NAME,
+                                  result.idxmax(axis=1))
 
-    # Create a synthetic population:
+        # Create a synthetic population:
 
-    # Create indicator variables for whether a unit happened to have the
-    # recommended treatment or was in the control group
-    actual_is_best = np.where(
-        df_test['treatment_group_key'] == best_treatment, 1, 0
-    )
-    actual_is_control = np.where(
-        df_test['treatment_group_key'] == CONTROL_NAME, 1, 0
-    )
+        # Create indicator variables for whether a unit happened to have the
+        # recommended treatment or was in the control group
+        actual_is_best = np.where(
+            df_test['treatment_group_key'] == best_treatment, 1, 0
+        )
+        actual_is_control = np.where(
+            df_test['treatment_group_key'] == CONTROL_NAME, 1, 0
+        )
 
-    synthetic = (actual_is_best == 1) | (actual_is_control == 1)
-    synth = result[synthetic]
+        synthetic = (actual_is_best == 1) | (actual_is_control == 1)
+        synth = result[synthetic]
 
-    auuc_metrics = synth.assign(
-        is_treated=1 - actual_is_control[synthetic],
-        conversion=df_test.loc[synthetic, CONVERSION].values,
-        uplift_tree=synth.max(axis=1)
-    ).drop(columns=list(uplift_model.classes_[1:]))
+        auuc_metrics = synth.assign(
+            is_treated=1 - actual_is_control[synthetic],
+            conversion=df_test.loc[synthetic, CONVERSION].values,
+            uplift_tree=synth.max(axis=1)
+        ).drop(columns=list(uplift_model.classes_[1:]))
 
-    cumgain = get_cumgain(auuc_metrics,
-                          outcome_col=CONVERSION,
-                          treatment_col='is_treated')
+        cumgain = get_cumgain(auuc_metrics,
+                              outcome_col=CONVERSION,
+                              treatment_col='is_treated')
 
-    # Check if the cumulative gain of UpLift Random Forest is higher than
-    # random
-    assert cumgain['uplift_tree'].sum() > cumgain['Random'].sum()
+        # Check if the cumulative gain of UpLift Random Forest is higher than
+        # random
+        assert cumgain['uplift_tree'].sum() > cumgain['Random'].sum()
 
 
 def test_UpliftTreeClassifier(generate_classification_data):


### PR DESCRIPTION
## Proposed changes

This fixes #475 by merely indicating a preference for the backend instead of hardcoding it. This way users can specify the backend using `joblib.parallel_backend` (see https://joblib.readthedocs.io/en/latest/parallel.html#parallel) according to their circumstances.

## Types of changes

What types of changes does your code introduce to **CausalML**?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/uber/causalml/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/uber/causalml)
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

Related: #468 