### PR TITLE
Exclude tests in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ extensions = [
     ),
 ]
 
-packages = find_packages()
+packages = find_packages(exclude=["tests", "tests.*"])
 
 setup(
     name="causalml",


### PR DESCRIPTION
## Proposed changes

This fixes #507 by specifying in `setup.py` that `tests` should not be packaged.

## Types of changes

What types of changes does your code introduce to **CausalML**?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/uber/causalml/blob/master/CONTRIBUTING.md) doc
- [ ] I have signed the [CLA](https://cla-assistant.io/uber/causalml)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

Compare https://github.com/quiltdata/quilt/pull/2632/files for an example of a similar change elsewhere.
