### PR TITLE
resolves #811, update propensity.py

### DIFF
--- a/causalml/propensity.py
+++ b/causalml/propensity.py
@@ -223,13 +223,13 @@ def compute_propensity_score(
 
     p_model.fit(X, treatment)
 
-    X = X if X_pred is None else X_pred
+    X_pred = X if X_pred is None else X_pred
 
     try:
-        p = p_model.predict_proba(X)[:, 1]
+        p = p_model.predict_proba(X_pred)[:, 1]
     except AttributeError:
         logger.info("predict_proba not available, using predict instead")
-        p = p_model.predict(X)
+        p = p_model.predict(X_pred)
 
     if calibrate_p:
         logger.info("Calibrating propensity scores. Returning p_model=None.")

--- a/causalml/propensity.py
+++ b/causalml/propensity.py
@@ -201,13 +201,12 @@ def calibrate(ps, treatment):
 def compute_propensity_score(
     X, treatment, p_model=None, X_pred=None, treatment_pred=None, calibrate_p=True
 ):
-    """Generate propensity score if user didn't provide
+    """Generate propensity score if user didn't provide and optionally calibrate.
 
     Args:
         X (np.matrix): features for training
         treatment (np.array or pd.Series): a treatment vector for training
-        p_model (propensity model object, optional):
-            ElasticNetPropensityModel (default) / GradientBoostedPropensityModel
+        p_model (model object, optional): a binary classifier with either a predict_proba or predict method
         X_pred (np.matrix, optional): features for prediction
         treatment_pred (np.array or pd.Series, optional): a treatment vector for prediciton
         calibrate_p (bool, optional): whether calibrate the propensity score
@@ -215,7 +214,7 @@ def compute_propensity_score(
     Returns:
         (tuple)
             - p (numpy.ndarray): propensity score
-            - p_model (PropensityModel): a trained PropensityModel object
+            - p_model (PropensityModel): either the original p_model, a trained ElasticNetPropensityModel, or None if calibrate_p=True
     """
     if treatment_pred is None:
         treatment_pred = treatment.copy()
@@ -224,14 +223,18 @@ def compute_propensity_score(
 
     p_model.fit(X, treatment)
 
-    if X_pred is None:
-        p = p_model.predict(X)
-    else:
-        p = p_model.predict(X_pred)
+    X0 = X if X_pred is None else X_pred
+
+    try:
+        p = p_model.predict_proba(X0)[:, 1]
+    except AttributeError:
+        logger.info("predict_proba not available, using predict instead")
+        p = p_model.predict(X0)
 
     if calibrate_p:
-        logger.info("Calibrating propensity scores.")
+        logger.info("Calibrating propensity scores. Returning p_model=None.")
         p = calibrate(p, treatment_pred)
+        p_model = None
 
     # force the p values within the range
     eps = np.finfo(float).eps

--- a/causalml/propensity.py
+++ b/causalml/propensity.py
@@ -223,13 +223,13 @@ def compute_propensity_score(
 
     p_model.fit(X, treatment)
 
-    X0 = X if X_pred is None else X_pred
+    X = X if X_pred is None else X_pred
 
     try:
-        p = p_model.predict_proba(X0)[:, 1]
+        p = p_model.predict_proba(X)[:, 1]
     except AttributeError:
         logger.info("predict_proba not available, using predict instead")
-        p = p_model.predict(X0)
+        p = p_model.predict(X)
 
     if calibrate_p:
         logger.info("Calibrating propensity scores. Returning p_model=None.")


### PR DESCRIPTION
## Proposed changes

In `propensity.py` modify the `compute_propensity_score(...)` function to:

- Try predict_proba and fall back to predict for any classifier.
- Return p_model=None if calibrate_p=True.


## Types of changes

What types of changes does your code introduce to **CausalML**?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/uber/causalml/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/uber/causalml)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

This is one potential update for `compute_propensity_score(...)`.  We'd also talked about modifying the `PropensityModel` class itself, however this would not allow for the passing of an arbitrary classifier like Naive-Bayes via the `p_model` argument to `compute_propensity_score`.  Nevertheless, updating `PropensityModel::predict(...)` and `PropensityModel::fit_predict(...)` might still also make sense for further robustness.