### PR TITLE
fix: update to `envs/` conda build for precompiled M1 installs

### DIFF
--- a/envs/environment-py39.yml
+++ b/envs/environment-py39.yml
@@ -9,7 +9,7 @@ dependencies:
   - pip:
     - absl-py==0.12.0
     - appnope==0.1.2
-    - argon2-cffi==20.1.0
+    - argon2-cffi==21.2.0
     - astunparse==1.6.3
     - async-generator==1.10
     - attrs==20.3.0
@@ -20,18 +20,18 @@ dependencies:
     - chardet==4.0.0
     - coverage==5.5
     - cycler==0.10.0
-    - cython==0.29.23
+    - Cython==0.29.34
     - decorator==5.0.7
     - defusedxml==0.7.1
-    - dill==0.3.3
+    - dill==0.3.5.1
     - entrypoints==0.3
     - future==0.18.2
     - gast==0.3.3
     - google-auth==1.29.0
     - google-auth-oauthlib==0.4.4
     - google-pasta==0.2.0
-    - grpcio==1.37.0
-    - h5py==2.10.0
+    - grpcio==1.51.3
+    - h5py==3.9.0
     - idna==2.10
     - iniconfig==1.1.1
     - ipykernel==5.5.3
@@ -54,8 +54,8 @@ dependencies:
     - jupyterlab-pygments==0.1.2
     - jupyterlab-widgets==1.0.0
     - kiwisolver==1.3.1
-    - lightgbm==3.2.1
-    - llvmlite==0.36.0
+    - lightgbm==3.3.4
+    - llvmlite==0.39.0
     - lxml==4.6.3
     - markdown==3.3.4
     - markupsafe==1.1.1
@@ -66,14 +66,14 @@ dependencies:
     - nbformat==5.1.3
     - nest-asyncio==1.5.1
     - notebook==6.3.0
-    - numba==0.53.1
+    - numba==0.56.0
     - oauthlib==3.1.0
     - opt-einsum==3.3.0
     - packaging==20.9
     - pandas==1.2.4
     - pandocfilters==1.4.3
     - parso==0.8.2
-    - patsy==0.5.1
+    - patsy==0.5.2
     - pexpect==4.8.0
     - pickleshare==0.7.5
     - pillow==8.2.0
@@ -133,4 +133,5 @@ dependencies:
     - widgetsnbextension==3.5.1
     - wrapt==1.12.1
     - xgboost==1.4.1
-    - causalml>=0.10.0
+    ## Relative path to setup.py directory for full local installation
+    - ../.


### PR DESCRIPTION
## Proposed changes

Follow up to #641 for some missed packages re: dedicated Mac M1 builds
* [grcpio==1.51.3](https://github.com/grpc/grpc/releases/tag/v1.51.3)
* [h5py==3.7.0](https://github.com/h5py/h5py/compare/3.6.0...3.7.0)
* [lightgbm==3.3.4](https://github.com/microsoft/LightGBM/commit/2f0d3a4d7cde1c5d97b371b24824bda0a9eec532)
* [llvmlite==0.39.0](https://github.com/numba/llvmlite/commit/a69c32ebafe8f8e1058f907740c439ee2bcf094e)
* [numba==0.56.0](https://numba.readthedocs.io/en/stable/release-notes.html#version-0-55-2-25-may-2022)

Also updating install of `causalml` to reference cloned repository `setup.py` file in order to distinguish from `pip` method/include pre-release changes.

## Types of changes

What types of changes does your code introduce to **CausalML**?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/uber/causalml/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/uber/causalml)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

Sorry I missed these earlier, but now all set on 3.9 conda virtual env building!
