### PR TITLE
Allow using external propensities in estimate_ate when pretrain=True …

### DIFF
--- a/causalml/inference/meta/xlearner.py
+++ b/causalml/inference/meta/xlearner.py
@@ -321,13 +321,16 @@ class BaseXLearner(BaseLearner):
         Returns:
             The mean and confidence interval (LB, UB) of the ATE estimate.
         """
-        if pretrain and p is None:
-            # when p is null, use pretrain propensity score
-            if not self.propensity:
-                raise ValueError("no propensity score, please call fit() first")
-            te, dhat_cs, dhat_ts = self.predict(
-                X, treatment, y, p=self.propensity, return_components=True
-            )
+        if pretrain:
+            if p is None:
+                # when p is null, use pretrain propensity score
+                if not self.propensity:
+                    raise ValueError("no propensity score, please call fit() first")
+                te, dhat_cs, dhat_ts = self.predict(
+                    X, treatment, y, p=self.propensity, return_components=True
+                )
+            else:
+                p = self._format_p(p, self.t_groups)
         else:
             te, dhat_cs, dhat_ts = self.fit_predict(
                 X, treatment, y, p, return_components=True


### PR DESCRIPTION
…without triggering a retrain of the model

When pretrain=True and p is not None, the implementation of estimate_ate triggered a retrain of the model. I believe this is not the expected behavior, so I changed it. When the Xlearner is used with externally generated propensity scores, one should be able to use estimate_ate with the same externally generated propensity scores without retaining the model. Now when pretrain=True and p is not None, estimate_ate will use the pretrained model and the vector of propensities p.

## Proposed changes

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

## Types of changes

What types of changes does your code introduce to **CausalML**?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have read the [CONTRIBUTING](https://github.com/uber/causalml/blob/master/CONTRIBUTING.md) doc
- [ ] I have signed the [CLA](https://cla-assistant.io/uber/causalml)
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc. This PR template is adopted from [appium](https://github.com/appium/appium).
