### PR TITLE
Remove the pygam dependency and allow latest versions of Cython, numpy, scipy, scikit-learn

### DIFF
--- a/causalml/inference/tree/causal/_criterion.pyx
+++ b/causalml/inference/tree/causal/_criterion.pyx
@@ -212,7 +212,7 @@ cdef class CausalRegressionCriterion(RegressionCriterion):
 
         return 0
 
-    cdef void node_value(self, float64_t * dest) nogil:
+    cdef void node_value(self, float64_t * dest) noexcept nogil:
         """Compute the node values of sample_indices[start:end] into dest."""
         dest[0] = self.state.node.ct_y_sum / self.state.node.ct_count
         dest[1] = self.state.node.tr_y_sum / self.state.node.tr_count
@@ -228,7 +228,7 @@ cdef class StandardMSE(CausalRegressionCriterion):
     Source: https://github.com/scikit-learn/scikit-learn/blob/main/sklearn/tree/_criterion.pyx
     """
 
-    cdef float64_t node_impurity(self) nogil:
+    cdef float64_t node_impurity(self) noexcept nogil:
         """Evaluate the impurity of the current node.
         Evaluate the MSE criterion as impurity of the current node,
         i.e. the impurity of sample_indices[start:end]. The smaller the impurity the
@@ -246,7 +246,7 @@ cdef class StandardMSE(CausalRegressionCriterion):
 
         return impurity / self.n_outputs
 
-    cdef float64_t proxy_impurity_improvement(self) nogil:
+    cdef float64_t proxy_impurity_improvement(self) noexcept nogil:
         """Compute a proxy of the impurity reduction.
         This method is used to speed up the search for the best split.
         It is a proxy quantity such that the split that maximizes this value
@@ -279,7 +279,7 @@ cdef class StandardMSE(CausalRegressionCriterion):
         self,
         float64_t * impurity_left,
         float64_t * impurity_right
-    ) nogil:
+    ) noexcept nogil:
         """Evaluate the impurity in children nodes.
         i.e. the impurity of the left child (sample_indices[start:pos]) and the
         impurity the right child (sample_indices[pos:end]).
@@ -335,7 +335,7 @@ cdef class CausalMSE(CausalRegressionCriterion):
     effect = alpha * tau^2 - (1 - alpha) * (1 + train_to_est_ratio) * (VAR_tr / p + VAR_cont / (1 - p))
     """
 
-    cdef float64_t node_impurity(self) nogil:
+    cdef float64_t node_impurity(self) noexcept nogil:
         """
         Evaluate the impurity of the current node, i.e. the impurity of sample_indices[start:end].
         """
@@ -365,7 +365,7 @@ cdef class CausalMSE(CausalRegressionCriterion):
     cdef float64_t get_variance(self, float64_t y_sum, float64_t y_sq_sum, float64_t count) nogil:
         return  y_sq_sum / count - (y_sum * y_sum) / (count * count)
 
-    cdef void children_impurity(self, float64_t * impurity_left, float64_t * impurity_right) nogil:
+    cdef void children_impurity(self, float64_t * impurity_left, float64_t * impurity_right) noexcept nogil:
         """
         Evaluate the impurity in children nodes, i.e. the impurity of the
            left child (sample_indices[start:pos]) and the impurity the right child
@@ -405,7 +405,7 @@ cdef class TTest(CausalRegressionCriterion):
     """
     TTest impurity criterion for Causal Tree based on "Su, Xiaogang, et al. (2009). Subgroup analysis via recursive partitioning."
     """
-    cdef float64_t node_impurity(self) nogil:
+    cdef float64_t node_impurity(self) noexcept nogil:
         cdef float64_t impurity
         cdef float64_t node_tau
         cdef float64_t tr_var
@@ -432,7 +432,7 @@ cdef class TTest(CausalRegressionCriterion):
     cdef float64_t get_variance(self, float64_t y_sum, float64_t y_sq_sum, float64_t count) nogil:
         return y_sq_sum / count - (y_sum * y_sum) / (count * count)
 
-    cdef void children_impurity(self, float64_t * impurity_left, float64_t * impurity_right) nogil:
+    cdef void children_impurity(self, float64_t * impurity_left, float64_t * impurity_right) noexcept nogil:
         """
         Evaluate the impurity in children nodes, i.e. the impurity of the
            left child (sample_indices[start:pos]) and the impurity the right child
@@ -496,10 +496,10 @@ cdef class TTest(CausalRegressionCriterion):
 
     cdef float64_t impurity_improvement(self, float64_t impurity_parent,
                                      float64_t impurity_left,
-                                     float64_t impurity_right) nogil:
+                                     float64_t impurity_right) noexcept nogil:
         return self.state.left.split_metric
 
-    cdef float64_t proxy_impurity_improvement(self) nogil:
+    cdef float64_t proxy_impurity_improvement(self) noexcept nogil:
         """Compute a proxy of the impurity reduction. In case of t statistic - proxy_impurity_improvement
         is the same as impurity_improvement.
         """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 dependencies = [
     "forestci==0.6",
     "pathos==0.2.9",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,18 +21,18 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 dependencies = [
     "forestci==0.6",
     "pathos==0.2.9",
     "pip>=10.0",
-    "numpy>=1.18.5, <2",
+    "numpy>=1.18.5",
     "scipy>=1.4.1",
     "matplotlib",
     "pandas>=0.24.1",
-    "scikit-learn>=1.5.2, <1.6",
+    "scikit-learn>=1.5.2",
     "statsmodels>=0.9.0",
-    "Cython<=0.29.34",
+    "Cython",
     "seaborn",
     "xgboost",
     "pydotplus",
@@ -40,7 +40,6 @@ dependencies = [
     "shap",
     "dill",
     "lightgbm",
-    "pygam",
     "packaging",
     "graphviz",
 ]


### PR DESCRIPTION
## Proposed changes

This PR fixes #796 by removing `pygam` from `pyproject.toml`. It also removes the upper version restrictions for `Cython`, `numpy`, `scipy` and `scikit-learn`.
- #803 replaced `pygam` with the Isotonic calibration in `scikit-learn` and allowed to use the latest `scipy`, `Cython`, and `numpy`.
- The recent `xgboost==2.1.4` release resolved the compatibility issue with `scikit-learn==1.6` in dmlc/xgboost#11021 and allowed to use the latest `scikit-learn`.
- The `noexcept` modifier has been added to the Cython code to comply with `Cython 3.x` ([ref](https://cython.readthedocs.io/en/latest/src/userguide/migrating_to_cy30.html#exception-values-and-noexcept))

## Types of changes

What types of changes does your code introduce to **CausalML**?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/uber/causalml/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/uber/causalml)
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments

N/A