### PR TITLE
757: add return_ci=True in sensitivity

### DIFF
--- a/causalml/metrics/sensitivity.py
+++ b/causalml/metrics/sensitivity.py
@@ -147,19 +147,34 @@ class Sensitivity(object):
         learner = self.learner
         from ..inference.meta.tlearner import BaseTLearner
 
-        if isinstance(learner, BaseTLearner):
-            ate, ate_lower, ate_upper = learner.estimate_ate(
-                X=X, treatment=treatment, y=y
-            )
-        else:
-            try:
-                ate, ate_lower, ate_upper = learner.estimate_ate(
-                    X=X, p=p, treatment=treatment, y=y
-                )
-            except TypeError:
+        try:
+            if isinstance(learner, BaseTLearner):
                 ate, ate_lower, ate_upper = learner.estimate_ate(
                     X=X, treatment=treatment, y=y, return_ci=True
                 )
+            else:
+                try:
+                    ate, ate_lower, ate_upper = learner.estimate_ate(
+                        X=X, p=p, treatment=treatment, y=y
+                    )
+                except TypeError:
+                    ate, ate_lower, ate_upper = learner.estimate_ate(
+                        X=X, treatment=treatment, y=y, return_ci=True
+                    )
+        except TypeError:
+            if isinstance(learner, BaseTLearner):
+                ate, ate_lower, ate_upper = learner.estimate_ate(
+                    X=X, treatment=treatment, y=y
+                )
+            else:
+                try:
+                    ate, ate_lower, ate_upper = learner.estimate_ate(
+                        X=X, p=p, treatment=treatment, y=y
+                    )
+                except TypeError:
+                    ate, ate_lower, ate_upper = learner.estimate_ate(
+                        X=X, treatment=treatment, y=y
+                    )
         return ate[0], ate_lower[0], ate_upper[0]
 
     @staticmethod

--- a/causalml/metrics/sensitivity.py
+++ b/causalml/metrics/sensitivity.py
@@ -148,33 +148,9 @@ class Sensitivity(object):
         from ..inference.meta.tlearner import BaseTLearner
 
         try:
-            if isinstance(learner, BaseTLearner):
-                ate, ate_lower, ate_upper = learner.estimate_ate(
-                    X=X, treatment=treatment, y=y, return_ci=True
-                )
-            else:
-                try:
-                    ate, ate_lower, ate_upper = learner.estimate_ate(
-                        X=X, p=p, treatment=treatment, y=y
-                    )
-                except TypeError:
-                    ate, ate_lower, ate_upper = learner.estimate_ate(
-                        X=X, treatment=treatment, y=y, return_ci=True
-                    )
+            ate, ate_lower, ate_upper = self.learner.estimate_ate(X=X, p=p, treatment=treatment, y=y, return_ci=True)
         except TypeError:
-            if isinstance(learner, BaseTLearner):
-                ate, ate_lower, ate_upper = learner.estimate_ate(
-                    X=X, treatment=treatment, y=y
-                )
-            else:
-                try:
-                    ate, ate_lower, ate_upper = learner.estimate_ate(
-                        X=X, p=p, treatment=treatment, y=y
-                    )
-                except TypeError:
-                    ate, ate_lower, ate_upper = learner.estimate_ate(
-                        X=X, treatment=treatment, y=y
-                    )
+            ate, ate_lower, ate_upper = self.learner.estimate_ate(X=X, p=p, treatment=treatment, y=y)
         return ate[0], ate_lower[0], ate_upper[0]
 
     @staticmethod

--- a/causalml/metrics/sensitivity.py
+++ b/causalml/metrics/sensitivity.py
@@ -148,9 +148,13 @@ class Sensitivity(object):
         from ..inference.meta.tlearner import BaseTLearner
 
         try:
-            ate, ate_lower, ate_upper = self.learner.estimate_ate(X=X, p=p, treatment=treatment, y=y, return_ci=True)
+            ate, ate_lower, ate_upper = self.learner.estimate_ate(
+                X=X, p=p, treatment=treatment, y=y, return_ci=True
+            )
         except TypeError:
-            ate, ate_lower, ate_upper = self.learner.estimate_ate(X=X, p=p, treatment=treatment, y=y)
+            ate, ate_lower, ate_upper = self.learner.estimate_ate(
+                X=X, p=p, treatment=treatment, y=y
+            )
         return ate[0], ate_lower[0], ate_upper[0]
 
     @staticmethod


### PR DESCRIPTION
## Proposed changes
[Issue 757](https://github.com/uber/causalml/issues/757) 

`return_ci=True` argument is not passed in the `get_ate_ci` method of `Sensitivity` class object and running `sensitivity_analysis` gives a `ValueError` for a Tlearner object. Adding `return_ci=True` to the `get_ate_ci` method with another nested try/except layer since not all `estimate_ate` methods of learners that is to be run in `get_ate_ci` method of `Sensitivity` take the `return_ci` argument.

## Types of changes

What types of changes does your code introduce to **CausalML**?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/uber/causalml/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/uber/causalml)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc. This PR template is adopted from [appium](https://github.com/appium/appium).
