### PR TITLE
Dev/717 pytest tau col hotfix

### DIFF
--- a/tests/test_cevae.py
+++ b/tests/test_cevae.py
@@ -38,9 +38,7 @@ def test_CEVAE():
     # check the accuracy of the ite accuracy
     ite = cevae.predict(X).flatten()
 
-    auuc_metrics = pd.DataFrame(
-        {"ite": ite, "W": treatment, "y": y, "treatment_effect_col": tau}
-    )
+    auuc_metrics = pd.DataFrame({"ite": ite, "W": treatment, "y": y, "tau": tau})
 
     cumgain = get_cumgain(
         auuc_metrics, outcome_col="y", treatment_col="W", treatment_effect_col="tau"

--- a/tests/test_ivlearner.py
+++ b/tests/test_ivlearner.py
@@ -71,7 +71,7 @@ def test_drivlearner():
             "cate_p": cate_p.flatten(),
             "W": treatment,
             "y": y,
-            "treatment_effect_col": tau,
+            "tau": tau,
         }
     )
 

--- a/tests/test_meta_learners.py
+++ b/tests/test_meta_learners.py
@@ -123,7 +123,7 @@ def test_BaseSRegressor(generate_regression_data):
             "cate_p": cate_p.flatten(),
             "W": treatment,
             "y": y,
-            "treatment_effect_col": tau,
+            "tau": tau,
         }
     )
 
@@ -179,7 +179,7 @@ def test_BaseTLearner(generate_regression_data):
             "cate_p": cate_p.flatten(),
             "W": treatment,
             "y": y,
-            "treatment_effect_col": tau,
+            "tau": tau,
         }
     )
 
@@ -229,7 +229,7 @@ def test_BaseTRegressor(generate_regression_data):
             "cate_p": cate_p.flatten(),
             "W": treatment,
             "y": y,
-            "treatment_effect_col": tau,
+            "tau": tau,
         }
     )
 
@@ -268,7 +268,7 @@ def test_MLPTRegressor(generate_regression_data):
             "cate_p": cate_p.flatten(),
             "W": treatment,
             "y": y,
-            "treatment_effect_col": tau,
+            "tau": tau,
         }
     )
 
@@ -307,7 +307,7 @@ def test_XGBTRegressor(generate_regression_data):
             "cate_p": cate_p.flatten(),
             "W": treatment,
             "y": y,
-            "treatment_effect_col": tau,
+            "tau": tau,
         }
     )
 
@@ -346,7 +346,7 @@ def test_BaseXLearner(generate_regression_data):
             "cate_p": cate_p.flatten(),
             "W": treatment,
             "y": y,
-            "treatment_effect_col": tau,
+            "tau": tau,
         }
     )
 
@@ -398,7 +398,7 @@ def test_BaseXRegressor(generate_regression_data):
             "cate_p": cate_p.flatten(),
             "W": treatment,
             "y": y,
-            "treatment_effect_col": tau,
+            "tau": tau,
         }
     )
 
@@ -439,7 +439,7 @@ def test_BaseXLearner_without_p(generate_regression_data):
             "cate_p": cate_p.flatten(),
             "W": treatment,
             "y": y,
-            "treatment_effect_col": tau,
+            "tau": tau,
         }
     )
 
@@ -478,7 +478,7 @@ def test_BaseXRegressor_without_p(generate_regression_data):
             "cate_p": cate_p.flatten(),
             "W": treatment,
             "y": y,
-            "treatment_effect_col": tau,
+            "tau": tau,
         }
     )
 
@@ -517,7 +517,7 @@ def test_BaseRLearner(generate_regression_data):
             "cate_p": cate_p.flatten(),
             "W": treatment,
             "y": y,
-            "treatment_effect_col": tau,
+            "tau": tau,
         }
     )
 
@@ -568,7 +568,7 @@ def test_BaseRRegressor(generate_regression_data):
             "cate_p": cate_p.flatten(),
             "W": treatment,
             "y": y,
-            "treatment_effect_col": tau,
+            "tau": tau,
         }
     )
 
@@ -607,7 +607,7 @@ def test_BaseRLearner_without_p(generate_regression_data):
             "cate_p": cate_p.flatten(),
             "W": treatment,
             "y": y,
-            "treatment_effect_col": tau,
+            "tau": tau,
         }
     )
 
@@ -646,7 +646,7 @@ def test_BaseRRegressor_without_p(generate_regression_data):
             "cate_p": cate_p.flatten(),
             "W": treatment,
             "y": y,
-            "treatment_effect_col": tau,
+            "tau": tau,
         }
     )
 
@@ -698,7 +698,7 @@ def test_BaseSClassifier(generate_classification_data):
             "tau_pred": tau_pred.flatten(),
             "W": df_test["treatment_group_key"].values,
             CONVERSION: df_test[CONVERSION].values,
