### PR TITLE
Update _builder.pyx

### DIFF
--- a/causalml/inference/tree/causal/_builder.pyx
+++ b/causalml/inference/tree/causal/_builder.pyx
@@ -58,7 +58,7 @@ cdef class DepthFirstCausalTreeBuilder(TreeBuilder):
         cdef int init_capacity
 
         if tree.max_depth <= 10:
-            init_capacity = (2 ** (tree.max_depth + 1)) - 1
+            init_capacity = int((2 ** (tree.max_depth + 1)) - 1)
         else:
             init_capacity = 2047
 

--- a/envs/environment-py37.yml
+++ b/envs/environment-py37.yml
@@ -24,6 +24,7 @@ dependencies:
     - decorator==5.0.7
     - defusedxml==0.7.1
     - dill==0.3.3
+    - duecredit==0.9.2
     - entrypoints==0.3
     - future==0.18.2
     - gast==0.4.0

--- a/envs/environment-py38.yml
+++ b/envs/environment-py38.yml
@@ -23,6 +23,7 @@ dependencies:
     - decorator==5.0.7
     - defusedxml==0.7.1
     - dill==0.3.3
+    - duecredit==0.9.2
     - entrypoints==0.3
     - future==0.18.2
     - gast==0.3.3

--- a/envs/environment-py39.yml
+++ b/envs/environment-py39.yml
@@ -23,6 +23,7 @@ dependencies:
     - decorator==5.0.7
     - defusedxml==0.7.1
     - dill==0.3.3
+    - duecredit==0.9.2
     - entrypoints==0.3
     - future==0.18.2
     - gast==0.3.3


### PR DESCRIPTION
Exponentiation appears to cause type conversion to double in some instances.

## Proposed changes

Same issue as shown in https://github.com/uber/causalml/issues/534. I cannot deploy causalml models in SageMaker because I see same error, and also on my M1 laptop.

## Types of changes

What types of changes does your code introduce to **CausalML**?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have read the [CONTRIBUTING](https://github.com/uber/causalml/blob/master/CONTRIBUTING.md) doc
- [ ] I have signed the [CLA](https://cla-assistant.io/uber/causalml)
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x ] I have added necessary documentation (if appropriate)
- [x ] Any dependent changes have been merged and published in downstream modules

## Further comments

Small change to ensure any type conversion due to exponentiation is undone.
