### PR TITLE
Fix incorrect effect_learner_objective in XGBRRegressor

### DIFF
--- a/causalml/inference/meta/rlearner.py
+++ b/causalml/inference/meta/rlearner.py
@@ -516,7 +516,7 @@ class XGBRRegressor(BaseRRegressor):
         early_stopping=True,
         test_size=0.3,
         early_stopping_rounds=30,
-        effect_learner_objective="rank:pairwise",
+        effect_learner_objective="reg:squarederror",
         effect_learner_n_estimators=500,
         random_state=42,
         *args,
@@ -531,7 +531,7 @@ class XGBRRegressor(BaseRRegressor):
             early_stopping_rounds (int, optional): validation metric needs to improve at least once in every
                                                    early_stopping_rounds round(s) to continue training
             effect_learner_objective (str, optional): the learning objective for the effect learner
-                                                      (default = 'rank:pairwise')
+                                                      (default = 'reg:squarederror')
             effect_learner_n_estimators (int, optional): number of trees to fit for the effect learner (default = 500)
         """
 

--- a/tests/test_meta_learners.py
+++ b/tests/test_meta_learners.py
@@ -840,18 +840,24 @@ def test_BaseRClassifier_with_sample_weights(generate_classification_data):
     # higher than it would be under random targeting
     assert cumgain["tau_pred"].sum() > cumgain["Random"].sum()
 
+
+def test_XGBRegressor_with_sample_weights(generate_regression_data):
+    y, X, treatment, tau, b, e = generate_regression_data()
+
+    weights = np.random.rand(y.shape[0])
+
     # Check if XGBRRegressor successfully produces treatment effect estimation
     # when sample_weight is passed
     uplift_model = XGBRRegressor()
     uplift_model.fit(
-        X=df_train[x_names].values,
-        p=df_train["propensity_score"].values,
-        treatment=df_train["treatment_group_key"].values,
-        y=df_train[CONVERSION].values,
-        sample_weight=df_train["sample_weights"],
+        X=X,
+        p=e,
+        treatment=treatment,
+        y=y,
+        sample_weight=weights,
     )
-    tau_pred = uplift_model.predict(X=df_test[x_names].values)
-    assert len(tau_pred) == len(df_test["sample_weights"].values)
+    tau_pred = uplift_model.predict(X=X)
+    assert len(tau_pred) == len(weights)
 
 
 def test_pandas_input(generate_regression_data):


### PR DESCRIPTION
## Proposed changes

This PR fixes #501.

Currently the default value of `effect_learner_objective` in `XGBRRegressor` is incorrectly set to `rank:pairwise`, which is for classification.

This PR updates it to `reg:squarederror`, and also splits the test for `XGBRRegressor` with `sample_weights` from one for `BaseRClassifier` with `sample_weights`.

## Types of changes

What types of changes does your code introduce to **CausalML**?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/uber/causalml/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/uber/causalml)
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

N/A
