### PR TITLE
Update input arguments of XGBoost to be compatible with the latest APIs

### DIFF
--- a/causalml/metrics/visualize.py
+++ b/causalml/metrics/visualize.py
@@ -640,7 +640,7 @@ def plot_qini(
 def plot_tmlegain(
     df,
     inference_col,
-    learner=LGBMRegressor(num_leaves=64, learning_rate=0.05, n_estimators=300),
+    learner=LGBMRegressor(num_leaves=64, learning_rate=0.05, n_estimators=300, verbose=-1),
     outcome_col="y",
     treatment_col="w",
     p_col="tau",

--- a/causalml/propensity.py
+++ b/causalml/propensity.py
@@ -113,10 +113,9 @@ class GradientBoostedPropensityModel(PropensityModel):
     """
 
     def __init__(self, early_stop=False, clip_bounds=(1e-3, 1 - 1e-3), **model_kwargs):
-        super(GradientBoostedPropensityModel, self).__init__(
-            clip_bounds, **model_kwargs
-        )
         self.early_stop = early_stop
+
+        super(GradientBoostedPropensityModel, self).__init__(clip_bounds, **model_kwargs)
 
     @property
     def _model(self):
@@ -131,9 +130,12 @@ class GradientBoostedPropensityModel(PropensityModel):
         }
         kwargs.update(self.model_kwargs)
 
+        if self.early_stop:
+            kwargs.update({"early_stopping_rounds": 10})
+
         return xgb.XGBClassifier(**kwargs)
 
-    def fit(self, X, y, early_stopping_rounds=10, stop_val_size=0.2):
+    def fit(self, X, y, stop_val_size=0.2):
         """
         Fit a propensity model.
 
@@ -151,7 +153,6 @@ class GradientBoostedPropensityModel(PropensityModel):
                 X_train,
                 y_train,
                 eval_set=[(X_val, y_val)],
-                early_stopping_rounds=early_stopping_rounds,
             )
         else:
             super(GradientBoostedPropensityModel, self).fit(X, y)


### PR DESCRIPTION
## Proposed changes

This PR fixes #787 by updating the input arguments of XGBoost to be compatible with the latest APIs. It moves `eval_metric` and `early_stopping_rounds` from `fit()` to `__init__()`.

It also suppresses warnings from LightGBM in `plot_tmle_gain()`.

## Types of changes

What types of changes does your code introduce to **CausalML**?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/uber/causalml/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/uber/causalml)
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments
N/A