### PR TITLE
Update the cibuildwheel version to 2.21

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -47,7 +47,7 @@ jobs:
           fetch-depth: 0
           submodules: true
 
-      - uses: pypa/cibuildwheel@v2.17
+      - uses: pypa/cibuildwheel@v2.21
 
       - name: Upload wheels
         uses: actions/upload-artifact@v4

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -3,6 +3,8 @@
 Changelog
 =========
 
+You can find the latest changes in the `GitHub releases <https://github.com/uber/causalml/releases>`_
+
 0.15.1 (Apr 2024)
 -----------------
 * This release fixes the build failure on macOS and a few bugs in ``UpliftTreeClassifier``.


### PR DESCRIPTION
## Proposed changes

This PR updates the `cibuildwheel` version to 2.21 to address the Windows wheel build failure.

## Types of changes

What types of changes does your code introduce to **CausalML**?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/uber/causalml/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/uber/causalml)
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments

N/A