-            "treatment_effect_col": df_test["treatment_effect"].values,
+            "tau": df_test["treatment_effect"].values,
         }
     )
 
@@ -706,7 +706,7 @@ def test_BaseSClassifier(generate_classification_data):
         auuc_metrics,
         outcome_col=CONVERSION,
         treatment_col="W",
-        treatment_effect_col="treatment_effect_col",
+        treatment_effect_col="tau",
     )
 
     # Check if the cumulative gain when using the model's prediction is
@@ -742,7 +742,7 @@ def test_BaseTClassifier(generate_classification_data):
             "tau_pred": tau_pred.flatten(),
             "W": df_test["treatment_group_key"].values,
             CONVERSION: df_test[CONVERSION].values,
-            "treatment_effect_col": df_test["treatment_effect"].values,
+            "tau": df_test["treatment_effect"].values,
         }
     )
 
@@ -750,7 +750,7 @@ def test_BaseTClassifier(generate_classification_data):
         auuc_metrics,
         outcome_col=CONVERSION,
         treatment_col="W",
-        treatment_effect_col="treatment_effect_col",
+        treatment_effect_col="tau",
     )
 
     # Check if the cumulative gain when using the model's prediction is
@@ -812,7 +812,7 @@ def test_BaseXClassifier(generate_classification_data):
             "tau_pred": tau_pred.flatten(),
             "W": df_test["treatment_group_key"].values,
             CONVERSION: df_test[CONVERSION].values,
-            "treatment_effect_col": df_test["treatment_effect"].values,
+            "tau": df_test["treatment_effect"].values,
         }
     )
 
@@ -820,7 +820,7 @@ def test_BaseXClassifier(generate_classification_data):
         auuc_metrics,
         outcome_col=CONVERSION,
         treatment_col="W",
-        treatment_effect_col="treatment_effect_col",
+        treatment_effect_col="tau",
     )
 
     # Check if the cumulative gain when using the model's prediction is
@@ -861,7 +861,7 @@ def test_BaseRClassifier(generate_classification_data):
             "tau_pred": tau_pred.flatten(),
             "W": df_test["treatment_group_key"].values,
             CONVERSION: df_test[CONVERSION].values,
-            "treatment_effect_col": df_test["treatment_effect"].values,
+            "tau": df_test["treatment_effect"].values,
         }
     )
 
@@ -869,7 +869,7 @@ def test_BaseRClassifier(generate_classification_data):
         auuc_metrics,
         outcome_col=CONVERSION,
         treatment_col="W",
-        treatment_effect_col="treatment_effect_col",
+        treatment_effect_col="tau",
     )
 
     # Check if the cumulative gain when using the model's prediction is
@@ -912,7 +912,7 @@ def test_BaseRClassifier_with_sample_weights(generate_classification_data):
             "tau_pred": tau_pred.flatten(),
             "W": df_test["treatment_group_key"].values,
             CONVERSION: df_test[CONVERSION].values,
-            "treatment_effect_col": df_test["treatment_effect"].values,
+            "tau": df_test["treatment_effect"].values,
         }
     )
 
@@ -920,7 +920,7 @@ def test_BaseRClassifier_with_sample_weights(generate_classification_data):
         auuc_metrics,
         outcome_col=CONVERSION,
         treatment_col="W",
-        treatment_effect_col="treatment_effect_col",
+        treatment_effect_col="tau",
     )
 
     # Check if the cumulative gain when using the model's prediction is
@@ -1005,7 +1005,7 @@ def test_BaseDRLearner(generate_regression_data):
             "cate_p": cate_p.flatten(),
             "W": treatment,
             "y": y,
-            "treatment_effect_col": tau,
+            "tau": tau,
         }
     )
 


### PR DESCRIPTION
## Proposed changes

This is work to resolve the issue described in #717.

## Types of changes

What types of changes does your code introduce to **CausalML**?
_Put an `x` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [X] I have read the [CONTRIBUTING](https://github.com/uber/causalml/blob/master/CONTRIBUTING.md) doc
- [X] I have signed the [CLA](https://cla-assistant.io/uber/causalml)
- [X] Lint and unit tests pass locally with my changes
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have added necessary documentation (if appropriate)
- [X] Any dependent changes have been merged and published in downstream modules

## Further comments

A variety of errors arise when currently building as described in #717, this PR resolves those errors.  Errors were due to non-existent keys from two sources:
- most errors were due to visualization functions like `get_cumgain` looking for a treatment_effect_col named "tau" by default, but the treatment effect column being passed was called "treatment_effect_col" without supplying the new name as an argument to the function
- errors in `test_causal_trees.py` were due to indexing the wrong element of what is returned by `qini_score(...)`

Starting this PR to see how it builds on the uber fork and will resolve issues as required.