### PR TITLE
Fix AttributeError in builds with numpy>=1.24 and pandas>=2.0

### DIFF
--- a/causalml/features.py
+++ b/causalml/features.py
@@ -240,13 +240,13 @@ def load_data(data, features, transformations={}):
     df = data[features].copy()
 
     bool_cols = [col for col in df.columns if df[col].dtype == bool]
-    df.loc[:, bool_cols] = df[bool_cols].astype(np.int8)
+    df.loc[:, bool_cols] = df[bool_cols].astype(int)
 
     for col, transformation in transformations.items():
         logger.info("Applying {} to {}".format(transformation.__name__, col))
         df[col] = df[col].apply(transformation)
 
-    cat_cols = [col for col in features if df[col].dtype == np.object]
+    cat_cols = [col for col in features if df[col].dtype == object]
     num_cols = [col for col in features if col not in cat_cols]
 
     logger.info("Applying one-hot-encoding to {}".format(cat_cols))

--- a/causalml/metrics/sensitivity.py
+++ b/causalml/metrics/sensitivity.py
@@ -7,6 +7,8 @@ from importlib import import_module
 
 logger = logging.getLogger("sensitivity")
 
+SUMMARY_COLS = ["Method", "ATE", "New ATE", "New ATE LB", "New ATE UB"]
+
 
 def one_sided(alpha, p, treatment):
     """One sided confounding function.
@@ -217,9 +219,7 @@ class Sensitivity(object):
 
         alpha_range.sort()
 
-        summary_df = pd.DataFrame(
-            columns=["Method", "ATE", "New ATE", "New ATE LB", "New ATE UB"]
-        )
+        summary = []
         for method in methods:
             sens = self.get_class_object(method)
             sens = sens(
@@ -238,7 +238,9 @@ class Sensitivity(object):
                 method = method + "(sample size @{})".format(sample_size)
 
             sens_df = sens.summary(method=method)
-            summary_df = summary_df.append(sens_df)
+            summary.append(sens_df.values.tolist()[0])
+
+        summary_df = pd.DataFrame(summary, columns=SUMMARY_COLS)
 
         return summary_df
 
@@ -264,13 +266,7 @@ class Sensitivity(object):
         sensitivity_summary = pd.DataFrame(
             [method_name, ate, ate_new, ate_new_lower, ate_new_upper]
         ).T
-        sensitivity_summary.columns = [
-            "Method",
-            "ATE",
-            "New ATE",
-            "New ATE LB",
-            "New ATE UB",
-        ]
+        sensitivity_summary.columns = SUMMARY_COLS
         return sensitivity_summary
 
     def sensitivity_estimate(self):
@@ -453,20 +449,20 @@ class SensitivitySelectionBias(Sensitivity):
         preds = self.get_prediction(X, p, treatment, y)
 
         sens_df = pd.DataFrame()
+
+        sens = []
         for a in alpha_range:
-            sens = defaultdict(list)
-            sens["alpha"] = a
             adj = confound(a, p, treatment)
             preds_adj = y - adj
             s_preds = self.get_prediction(X, p, treatment, preds_adj)
             ate, ate_lb, ate_ub = self.get_ate_ci(X, p, treatment, preds_adj)
 
             s_preds_residul = preds_adj - s_preds
-            sens["rsqs"] = a**2 * np.var(treatment) / np.var(s_preds_residul)
-            sens["New ATE"] = ate
-            sens["New ATE LB"] = ate_lb
-            sens["New ATE UB"] = ate_ub
-            sens_df = sens_df.append(pd.DataFrame(sens, index=[0]))
+            rsqs = a**2 * np.var(treatment) / np.var(s_preds_residul)
+
+            sens.append([a, rsqs, ate, ate_lb, ate_ub])
+
+        sens_df = pd.DataFrame(sens, columns=['alpha', 'rsqs', 'New ATE', 'New ATE LB', 'New ATE UB'])
 
         rss = np.sum(np.square(y - preds))
         partial_rsqs = []
@@ -502,9 +498,7 @@ class SensitivitySelectionBias(Sensitivity):
         sensitivity_summary["ATE"] = sensitivity_summary[
             sensitivity_summary.alpha == 0
         ]["New ATE"]
-        return sensitivity_summary[
-            ["Method", "ATE", "New ATE", "New ATE LB", "New ATE UB"]
-        ]
+        return sensitivity_summary[SUMMARY_COLS]
 
     @staticmethod
     def plot(sens_df, partial_rsqs_df=None, type="raw", ci=False, partial_rsqs=False):

--- a/causalml/metrics/sensitivity.py
+++ b/causalml/metrics/sensitivity.py
@@ -462,7 +462,9 @@ class SensitivitySelectionBias(Sensitivity):
 
             sens.append([a, rsqs, ate, ate_lb, ate_ub])
 
-        sens_df = pd.DataFrame(sens, columns=['alpha', 'rsqs', 'New ATE', 'New ATE LB', 'New ATE UB'])
+        sens_df = pd.DataFrame(
+            sens, columns=["alpha", "rsqs", "New ATE", "New ATE LB", "New ATE UB"]
+        )
 
         rss = np.sum(np.square(y - preds))
         partial_rsqs = []

--- a/tests/test_counterfactual_unit_selection.py
+++ b/tests/test_counterfactual_unit_selection.py
@@ -60,13 +60,13 @@ def test_counterfactual_unit_selection():
     )
 
     cus.fit(
-        data=df_train.drop("treatment_group_key", 1),
+        data=df_train.drop("treatment_group_key", axis=1),
         treatment="treatment_numeric",
         outcome="conversion",
     )
 
     cus_pred = cus.predict(
-        data=df_test.drop("treatment_group_key", 1),
+        data=df_test.drop("treatment_group_key", axis=1),
         treatment="treatment_numeric",
         outcome="conversion",
     )


### PR DESCRIPTION
## Proposed changes

This PR fixes #630 by removing `np.object`, `np.int` and `df.append()` in the codebase.

- Numpy deprecated `np.object`, `np.int` and other alias. See [release notes](https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations) for more details.
- Pandas deprecated `df.append()`. See [release notes](https://pandas.pydata.org/docs/whatsnew/v2.0.0.html#removal-of-prior-version-deprecations-changes) for more details. 

## Types of changes

What types of changes does your code introduce to **CausalML**?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/uber/causalml/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/uber/causalml)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

N/A
