### PR TITLE
Add **kwargs to Explainer.plot_shap_values()

### DIFF
--- a/causalml/inference/meta/explainer.py
+++ b/causalml/inference/meta/explainer.py
@@ -215,17 +215,22 @@ class Explainer(object):
                 title = "{} - {}".format(title_prefix, title)
             plt.title(title)
 
-    def plot_shap_values(self, shap_dict=None):
+    def plot_shap_values(self, shap_dict=None, **kwargs):
         """
         Calculates and plots the distribution of shapley values of each feature, for each treatment group.
         Skips the calculation part if shap_dict is given.
+
+        Args:
+            shap_dict (optional, dict): a dict of shapley value matrics. If None, shap_dict will be computed.
         """
         if shap_dict is None:
             shap_dict = self.get_shap_values()
 
         for group, values in shap_dict.items():
             plt.title(group)
-            shap.summary_plot(values, features=self.X, feature_names=self.features)
+            shap.summary_plot(
+                values, features=self.X, feature_names=self.features, **kwargs
+            )
 
     def plot_shap_dependence(
         self,
@@ -246,9 +251,9 @@ class Explainer(object):
 
         Args:
              treatment_group (str or int): name of treatment group to create dependency plot on
-             feature_idx (str or int): feature index / name to create dependency plot on
+             feature_idx (str or int): feature index/name to create dependency plot on
              shap_dict (optional, dict): a dict of shapley value matrices. If None, shap_dict will be computed.
-             interaction_idx (optional, str or int): feature index / name used in coloring scheme as interaction feature.
+             interaction_idx (optional, str or int): feature index/name used in coloring scheme as interaction feature.
                  If "auto" then shap.common.approximate_interactions is used to pick what seems to be the
                  strongest interaction (note that to find to true strongest interaction you need to compute
                  the SHAP interaction values).

--- a/causalml/inference/tree/causal/_tree.py
+++ b/causalml/inference/tree/causal/_tree.py
@@ -32,7 +32,6 @@ class BaseCausalDecisionTree(BaseDecisionTree):
     def fit(
         self, X, y, sample_weight=None, check_input=True, X_idx_sorted="deprecated"
     ):
-
         random_state = check_random_state(self.random_state)
 
         if self.ccp_alpha < 0.0:

--- a/causalml/inference/tree/causal/causaltree.py
+++ b/causalml/inference/tree/causal/causaltree.py
@@ -367,7 +367,6 @@ class CausalTreeRegressor(RegressorMixin, BaseCausalDecisionTree):
         return X, y, w
 
     def _count_groups_distribution(self, X: np.ndarray, treatment: np.ndarray) -> dict:
-
         """
         Count treatment, control distribution for tree nodes/leaves
         Args:

--- a/causalml/inference/tree/utils.py
+++ b/causalml/inference/tree/utils.py
@@ -278,7 +278,6 @@ def get_tree_leaves_mask(tree) -> np.ndarray:
     is_leaves = np.zeros(shape=n_nodes, dtype=bool)
     stack = [(0, 0)]
     while len(stack) > 0:
-
         node_id, depth = stack.pop()
         node_depth[node_id] = depth
 

--- a/causalml/match.py
+++ b/causalml/match.py
@@ -424,7 +424,6 @@ class MatchOptimizer(object):
 
 
 if __name__ == "__main__":
-
     from .features import TREATMENT_COL, SCORE_COL, GROUPBY_COL, PROPENSITY_FEATURES
     from .features import PROPENSITY_FEATURE_TRANSFORMATIONS, MATCHING_COVARIATES
     from .features import load_data

--- a/causalml/optimize/pns.py
+++ b/causalml/optimize/pns.py
@@ -61,18 +61,15 @@ def get_pns_bounds(data_exp, data_obs, T, Y, type="PNS"):
     Y0doT0 = 1 - Y1doT0
 
     if type == "PNS":
-
         lb_args = [0, Y1doT1 - Y1doT0, Y1 - Y1doT0, Y1doT1 - Y1]
 
         ub_args = [Y1doT1, Y0doT0, T1Y1 + T0Y0, Y1doT1 - Y1doT0 + T1Y0 + T0Y1]
 
     if type == "PN":
-
         lb_args = [0, (Y1 - Y1doT0) / T1Y1]
         ub_args = [1, (Y0doT0 - T0Y0) / T1Y1]
 
     if type == "PS":
-
         lb_args = [0, (Y1doT1 - Y1) / T0Y0]
         ub_args = [1, (Y1doT1 - T1Y1) / T0Y0]
 

--- a/causalml/optimize/unit_selection.py
+++ b/causalml/optimize/unit_selection.py
@@ -62,7 +62,6 @@ class CounterfactualUnitSelector:
         defier_payoff,
         organic_conversion=None,
     ):
-
         self.learner = learner
         self.nevertaker_payoff = nevertaker_payoff
         self.alwaystaker_payoff = alwaystaker_payoff
@@ -76,11 +75,9 @@ class CounterfactualUnitSelector:
         """
 
         if self._gain_equality_check():
-
             self._fit_segment_model(data, treatment, outcome)
 
         else:
-
             self._fit_segment_model(data, treatment, outcome)
             self._fit_condprob_models(data, treatment, outcome)
 
@@ -91,11 +88,9 @@ class CounterfactualUnitSelector:
         """
 
         if self._gain_equality_check():
-
             est_payoff = self._get_exact_benefit(data, treatment, outcome)
 
         else:
-
             est_payoff = self._obj_func_midp(data, treatment, outcome)
 
         return est_payoff
@@ -246,11 +241,9 @@ class CounterfactualUnitSelector:
         pr_y0w1_x = segment_prob[:, segment_name == "ND"]
 
         if self.organic_conversion is not None:
-
             pr_y_x = self.organic_conversion
 
         else:
-
             pr_y_x = pr_y1_w0
             warnings.warn(
                 "Probability of organic conversion estimated from control observations."

--- a/causalml/optimize/value_optimization.py
+++ b/causalml/optimize/value_optimization.py
@@ -57,7 +57,6 @@ class CounterfactualValueEstimator:
         *args,
         **kwargs
     ):
-
         self.treatment = treatment
         self.control_name = control_name
         self.treatment_names = treatment_names

--- a/tests/test_counterfactual_unit_selection.py
+++ b/tests/test_counterfactual_unit_selection.py
@@ -13,7 +13,6 @@ from tests.const import RANDOM_SEED
 
 
 def test_counterfactual_unit_selection():
-
     df, X_names = make_uplift_classification(
         n_samples=2000, treatment_name=["control", "treatment"]
     )

--- a/tests/test_match.py
+++ b/tests/test_match.py
@@ -9,7 +9,6 @@ from .const import RANDOM_SEED, TREATMENT_COL, SCORE_COL, GROUP_COL
 
 @pytest.fixture
 def generate_unmatched_data(generate_regression_data):
-
     generated = False
 
     def _generate_data():

--- a/tests/test_meta_learners.py
+++ b/tests/test_meta_learners.py
@@ -671,7 +671,6 @@ def test_TMLELearner(generate_regression_data):
 
 
 def test_BaseSClassifier(generate_classification_data):
-
     np.random.seed(RANDOM_SEED)
 
     df, x_names = generate_classification_data()
@@ -716,7 +715,6 @@ def test_BaseSClassifier(generate_classification_data):
 
 
 def test_BaseTClassifier(generate_classification_data):
-
     np.random.seed(RANDOM_SEED)
 
     df, x_names = generate_classification_data()
@@ -761,7 +759,6 @@ def test_BaseTClassifier(generate_classification_data):
 
 
 def test_BaseXClassifier(generate_classification_data):
-
     np.random.seed(RANDOM_SEED)
 
     df, x_names = generate_classification_data()
@@ -832,7 +829,6 @@ def test_BaseXClassifier(generate_classification_data):
 
 
 def test_BaseRClassifier(generate_classification_data):
-
     np.random.seed(RANDOM_SEED)
 
     df, x_names = generate_classification_data()
@@ -882,7 +878,6 @@ def test_BaseRClassifier(generate_classification_data):
 
 
 def test_BaseRClassifier_with_sample_weights(generate_classification_data):
-
     np.random.seed(RANDOM_SEED)
 
     df, x_names = generate_classification_data()

--- a/tests/test_value_optimization.py
+++ b/tests/test_value_optimization.py
@@ -15,7 +15,6 @@ from tests.const import RANDOM_SEED
 
 
 def test_counterfactual_value_optimization():
-
     df, X_names = make_uplift_classification(
         n_samples=2000, treatment_name=["control", "treatment1", "treatment2"]
     )


### PR DESCRIPTION
## Proposed changes

This PR fixes #601. It adds `**kwargs` to `Explainer.plot_shap_values()` so that users can pass additional arguments to `shap.summary_plot()`.

## Types of changes

What types of changes does your code introduce to **CausalML**?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/uber/causalml/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/uber/causalml)
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

N/A