### PR TITLE
Pin scikit-learn<1.6 until xgboost fix gets released

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
     "scipy>=1.4.1",
     "matplotlib",
     "pandas>=0.24.1",
-    "scikit-learn>=0.22.0",
+    "scikit-learn>=0.22.0, <1.6",
     "statsmodels>=0.9.0",
     "Cython<=0.29.34",
     "seaborn",


### PR DESCRIPTION
## Proposed changes

This PR fixes #808 by pinning `scikit-learn` to be `<1.16` temporarily until `xgboost` [fix](https://github.com/dmlc/xgboost/pull/11021) gets released.

## Types of changes

What types of changes does your code introduce to **CausalML**?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/uber/causalml/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/uber/causalml)
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments

N/A