### PR TITLE
small fix in xlearner formula

### DIFF
--- a/docs/methodology.rst
+++ b/docs/methodology.rst
@@ -79,7 +79,7 @@ Impute the user level treatment effects, :math:`D^1_i` and :math:`D^0_j` for use
 
 .. math::
    D^1_i = Y^1_i - \hat\mu_0(X^1_i) \\
-   D^0_i = \hat\mu_1(X^0_i) - Y^0_i
+   D^0_j = \hat\mu_1(X^0_j) - Y^0_j
 
 then estimate :math:`\tau_1(x) = E[D^1|X=x]`, and :math:`\tau_0(x) = E[D^0|X=x]` using machine learning models.
 


### PR DESCRIPTION
## Proposed changes
This PR fixes a formula in XLearner. Description above talks about user `i` and `j` but formulas eludes user `j`. This is now fixed.

![Screenshot 2022-10-26 at 17 59 29](https://user-images.githubusercontent.com/75308940/198076275-250a8d05-f6c0-4f00-883a-860a4607aede.png)

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/uber/causalml/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/uber/causalml)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules