### PR TITLE
Pin the numpy version to be <2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
     "forestci==0.6",
     "pathos==0.2.9",
     "pip>=10.0",
-    "numpy>=1.18.5",
+    "numpy>=1.18.5, <2",
     "scipy>=1.4.1",
     "matplotlib",
     "pandas>=0.24.1",
@@ -63,7 +63,7 @@ requires = [
     "setuptools>=18.0",
     "wheel",
     "Cython<=0.29.34",
-    "numpy>=1.18.5",
+    "numpy>=1.18.5, <2",
     "scikit-learn>=0.22.0",
 ]
 


### PR DESCRIPTION
## Proposed changes

The windows build is failing due to incompatible build dependencies between numpy 2.0 and cython 0.29.x.

This PR pins the numpy version to 1.x until we can make it work for numpy 2 and cython 3.

## Types of changes

What types of changes does your code introduce to **CausalML**?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have read the [CONTRIBUTING](https://github.com/uber/causalml/blob/master/CONTRIBUTING.md) doc
- [ ] I have signed the [CLA](https://cla-assistant.io/uber/causalml)
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

N/A