### PR TITLE
install via `uv`

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -51,6 +51,35 @@ Install ``causalml`` with ``torch`` for ``CEVAE`` from ``PyPI``
     pip install causalml[torch]
 
 
+
+Install from ``PyPI`` using [`uv`](https://github.com/astral-sh/uv/blob/main/README.md)
+---------------------
+
+.. code-block:: bash
+
+    uv init myproject
+    uv venv
+    source .venv/bin/activate
+    uv pip install causalml
+
+Install ``causalml`` with ``tensorflow`` for ``DragonNet`` from ``PyPI`` using [`uv`](https://github.com/astral-sh/uv/blob/main/README.md)  
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. code-block:: bash
+
+    uv pip install causalml[tf]
+
+Install ``causalml`` with ``torch`` for ``CEVAE`` from ``PyPI`` using [`uv`](https://github.com/astral-sh/uv/blob/main/README.md)  
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. code-block:: bash
+
+    uv pip install causalml[torch]
+
+
+
+
+    
 Install from source
 -------------------
 


### PR DESCRIPTION
## Proposed changes

Simple illustration of how to install causalml using `uv`.
