### PR TITLE
resolves #796 remove dep on pygam, use IsotonicRegression

### DIFF
--- a/causalml/propensity.py
+++ b/causalml/propensity.py
@@ -1,10 +1,10 @@
 from abc import ABCMeta, abstractmethod
 import logging
 import numpy as np
-from pygam import LogisticGAM, s
 from sklearn.metrics import roc_auc_score as auc
 from sklearn.linear_model import LogisticRegressionCV
 from sklearn.model_selection import StratifiedKFold, train_test_split
+from sklearn.isotonic import IsotonicRegression
 import xgboost as xgb
 
 
@@ -179,9 +179,9 @@ class GradientBoostedPropensityModel(PropensityModel):
 
 
 def calibrate(ps, treatment):
-    """Calibrate propensity scores with logistic GAM.
+    """Calibrate propensity scores with IsotonicRegression.
 
-    Ref: https://pygam.readthedocs.io/en/latest/api/logisticgam.html
+    Ref: https://scikit-learn.org/stable/modules/isotonic.html
 
     Args:
         ps (numpy.array): a propensity score vector
@@ -191,9 +191,10 @@ def calibrate(ps, treatment):
         (numpy.array): a calibrated propensity score vector
     """
 
-    gam = LogisticGAM(s(0)).fit(ps, treatment)
+    pm_ir = IsotonicRegression(out_of_bounds="clip")
+    ps_ir = pm_ir.fit_transform(ps, treatment)
 
-    return gam.predict_proba(ps)
+    return ps_ir
 
 
 def compute_propensity_score(

--- a/causalml/propensity.py
+++ b/causalml/propensity.py
@@ -191,7 +191,8 @@ def calibrate(ps, treatment):
         (numpy.array): a calibrated propensity score vector
     """
 
-    pm_ir = IsotonicRegression(out_of_bounds="clip")
+    two_eps = 2.0*np.finfo(float).eps
+    pm_ir = IsotonicRegression(out_of_bounds="clip", y_min=two_eps, y_max=1.0-two_eps)
     ps_ir = pm_ir.fit_transform(ps, treatment)
 
     return ps_ir

--- a/causalml/propensity.py
+++ b/causalml/propensity.py
@@ -191,8 +191,8 @@ def calibrate(ps, treatment):
         (numpy.array): a calibrated propensity score vector
     """
 
-    two_eps = 2.0*np.finfo(float).eps
-    pm_ir = IsotonicRegression(out_of_bounds="clip", y_min=two_eps, y_max=1.0-two_eps)
+    two_eps = 2.0 * np.finfo(float).eps
+    pm_ir = IsotonicRegression(out_of_bounds="clip", y_min=two_eps, y_max=1.0 - two_eps)
     ps_ir = pm_ir.fit_transform(ps, treatment)
 
     return ps_ir


### PR DESCRIPTION
## Proposed changes

This removes the dependency on pygam and replaces the use of `LogisticGAM()` in `causalml/propensity.py` : `calibrate()` with `IsotonicRegression()`.  Work shown [here](https://github.com/ras44/causalml/blob/ras44/remove_pygam_dep_796_dev/docs/examples/pygam_removal_and_testing.ipynb) supports that using `IsotonicRegression()` produces comparable or improves log-loss and brier score loss values.

This removes the pygam dependency, which is acting as a constraint on other dependencies.

## Types of changes

What types of changes does your code introduce to **CausalML**?
_Put an `x` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/uber/causalml/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/uber/causalml)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
