### PR TITLE
fix: simulate_randomized_trial

### DIFF
--- a/causalml/dataset/regression.py
+++ b/causalml/dataset/regression.py
@@ -102,7 +102,7 @@ def simulate_randomized_trial(n=1000, p=5, sigma=1.0, adj=0.0):
     """
 
     X = np.random.normal(size=n * p).reshape((n, -1))
-    b = np.maximum(np.repeat(0.0, n), X[:, 0] + X[:, 1], X[:, 2]) + np.maximum(
+    b = np.maximum.reduce([np.repeat(0.0, n), X[:, 0] + X[:, 1], X[:, 2]]) + np.maximum(
         np.repeat(0.0, n), X[:, 3] + X[:, 4]
     )
     e = np.repeat(0.5, n)


### PR DESCRIPTION
## Proposed changes

Caught a bug in the simulation of randomized trial data, prior code of `np.maximum(np.repeat(0.0, n), X[:, 0] + X[:, 1], X[:, 2])` was actually returning `np.maximum(np.repeat(0.0,n), X[:,0] + X[:,1])` and assigning the value of this to X[:,2] based on the documentation (see [out](https://numpy.org/doc/stable/reference/generated/numpy.maximum.html)).

## Types of changes

What types of changes does your code introduce to **CausalML**?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/uber/causalml/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/uber/causalml)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

Impact of this is issues with parameter recall on different models (X[:,2] suddenly shows up as super important under shap values when it shouldn't be related to tau). Illustration of data impact included below:

<img width="632" alt="image" src="https://github.com/uber/causalml/assets/28548757/c418915c-2df9-4ef9-b19a-84aa2d93462d">
