### PR TITLE
Remove the numpy and pandas version restriction in pyproject.toml

### DIFF
--- a/causalml/propensity.py
+++ b/causalml/propensity.py
@@ -166,9 +166,7 @@ class GradientBoostedPropensityModel(PropensityModel):
         """
         if self.early_stop:
             return np.clip(
-                self.model.predict_proba(X, ntree_limit=self.model.best_ntree_limit)[
-                    :, 1
-                ],
+                self.model.predict_proba(X)[:, 1],
                 *self.clip_bounds,
             )
         else:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,10 +26,10 @@ dependencies = [
     "forestci==0.6",
     "pathos==0.2.9",
     "pip>=10.0",
-    "numpy<1.24",
+    "numpy",
     "scipy>=1.4.1",
     "matplotlib",
-    "pandas>=0.24.1,<1.4.0",
+    "pandas>=0.24.1",
     "scikit-learn<=1.0.2",
     "statsmodels>=0.9.0",
     "Cython<=0.29.34",
@@ -62,7 +62,7 @@ requires = [
     "setuptools>=18.0",
     "wheel",
     "Cython<=0.29.34",
-    "numpy<1.24",
+    "numpy",
     "scikit-learn<=1.0.2",
 ]
 


### PR DESCRIPTION
## Proposed changes

This PR fixes #680 by removing the numpy and pandas version restriction in pyproject.toml. I tested causalml with the latest numpy and pandas locally and it passed the build and all tests.

I also removed `ntree_limit` from `GradientBoostedPropensityModel.predict()` to reflect the latest XGBoost API updates and resolve the build error (e.g., https://github.com/uber/causalml/actions/runs/6285485709/job/17079160049?pr=683).

## Types of changes

What types of changes does your code introduce to **CausalML**?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/uber/causalml/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/uber/causalml)
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments

N/A