### PR TITLE
Test get qini

### DIFF
--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,0 +1,31 @@
+import pandas as pd
+from numpy import isclose
+from causalml.metrics.visualize import qini_score
+
+
+def test_get_qini():
+    test_df = pd.DataFrame(
+        {
+            "y": [0, 0, 0, 0, 1, 0, 0, 1, 1, 1],
+            "w": [0] * 5 + [1] * 5,
+        }
+    )
+
+    good_uplift = [_ / 10 for _ in range(0, 5)]
+    bad_uplift = [1] + [0] * 9
+    test_df["learner_1"] = good_uplift * 2
+    # learner_2 is a bad model because it gives zero for almost all rows of data
+    test_df["learner_2"] = bad_uplift
+
+    # get qini score for 2 models in the single calling of qini_score
+    full_result = qini_score(test_df)
+
+    # get qini score for learner_1 separately
+    learner_1_result = qini_score(test_df[["y", "w", "learner_1"]])
+
+    # get qini score for learner_2 separately
+    learner_2_result = qini_score(test_df[["y", "w", "learner_2"]])
+
+    # for each learner, its qini score should stay same no matter calling with another model or calling separately
+    assert isclose(full_result["learner_1"], learner_1_result["learner_1"])
+    assert isclose(full_result["learner_2"], learner_2_result["learner_2"])

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -3,7 +3,7 @@ from numpy import isclose
 from causalml.metrics.visualize import qini_score
 
 
-def test_get_qini():
+def test_qini_score():
     test_df = pd.DataFrame(
         {
             "y": [0, 0, 0, 0, 1, 0, 0, 1, 1, 1],


### PR DESCRIPTION
## Proposed changes

Add test for `qini_score` in `causalml.metrics.visualize`.  
When the function is called with input of multiple models, this test ensures that score of one model is not influenced by other models. 
A related bug has been fixed in #520 

## Types of changes

What types of changes does your code introduce to **CausalML**?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/uber/causalml/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/uber/causalml)
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc. This PR template is adopted from [appium](https://github.com/appium/appium).
