### PR TITLE
Pass on **kwargs in `plot_shap_values` of base meta leaner

### DIFF
--- a/causalml/inference/meta/base.py
+++ b/causalml/inference/meta/base.py
@@ -276,7 +276,7 @@ class BaseLearner(metaclass=ABCMeta):
             override_checks=override_checks,
             classes=self._classes,
         )
-        explainer.plot_shap_values(shap_dict=shap_dict)
+        explainer.plot_shap_values(shap_dict=shap_dict, **kwargs)
 
     def plot_shap_dependence(
         self,


### PR DESCRIPTION
## Proposed changes

As of now, the `plot_shap_values` method of the base meta learner class has a `**kwargs` parameter. Yet, the latter isn't actually passed to the `plot_shap_values` method of the explainer. The latter would pass those to actual plotting methods, allowing e.g. for setting `show=False`.

## Types of changes

What types of changes does your code introduce to **CausalML**?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/uber/causalml/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/uber/causalml)
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments
 
This is analogous to https://github.com/uber/causalml/pull/603.