### PR TITLE
Fix the bug of incorrent result in qini for multiple models

### DIFF
--- a/causalml/metrics/visualize.py
+++ b/causalml/metrics/visualize.py
@@ -235,24 +235,34 @@ def get_qini(
 
     qini = []
     for i, col in enumerate(model_names):
-        df = df.sort_values(col, ascending=False).reset_index(drop=True)
-        df.index = df.index + 1
-        df["cumsum_tr"] = df[treatment_col].cumsum()
+        sorted_df = df.sort_values(col, ascending=False).reset_index(drop=True)
+        sorted_df.index = sorted_df.index + 1
+        sorted_df["cumsum_tr"] = sorted_df[treatment_col].cumsum()
 
-        if treatment_effect_col in df.columns:
+        if treatment_effect_col in sorted_df.columns:
             # When treatment_effect_col is given, use it to calculate the average treatment effects
             # of cumulative population.
-            l = df[treatment_effect_col].cumsum() / df.index * df["cumsum_tr"]
+            l = (
+                sorted_df[treatment_effect_col].cumsum()
+                / sorted_df.index
+                * sorted_df["cumsum_tr"]
+            )
         else:
             # When treatment_effect_col is not given, use outcome_col and treatment_col
             # to calculate the average treatment_effects of cumulative population.
-            df["cumsum_ct"] = df.index.values - df["cumsum_tr"]
-            df["cumsum_y_tr"] = (df[outcome_col] * df[treatment_col]).cumsum()
-            df["cumsum_y_ct"] = (df[outcome_col] * (1 - df[treatment_col])).cumsum()
+            sorted_df["cumsum_ct"] = sorted_df.index.values - sorted_df["cumsum_tr"]
+            sorted_df["cumsum_y_tr"] = (
+                sorted_df[outcome_col] * sorted_df[treatment_col]
+            ).cumsum()
+            sorted_df["cumsum_y_ct"] = (
+                sorted_df[outcome_col] * (1 - sorted_df[treatment_col])
+            ).cumsum()
 
             l = (
-                df["cumsum_y_tr"]
-                - df["cumsum_y_ct"] * df["cumsum_tr"] / df["cumsum_ct"]
+                sorted_df["cumsum_y_tr"]
+                - sorted_df["cumsum_y_ct"]
+                * sorted_df["cumsum_tr"]
+                / sorted_df["cumsum_ct"]
             )
 
         qini.append(l)


### PR DESCRIPTION
## Proposed changes

Similar to #273 , the `get_qini` function re-uses the same `df` during evaluation for multiple models.  
Therefore, result of the second model could be influenced by the first model.

This PR will fix the issue #519 by copying a new `sorted_df` in evaluation for each model.

## Types of changes

What types of changes does your code introduce to **CausalML**?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/uber/causalml/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/uber/causalml)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc. This PR template is adopted from [appium](https://github.com/appium/appium).
