### PR TITLE
Add with_std, with_counts to create_table_one

### DIFF
--- a/causalml/match.py
+++ b/causalml/match.py
@@ -31,7 +31,7 @@ def smd(feature, treatment):
     return (t.mean() - c.mean()) / np.sqrt(0.5 * (t.var() + c.var()))
 
 
-def create_table_one(data, treatment_col, features, with_std = True, with_counts = True):
+def create_table_one(data, treatment_col, features, with_std=True, with_counts=True):
     """Report balance in input features between the treatment and control groups.
 
     References:
@@ -53,7 +53,11 @@ def create_table_one(data, treatment_col, features, with_std = True, with_counts
     t1 = pd.pivot_table(
         data[features + [treatment_col]],
         columns=treatment_col,
-        aggfunc=[lambda x: "{:.2f} ({:.2f})".format(x.mean(), x.std()) if with_std else "{:.2f}".format(x.mean())],
+        aggfunc=[
+            lambda x: "{:.2f} ({:.2f})".format(x.mean(), x.std())
+            if with_std
+            else "{:.2f}".format(x.mean())
+        ],
     )
     t1.columns = t1.columns.droplevel(level=0)
     t1["SMD"] = data[features].apply(lambda x: smd(x, data[treatment_col])).round(4)

--- a/causalml/match.py
+++ b/causalml/match.py
@@ -54,9 +54,11 @@ def create_table_one(data, treatment_col, features, with_std=True, with_counts=T
         data[features + [treatment_col]],
         columns=treatment_col,
         aggfunc=[
-            lambda x: "{:.2f} ({:.2f})".format(x.mean(), x.std())
-            if with_std
-            else "{:.2f}".format(x.mean())
+            lambda x: (
+                "{:.2f} ({:.2f})".format(x.mean(), x.std())
+                if with_std
+                else "{:.2f}".format(x.mean())
+            )
         ],
     )
     t1.columns = t1.columns.droplevel(level=0)


### PR DESCRIPTION
## Proposed changes

A auxiliary function [create_table_one](https://github.com/uber/causalml/blob/750e84e4916e6ec1f364bd30d5504f9b0e437f93/causalml/match.py#L34) currently generates a table of mean values in a string format of "{:.2f} ({:.2f})".format(x.mean(), x.std()) and a user cannot use the mean values directly from the output table along with SMD calculated.

Issue: https://github.com/uber/causalml/issues/747

## Types of changes

What types of changes does your code introduce to **CausalML**?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/uber/causalml/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/uber/causalml)
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc. This PR template is adopted from [appium](https://github.com/appium/appium).
