### PR TITLE
expose n_jobs for rlearner

### DIFF
--- a/causalml/inference/meta/rlearner.py
+++ b/causalml/inference/meta/rlearner.py
@@ -38,6 +38,7 @@ class BaseRLearner(BaseLearner):
         control_name=0,
         n_fold=5,
         random_state=None,
+        cv_n_jobs=-1,
     ):
         """Initialize an R-learner.
 
@@ -52,6 +53,7 @@ class BaseRLearner(BaseLearner):
             control_name (str or int, optional): name of control group
             n_fold (int, optional): the number of cross validation folds for outcome_learner
             random_state (int or RandomState, optional): a seed (int) or random number generator (RandomState)
+            cv_n_jobs (int, optional): number of parallel jobs to run for cross_val_predict. -1 means using all processors
         """
         assert (learner is not None) or (
             (outcome_learner is not None) and (effect_learner is not None)
@@ -71,6 +73,7 @@ class BaseRLearner(BaseLearner):
 
         self.random_state = random_state
         self.cv = KFold(n_splits=n_fold, shuffle=True, random_state=random_state)
+        self.cv_n_jobs = cv_n_jobs
 
         self.propensity = None
         self.propensity_model = None
@@ -120,7 +123,7 @@ class BaseRLearner(BaseLearner):
 
         if verbose:
             logger.info("generating out-of-fold CV outcome estimates")
-        yhat = cross_val_predict(self.model_mu, X, y, cv=self.cv, n_jobs=-1)
+        yhat = cross_val_predict(self.model_mu, X, y, cv=self.cv, n_jobs=self.cv_n_jobs)
 
         for group in self.t_groups:
             mask = (treatment == group) | (treatment == self.control_name)


### PR DESCRIPTION
## Proposed changes

The Rlearner interface uses `cross_val_predict` to predict `mu` but did not expose n_jobs params. The default value of `n_jobs` uses all processors, which may consumes too much memory (to OOM) especially for large dataset. The `cross_val_predict` method uses `joblib` for parallelization, the memory will grow with the number of workers. It's more reasonable to expose this param and let users decide.

## Types of changes

What types of changes does your code introduce to **CausalML**?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/uber/causalml/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/uber/causalml)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

Nope
