### PR TITLE
fix typo in MAINTAINERS.md

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -9,7 +9,7 @@ This document lists the Maintainers of the Project. Maintainers may be added onc
 | Jeong-Yoon Lee | @jeongyoonlee |
 | Paul Lo | @paullo0106 |
 | Jing Pan | @ppstacy |
-| Alexander Popkov | @@alexander-pv |
+| Alexander Popkov | @alexander-pv |
 | Roland Stevenson | @ras44 |
 | Yifeng Wu | @vincewu51 |
 | Zhenyu Zhao | @zhenyuz0500 |


### PR DESCRIPTION
## Proposed changes

This PR removes an extra `@` in front of @alexander-pv in `MAINTAINERS.MD`.

## Types of changes

What types of changes does your code introduce to **CausalML**?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [X] I have read the [CONTRIBUTING](https://github.com/uber/causalml/blob/master/CONTRIBUTING.md) doc
- [X] I have signed the [CLA](https://cla-assistant.io/uber/causalml)
- [X] Lint and unit tests pass locally with my changes
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have added necessary documentation (if appropriate)
- [X] Any dependent changes have been merged and published in downstream modules

## Further comments

N/A