### PR TITLE
Bug Fix in Dragonnet: Adam parameter name lr depreciation

### DIFF
--- a/causalml/inference/tf/dragonnet.py
+++ b/causalml/inference/tf/dragonnet.py
@@ -176,7 +176,7 @@ class DragonNet:
 
         if self.use_adam:
             self.dragonnet.compile(
-                optimizer=Adam(lr=self.adam_learning_rate), loss=loss, metrics=metrics
+                optimizer=Adam(learning_rate=self.adam_learning_rate), loss=loss, metrics=metrics
             )
 
             adam_callbacks = [
@@ -220,7 +220,7 @@ class DragonNet:
         ]
 
         self.dragonnet.compile(
-            optimizer=SGD(lr=self.learning_rate, momentum=self.momentum, nesterov=True),
+            optimizer=SGD(learning_rate=self.learning_rate, momentum=self.momentum, nesterov=True),
             loss=loss,
             metrics=metrics,
         )

--- a/causalml/inference/tf/dragonnet.py
+++ b/causalml/inference/tf/dragonnet.py
@@ -176,7 +176,9 @@ class DragonNet:
 
         if self.use_adam:
             self.dragonnet.compile(
-                optimizer=Adam(learning_rate=self.adam_learning_rate), loss=loss, metrics=metrics
+                optimizer=Adam(learning_rate=self.adam_learning_rate),
+                loss=loss,
+                metrics=metrics,
             )
 
             adam_callbacks = [
@@ -220,7 +222,9 @@ class DragonNet:
         ]
 
         self.dragonnet.compile(
-            optimizer=SGD(learning_rate=self.learning_rate, momentum=self.momentum, nesterov=True),
+            optimizer=SGD(
+                learning_rate=self.learning_rate, momentum=self.momentum, nesterov=True
+            ),
             loss=loss,
             metrics=metrics,
         )


### PR DESCRIPTION
## Proposed changes

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

For tensorflow>=2.3 lr parameter is depreciated in Adam optimizer. It produces nan result in Dragonnet. The fix is to use the updated name learning_rate and I am able to reproduce the result in the example notebook again.


## Types of changes

What types of changes does your code introduce to **CausalML**?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/uber/causalml/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/uber/causalml)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc. This PR template is adopted from [appium](https://github.com/appium/appium).
