### PR TITLE
Remove build for 32-bit systems that are failing

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -133,7 +133,7 @@ html_theme = "sphinx_rtd_theme"
 html_theme_options = {"logo_only": False, "display_version": True}
 
 # Add any paths that contain custom themes here, relative to this directory.
-html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
+# html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 
 # The name for this set of Sphinx documents.  If None, it defaults to
 # "<project> v<release> documentation".

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,3 +72,5 @@ homepage = "https://github.com/uber/causalml"
 [tool.cibuildwheel]
 build = ["cp38-*", "cp39-*", "cp310-*", "cp311-*"]
 build-verbosity = 1
+# Skip 32-bit builds
+skip = ["*-win32", "*-manylinux_i686"]


### PR DESCRIPTION
## Proposed changes

This PR fixes wheel build GHA failures by removing build for 32-bit systems. It also fixes the issue of the search loading indefinitely on the documentation website.

## Types of changes

What types of changes does your code introduce to **CausalML**?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/uber/causalml/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/uber/causalml)
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments

N/A