### PR TITLE
Issue #498: Fixing sample_weight requirement in the Rlearner

### DIFF
--- a/causalml/inference/meta/rlearner.py
+++ b/causalml/inference/meta/rlearner.py
@@ -1,3 +1,4 @@
+import inspect
 from copy import deepcopy
 import logging
 import numpy as np
@@ -488,9 +489,14 @@ class BaseRClassifier(BaseRLearner):
                         group
                     )
                 )
-            self.models_tau[group].fit(
-                X_filt, (y_filt - yhat_filt) / (w - p_filt), sample_weight=weight
-            )
+            if 'sample_weight' in inspect.getargspec(self.models_tau[group].fit).args:
+                self.models_tau[group].fit(
+                    X_filt, (y_filt - yhat_filt) / (w - p_filt), sample_weight=weight
+                )
+            else:
+                self.models_tau[group].fit(
+                    X_filt, (y_filt - yhat_filt) / (w - p_filt)
+                )                
 
     def predict(self, X, p=None):
         """Predict treatment effects.


### PR DESCRIPTION
## Proposed changes

This PR resolves issue #498 .

Making sample_weight an optional argument for base regressor learner for Rlearner:
1) if there is a sample_weight is in the base learner (such as random forest regressor), then proceed as usual (same previous version);
2) if the base learner does not take sample_weight (such as neural network), then skip this argument;

## Types of changes

What types of changes does your code introduce to **CausalML**?
_Put an `x` in the boxes that apply_

- [x ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x ] I have read the [CONTRIBUTING](https://github.com/uber/causalml/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/uber/causalml)
- [x ] Lint and unit tests pass locally with my changes
- [x ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc. This PR template is adopted from [appium](https://github.com/appium/appium).
