### PR TITLE
bump numpy==1.23.2 in environment-py38.yml #338

### DIFF
--- a/envs/environment-py38.yml
+++ b/envs/environment-py38.yml
@@ -66,7 +66,7 @@ dependencies:
     - nest-asyncio==1.5.1
     - notebook==6.3.0
     - numba==0.53.1
-    - numpy==1.20.3
+    - numpy==1.23.2
     - oauthlib==3.1.0
     - opt-einsum==3.3.0
     - packaging==20.9


### PR DESCRIPTION
## Proposed changes

As described in https://github.com/uber/causalml/issues/338#issuecomment-1239665711, the py38 environment leads to an error in the example.  This can be resolved by bumping the numpy version to 1.23.2 for the envs/environment-py38.yml file, as is done in this PR.

## Types of changes

What types of changes does your code introduce to **CausalML**?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/uber/causalml/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/uber/causalml)
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments
