### PR TITLE
Fix the readthedocs build error

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -207,6 +207,10 @@ htmlhelp_basename = "causalml_doc"
 
 # -- Options for LaTeX output ------------------------------------------
 
+# To resolve a Unicode error as suggested in
+# https://docs.readthedocs.io/en/stable/guides/pdf-non-ascii-languages.html
+latex_engine = "xelatex"
+
 latex_elements = {
     # The paper size ('letterpaper' or 'a4paper').
     # 'papersize': 'letterpaper',

--- a/docs/examples/binary_policy_learner_example.ipynb
+++ b/docs/examples/binary_policy_learner_example.ipynb
@@ -80,7 +80,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Binary treatment policy learning"
+    "## Binary treatment policy learning"
    ]
   },
   {

--- a/docs/examples/dr_learner_with_synthetic_data.ipynb
+++ b/docs/examples/dr_learner_with_synthetic_data.ipynb
@@ -72,7 +72,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Synthetic Data Generation"
+    "## Synthetic Data Generation"
    ]
   },
   {
@@ -88,7 +88,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Comparing DR Learner with X Learner"
+    "## Comparing DR Learner with X Learner"
    ]
   },
   {
@@ -171,7 +171,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Synthetic Data with Hidden Confounder"
+    "## Synthetic Data with Hidden Confounder"
    ]
   },
   {
@@ -211,7 +211,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Comparing X Learner, DR Learner, and DRIV Learner"
+    "## Comparing X Learner, DR Learner, and DRIV Learner"
    ]
   },
   {

--- a/docs/examples/feature_interpretations_example.ipynb
+++ b/docs/examples/feature_interpretations_example.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Meta-Learners Interpretation with Feature Importance and SHAP Values"
+    "# Model Interpretation with Feature Importance and SHAP Values"
    ]
   },
   {
@@ -2172,7 +2172,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Uplift Tree/Forest"
+    "## Uplift Tree/Forest"
    ]
   },
   {


### PR DESCRIPTION
## Proposed changes

This PR fixes the [readthedocs build error](https://readthedocs.org/projects/causalml/builds/22492033/). Currently, the doc build is failing due to a Unicode error. I added the `latex_engine` config to `docs/conf.py` as suggested [here](https://docs.readthedocs.io/en/stable/guides/pdf-non-ascii-languages.html).

I also fixed inconsistent section levels in some of the example notebooks.

## Types of changes

What types of changes does your code introduce to **CausalML**?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/uber/causalml/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/uber/causalml)
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments
