### PR TITLE
Fix incorrect bootstrap mean calculation in meta-learners

### DIFF
--- a/causalml/inference/meta/base.py
+++ b/causalml/inference/meta/base.py
@@ -1,4 +1,4 @@
-from abc import ABCMeta, abstractclassmethod
+from abc import ABCMeta, abstractmethod
 import logging
 import numpy as np
 import pandas as pd
@@ -12,11 +12,13 @@ logger = logging.getLogger("causalml")
 
 
 class BaseLearner(metaclass=ABCMeta):
-    @abstractclassmethod
+    @classmethod
+    @abstractmethod
     def fit(self, X, treatment, y, p=None):
         pass
 
-    @abstractclassmethod
+    @classmethod
+    @abstractmethod
     def predict(
         self, X, treatment=None, y=None, p=None, return_components=False, verbose=True
     ):
@@ -37,7 +39,8 @@ class BaseLearner(metaclass=ABCMeta):
         self.fit(X, treatment, y, p)
         return self.predict(X, treatment, y, p, return_components, verbose)
 
-    @abstractclassmethod
+    @classmethod
+    @abstractmethod
     def estimate_ate(
         self,
         X,

--- a/causalml/inference/meta/drlearner.py
+++ b/causalml/inference/meta/drlearner.py
@@ -434,7 +434,7 @@ class BaseDRLearner(BaseLearner):
                 cate_b = self.bootstrap(
                     X, treatment, y, p, size=bootstrap_size, seed=seed
                 )
-                ate_bootstraps[:, n] = cate_b.mean()
+                ate_bootstraps[:, n] = cate_b.mean(axis=0)
 
             ate_lower = np.percentile(
                 ate_bootstraps, (self.ate_alpha / 2) * 100, axis=1

--- a/causalml/inference/meta/rlearner.py
+++ b/causalml/inference/meta/rlearner.py
@@ -324,7 +324,7 @@ class BaseRLearner(BaseLearner):
                 else:
                     p = self._format_p(p, self.t_groups)
                 cate_b = self.bootstrap(X, treatment, y, p, size=bootstrap_size)
-                ate_bootstraps[:, n] = cate_b.mean()
+                ate_bootstraps[:, n] = cate_b.mean(axis=0)
 
             ate_lower = np.percentile(
                 ate_bootstraps, (self.ate_alpha / 2) * 100, axis=1

--- a/causalml/inference/meta/slearner.py
+++ b/causalml/inference/meta/slearner.py
@@ -278,7 +278,7 @@ class BaseSLearner(BaseLearner):
 
             for n in tqdm(range(n_bootstraps)):
                 ate_b = self.bootstrap(X, treatment, y, size=bootstrap_size)
-                ate_bootstraps[:, n] = ate_b.mean()
+                ate_bootstraps[:, n] = ate_b.mean(axis=0)
 
             ate_lower = np.percentile(
                 ate_bootstraps, (self.ate_alpha / 2) * 100, axis=1

--- a/causalml/inference/meta/tlearner.py
+++ b/causalml/inference/meta/tlearner.py
@@ -280,7 +280,7 @@ class BaseTLearner(BaseLearner):
 
             for n in tqdm(range(n_bootstraps)):
                 ate_b = self.bootstrap(X, treatment, y, size=bootstrap_size)
-                ate_bootstraps[:, n] = ate_b.mean()
+                ate_bootstraps[:, n] = ate_b.mean(axis=0)
 
             ate_lower = np.percentile(
                 ate_bootstraps, (self.ate_alpha / 2) * 100, axis=1

--- a/causalml/inference/meta/xlearner.py
+++ b/causalml/inference/meta/xlearner.py
@@ -390,7 +390,7 @@ class BaseXLearner(BaseLearner):
 
             for n in tqdm(range(n_bootstraps)):
                 cate_b = self.bootstrap(X, treatment, y, p, size=bootstrap_size)
-                ate_bootstraps[:, n] = cate_b.mean()
+                ate_bootstraps[:, n] = cate_b.mean(axis=0)
 
             ate_lower = np.percentile(
                 ate_bootstraps, (self.ate_alpha / 2) * 100, axis=1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "causalml"
-version = "0.15.3"
+version = "0.15.4dev"
 description = "Python Package for Uplift Modeling and Causal Inference with Machine Learning Algorithms"
 readme = { file = "README.md", content-type = "text/markdown" }
 


### PR DESCRIPTION
## Proposed changes

This PR fixes #828 - incorrect indexing of bootstrap mean calculation in meta learners. It also replaces deprecated @abstractclassmethod with @classmethod and @abstractmethod.

## Types of changes

What types of changes does your code introduce to **CausalML**?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/uber/causalml/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/uber/causalml)
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments

N/A