### PR TITLE
Fix missing value when calculate cumulative lift

### DIFF
--- a/causalml/metrics/visualize.py
+++ b/causalml/metrics/visualize.py
@@ -113,11 +113,17 @@ def get_cumlift(
             sorted_df["cumsum_tr"] = sorted_df[treatment_col].cumsum()
             sorted_df["cumsum_ct"] = sorted_df.index.values - sorted_df["cumsum_tr"]
             sorted_df["cumsum_y_tr"] = (
-                sorted_df[outcome_col] * sorted_df[treatment_col]
-            ).fillna(0).cumsum(skipna=True).astype(float)
+                (sorted_df[outcome_col] * sorted_df[treatment_col])
+                .fillna(0)
+                .cumsum(skipna=True)
+                .astype(float)
+            )
             sorted_df["cumsum_y_ct"] = (
-                sorted_df[outcome_col] * (1 - sorted_df[treatment_col])
-            ).fillna(0).cumsum(skipna=True).astype(float)
+               (sorted_df[outcome_col] * (1 - sorted_df[treatment_col]))
+                .fillna(0)
+                .cumsum(skipna=True)
+                .astype(float)
+            )
 
             lift.append(
                 sorted_df["cumsum_y_tr"] / sorted_df["cumsum_tr"]

--- a/causalml/metrics/visualize.py
+++ b/causalml/metrics/visualize.py
@@ -114,10 +114,10 @@ def get_cumlift(
             sorted_df["cumsum_ct"] = sorted_df.index.values - sorted_df["cumsum_tr"]
             sorted_df["cumsum_y_tr"] = (
                 sorted_df[outcome_col] * sorted_df[treatment_col]
-            ).cumsum()
+            ).fillna(0).cumsum(skipna=True).astype(float)
             sorted_df["cumsum_y_ct"] = (
                 sorted_df[outcome_col] * (1 - sorted_df[treatment_col])
-            ).cumsum()
+            ).fillna(0).cumsum(skipna=True).astype(float)
 
             lift.append(
                 sorted_df["cumsum_y_tr"] / sorted_df["cumsum_tr"]

--- a/causalml/metrics/visualize.py
+++ b/causalml/metrics/visualize.py
@@ -119,7 +119,7 @@ def get_cumlift(
                 .astype(float)
             )
             sorted_df["cumsum_y_ct"] = (
-               (sorted_df[outcome_col] * (1 - sorted_df[treatment_col]))
+                (sorted_df[outcome_col] * (1 - sorted_df[treatment_col]))
                 .fillna(0)
                 .cumsum(skipna=True)
                 .astype(float)


### PR DESCRIPTION
## Proposed changes
Noticed that if there are missing values for the outcome column when calculate cumulative lift, the current `.cumsum()` function default as `skipna=False`  which will return NaN when there are missing values as a results the calculation of lift could be off
<img width="810" alt="image" src="https://github.com/uber/causalml/assets/99832397/4c19327d-d995-4e48-8acd-671c4284da0b">

Propose change to `.fillna(0).cumsum(skipna=True).astype(float)`  (change to float to avoid the division by zero error as well)

<img width="859" alt="image" src="https://github.com/uber/causalml/assets/99832397/999ff947-52c6-4c73-88b0-522519403956">



## Types of changes

What types of changes does your code introduce to **CausalML**?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/uber/causalml/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/uber/causalml)
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc. This PR template is adopted from [appium](https://github.com/appium/appium).
