### PR TITLE
Add `rate_score()` with bootstrap confidence intervals and p-values

### DIFF
--- a/causalml/metrics/rate.py
+++ b/causalml/metrics/rate.py
@@ -151,6 +151,9 @@ def rate_score(
     treatment_effect_col="tau",
     weighting="autoc",
     normalize=False,
+    return_ci=False,
+    n_bootstrap=200,
+    alpha=0.05,
 ):
     """Calculate the Rank-weighted Average Treatment Effect (RATE) score.
 
@@ -175,6 +178,12 @@ def rate_score(
     so the absolute scale matches the TOC values but may differ slightly from the paper's
     continuous integral definition. Model rankings are preserved.
 
+    When return_ci=True, standard errors and confidence intervals are estimated via the
+    half-sample bootstrap (m = n // 2 draws without replacement), which gives valid
+    coverage for the RATE functional per the Yadlowsky et al. (2021) functional CLT.
+    The p-value tests H0: RATE = 0 (i.e. the model's prioritization is no better than
+    random) using a two-sided z-test.
+
     For details, see Yadlowsky et al. (2021), `Evaluating Treatment Prioritization Rules
     via Rank-Weighted Average Treatment Effects`. https://arxiv.org/abs/2111.07966
 
@@ -189,16 +198,42 @@ def rate_score(
         weighting (str, optional): the weighting scheme for the RATE integral.
             One of ``"autoc"`` (default) or ``"qini"``.
         normalize (bool, optional): whether to normalize the TOC curve before scoring
+        return_ci (bool, optional): whether to return bootstrap confidence intervals and
+            p-values. Default False.
+        n_bootstrap (int, optional): number of half-sample bootstrap iterations.
+            Only used when return_ci=True. Default 200.
+        alpha (float, optional): significance level for confidence intervals.
+            Only used when return_ci=True. Default 0.05.
 
     Returns:
-        (pandas.Series): RATE scores of model estimates
+        If return_ci=False:
+            (pandas.Series): RATE scores of model estimates
+        If return_ci=True:
+            (pandas.DataFrame): RATE score, standard error, CI lower bound, CI upper bound,
+                and p-value for each model estimate column
     """
+    from scipy import stats
+
     assert weighting in (
         "autoc",
         "qini",
     ), "{} weighting is not implemented. Select one of {}".format(
         weighting, ("autoc", "qini")
     )
+
+    def _compute_rate_from_toc(toc, weighting):
+        quantiles = toc.index.values
+        q_mid = (quantiles[:-1] + quantiles[1:]) / 2
+        toc_mid = (toc.iloc[:-1].values + toc.iloc[1:].values) / 2
+        if weighting == "autoc":
+            weights = 1.0 / q_mid
+        else:
+            weights = q_mid
+        weights = weights / weights.sum()
+        return pd.Series(
+            np.average(toc_mid, axis=0, weights=weights),
+            index=toc.columns,
+        )
 
     toc = get_toc(
         df,
@@ -208,26 +243,55 @@ def rate_score(
         normalize=normalize,
     )
 
-    quantiles = toc.index.values  # includes 0 and 1
-
-    # Use midpoints to avoid division by zero for autoc at q=0
-    q_mid = (quantiles[:-1] + quantiles[1:]) / 2
-    toc_mid = (toc.iloc[:-1].values + toc.iloc[1:].values) / 2
-
-    if weighting == "autoc":
-        weights = 1.0 / q_mid
-    else:
-        weights = q_mid
-
-    # Normalize weights so they sum to 1 over the integration domain
-    weights = weights / weights.sum()
-
-    rate = pd.Series(
-        np.average(toc_mid, axis=0, weights=weights),
-        index=toc.columns,
-    )
+    rate = _compute_rate_from_toc(toc, weighting)
     rate.name = "RATE ({})".format(weighting)
-    return rate
+
+    if not return_ci:
+        return rate
+
+    # Half-sample bootstrap for SE and p-value
+    n = len(df)
+    m = n // 2
+    model_names = toc.columns.tolist()
+    boot_scores = {model: [] for model in model_names}
+
+    rng = np.random.default_rng(seed=42)
+    for _ in range(n_bootstrap):
+        idx = rng.choice(n, size=m, replace=False)
+        df_boot = df.iloc[idx].reset_index(drop=True)
+        toc_boot = get_toc(
+            df_boot,
+            outcome_col=outcome_col,
+            treatment_col=treatment_col,
+            treatment_effect_col=treatment_effect_col,
+            normalize=normalize,
+        )
+        rate_boot = _compute_rate_from_toc(toc_boot, weighting)
+        for model in model_names:
+            boot_scores[model].append(rate_boot[model])
+
+    z_crit = stats.norm.ppf(1 - alpha / 2)
+    results = []
+    for model in model_names:
+        point = rate[model]
+        boot = np.array(boot_scores[model])
+        se = np.std(boot, ddof=1)
+        ci_lower = point - z_crit * se
+        ci_upper = point + z_crit * se
+        z_stat = point / se if se > 0 else np.inf
+        p_value = 2 * (1 - stats.norm.cdf(abs(z_stat)))
+        results.append(
+            {
+                "model": model,
+                "rate": point,
+                "se": se,
+                "ci_lower": ci_lower,
+                "ci_upper": ci_upper,
+                "p_value": p_value,
+            }
+        )
+
+    return pd.DataFrame(results).set_index("model")
 
 
 def plot_toc(

--- a/causalml/metrics/rate.py
+++ b/causalml/metrics/rate.py
@@ -3,12 +3,37 @@ from typing import Optional
 import numpy as np
 import pandas as pd
 from matplotlib import pyplot as plt
+from scipy import stats
 import logging
 
 plt.style.use("fivethirtyeight")
 RANDOM_COL = "Random"
 
 logger = logging.getLogger("causalml")
+
+
+def _compute_rate_from_toc(toc, weighting):
+    """Compute the RATE scalar from a TOC DataFrame.
+
+    Args:
+        toc (pandas.DataFrame): TOC curve indexed by quantile q
+        weighting (str): one of ``"autoc"`` or ``"qini"``
+
+    Returns:
+        (pandas.Series): RATE score for each model column
+    """
+    quantiles = toc.index.values
+    q_mid = (quantiles[:-1] + quantiles[1:]) / 2
+    toc_mid = (toc.iloc[:-1].values + toc.iloc[1:].values) / 2
+    if weighting == "autoc":
+        weights = 1.0 / q_mid
+    else:
+        weights = q_mid
+    weights = weights / weights.sum()
+    return pd.Series(
+        np.average(toc_mid, axis=0, weights=weights),
+        index=toc.columns,
+    )
 
 
 def get_toc(
@@ -154,6 +179,7 @@ def rate_score(
     return_ci=False,
     n_bootstrap=200,
     alpha=0.05,
+    random_state=None,
 ):
     """Calculate the Rank-weighted Average Treatment Effect (RATE) score.
 
@@ -204,6 +230,8 @@ def rate_score(
             Only used when return_ci=True. Default 200.
         alpha (float, optional): significance level for confidence intervals.
             Only used when return_ci=True. Default 0.05.
+        random_state (int or None, optional): random seed for the bootstrap sampler.
+            Pass an integer for reproducible results. Default None.
 
     Returns:
         If return_ci=False:
@@ -212,28 +240,12 @@ def rate_score(
             (pandas.DataFrame): RATE score, standard error, CI lower bound, CI upper bound,
                 and p-value for each model estimate column
     """
-    from scipy import stats
-
     assert weighting in (
         "autoc",
         "qini",
     ), "{} weighting is not implemented. Select one of {}".format(
         weighting, ("autoc", "qini")
     )
-
-    def _compute_rate_from_toc(toc, weighting):
-        quantiles = toc.index.values
-        q_mid = (quantiles[:-1] + quantiles[1:]) / 2
-        toc_mid = (toc.iloc[:-1].values + toc.iloc[1:].values) / 2
-        if weighting == "autoc":
-            weights = 1.0 / q_mid
-        else:
-            weights = q_mid
-        weights = weights / weights.sum()
-        return pd.Series(
-            np.average(toc_mid, axis=0, weights=weights),
-            index=toc.columns,
-        )
 
     toc = get_toc(
         df,
@@ -255,7 +267,7 @@ def rate_score(
     model_names = toc.columns.tolist()
     boot_scores = {model: [] for model in model_names}
 
-    rng = np.random.default_rng(seed=42)
+    rng = np.random.default_rng(random_state)
     for _ in range(n_bootstrap):
         idx = rng.choice(n, size=m, replace=False)
         df_boot = df.iloc[idx].reset_index(drop=True)

--- a/tests/test_rate.py
+++ b/tests/test_rate.py
@@ -161,65 +161,50 @@ def test_plot_toc(synthetic_df, monkeypatch):
     assert isinstance(ax, plt.Axes)
 
 
-def test_rate_score_return_ci_returns_dataframe():
-    np.random.seed(42)
-    n = 300
-    df = pd.DataFrame(
-        {
-            "y": np.random.binomial(1, 0.5, n),
-            "w": np.random.binomial(1, 0.5, n),
-            "tau": np.random.normal(0.5, 1, n),
-            "model": np.random.normal(1, 1, n),
-        }
+def test_rate_score_return_ci_returns_dataframe(synthetic_df):
+    result = rate_score(
+        synthetic_df,
+        treatment_effect_col="tau",
+        return_ci=True,
+        n_bootstrap=50,
+        random_state=RANDOM_SEED,
     )
-    result = rate_score(df, return_ci=True, n_bootstrap=50)
     assert isinstance(result, pd.DataFrame)
     assert set(result.columns) == {"rate", "se", "ci_lower", "ci_upper", "p_value"}
 
 
-def test_rate_score_ci_bounds_ordered():
-    np.random.seed(42)
-    n = 300
-    df = pd.DataFrame(
-        {
-            "y": np.random.binomial(1, 0.5, n),
-            "w": np.random.binomial(1, 0.5, n),
-            "tau": np.random.normal(0.5, 1, n),
-            "model": np.random.normal(1, 1, n),
-        }
+def test_rate_score_ci_bounds_ordered(synthetic_df):
+    result = rate_score(
+        synthetic_df,
+        treatment_effect_col="tau",
+        return_ci=True,
+        n_bootstrap=50,
+        random_state=RANDOM_SEED,
     )
-    result = rate_score(df, return_ci=True, n_bootstrap=50)
     assert (result["ci_lower"] < result["rate"]).all()
     assert (result["ci_upper"] > result["rate"]).all()
 
 
-def test_rate_score_p_value_range():
-    np.random.seed(42)
-    n = 300
-    df = pd.DataFrame(
-        {
-            "y": np.random.binomial(1, 0.5, n),
-            "w": np.random.binomial(1, 0.5, n),
-            "tau": np.random.normal(0.5, 1, n),
-            "model": np.random.normal(1, 1, n),
-        }
+def test_rate_score_p_value_range(synthetic_df):
+    result = rate_score(
+        synthetic_df,
+        treatment_effect_col="tau",
+        return_ci=True,
+        n_bootstrap=50,
+        random_state=RANDOM_SEED,
     )
-    result = rate_score(df, return_ci=True, n_bootstrap=50)
     assert (result["p_value"] >= 0).all()
     assert (result["p_value"] <= 1).all()
 
 
-def test_rate_score_ci_qini_weighting():
-    np.random.seed(42)
-    n = 300
-    df = pd.DataFrame(
-        {
-            "y": np.random.binomial(1, 0.5, n),
-            "w": np.random.binomial(1, 0.5, n),
-            "tau": np.random.normal(0.5, 1, n),
-            "model": np.random.normal(1, 1, n),
-        }
+def test_rate_score_ci_qini_weighting(synthetic_df):
+    result = rate_score(
+        synthetic_df,
+        treatment_effect_col="tau",
+        weighting="qini",
+        return_ci=True,
+        n_bootstrap=50,
+        random_state=RANDOM_SEED,
     )
-    result = rate_score(df, weighting="qini", return_ci=True, n_bootstrap=50)
     assert isinstance(result, pd.DataFrame)
     assert not result["se"].isnull().any()

--- a/tests/test_rate.py
+++ b/tests/test_rate.py
@@ -159,3 +159,59 @@ def test_plot_toc(synthetic_df, monkeypatch):
     monkeypatch.setattr(plt, "show", lambda: None)
     ax = plot_toc(synthetic_df, treatment_effect_col="tau")
     assert isinstance(ax, plt.Axes)
+
+
+def test_rate_score_return_ci_returns_dataframe():
+    np.random.seed(42)
+    n = 300
+    df = pd.DataFrame({
+        "y": np.random.binomial(1, 0.5, n),
+        "w": np.random.binomial(1, 0.5, n),
+        "tau": np.random.normal(0.5, 1, n),
+        "model": np.random.normal(1, 1, n),
+    })
+    result = rate_score(df, return_ci=True, n_bootstrap=50)
+    assert isinstance(result, pd.DataFrame)
+    assert set(result.columns) == {"rate", "se", "ci_lower", "ci_upper", "p_value"}
+
+
+def test_rate_score_ci_bounds_ordered():
+    np.random.seed(42)
+    n = 300
+    df = pd.DataFrame({
+        "y": np.random.binomial(1, 0.5, n),
+        "w": np.random.binomial(1, 0.5, n),
+        "tau": np.random.normal(0.5, 1, n),
+        "model": np.random.normal(1, 1, n),
+    })
+    result = rate_score(df, return_ci=True, n_bootstrap=50)
+    assert (result["ci_lower"] < result["rate"]).all()
+    assert (result["ci_upper"] > result["rate"]).all()
+
+
+def test_rate_score_p_value_range():
+    np.random.seed(42)
+    n = 300
+    df = pd.DataFrame({
+        "y": np.random.binomial(1, 0.5, n),
+        "w": np.random.binomial(1, 0.5, n),
+        "tau": np.random.normal(0.5, 1, n),
+        "model": np.random.normal(1, 1, n),
+    })
+    result = rate_score(df, return_ci=True, n_bootstrap=50)
+    assert (result["p_value"] >= 0).all()
+    assert (result["p_value"] <= 1).all()
+
+
+def test_rate_score_ci_qini_weighting():
+    np.random.seed(42)
+    n = 300
+    df = pd.DataFrame({
+        "y": np.random.binomial(1, 0.5, n),
+        "w": np.random.binomial(1, 0.5, n),
+        "tau": np.random.normal(0.5, 1, n),
+        "model": np.random.normal(1, 1, n),
+    })
+    result = rate_score(df, weighting="qini", return_ci=True, n_bootstrap=50)
+    assert isinstance(result, pd.DataFrame)
+    assert not result["se"].isnull().any()

--- a/tests/test_rate.py
+++ b/tests/test_rate.py
@@ -164,12 +164,14 @@ def test_plot_toc(synthetic_df, monkeypatch):
 def test_rate_score_return_ci_returns_dataframe():
     np.random.seed(42)
     n = 300
-    df = pd.DataFrame({
-        "y": np.random.binomial(1, 0.5, n),
-        "w": np.random.binomial(1, 0.5, n),
-        "tau": np.random.normal(0.5, 1, n),
-        "model": np.random.normal(1, 1, n),
-    })
+    df = pd.DataFrame(
+        {
+            "y": np.random.binomial(1, 0.5, n),
+            "w": np.random.binomial(1, 0.5, n),
+            "tau": np.random.normal(0.5, 1, n),
+            "model": np.random.normal(1, 1, n),
+        }
+    )
     result = rate_score(df, return_ci=True, n_bootstrap=50)
     assert isinstance(result, pd.DataFrame)
     assert set(result.columns) == {"rate", "se", "ci_lower", "ci_upper", "p_value"}
@@ -178,12 +180,14 @@ def test_rate_score_return_ci_returns_dataframe():
 def test_rate_score_ci_bounds_ordered():
     np.random.seed(42)
     n = 300
-    df = pd.DataFrame({
-        "y": np.random.binomial(1, 0.5, n),
-        "w": np.random.binomial(1, 0.5, n),
-        "tau": np.random.normal(0.5, 1, n),
-        "model": np.random.normal(1, 1, n),
-    })
+    df = pd.DataFrame(
+        {
+            "y": np.random.binomial(1, 0.5, n),
+            "w": np.random.binomial(1, 0.5, n),
+            "tau": np.random.normal(0.5, 1, n),
+            "model": np.random.normal(1, 1, n),
+        }
+    )
     result = rate_score(df, return_ci=True, n_bootstrap=50)
     assert (result["ci_lower"] < result["rate"]).all()
     assert (result["ci_upper"] > result["rate"]).all()
@@ -192,12 +196,14 @@ def test_rate_score_ci_bounds_ordered():
 def test_rate_score_p_value_range():
     np.random.seed(42)
     n = 300
-    df = pd.DataFrame({
-        "y": np.random.binomial(1, 0.5, n),
-        "w": np.random.binomial(1, 0.5, n),
-        "tau": np.random.normal(0.5, 1, n),
-        "model": np.random.normal(1, 1, n),
-    })
+    df = pd.DataFrame(
+        {
+            "y": np.random.binomial(1, 0.5, n),
+            "w": np.random.binomial(1, 0.5, n),
+            "tau": np.random.normal(0.5, 1, n),
+            "model": np.random.normal(1, 1, n),
+        }
+    )
     result = rate_score(df, return_ci=True, n_bootstrap=50)
     assert (result["p_value"] >= 0).all()
     assert (result["p_value"] <= 1).all()
@@ -206,12 +212,14 @@ def test_rate_score_p_value_range():
 def test_rate_score_ci_qini_weighting():
     np.random.seed(42)
     n = 300
-    df = pd.DataFrame({
-        "y": np.random.binomial(1, 0.5, n),
-        "w": np.random.binomial(1, 0.5, n),
-        "tau": np.random.normal(0.5, 1, n),
-        "model": np.random.normal(1, 1, n),
-    })
+    df = pd.DataFrame(
+        {
+            "y": np.random.binomial(1, 0.5, n),
+            "w": np.random.binomial(1, 0.5, n),
+            "tau": np.random.normal(0.5, 1, n),
+            "model": np.random.normal(1, 1, n),
+        }
+    )
     result = rate_score(df, weighting="qini", return_ci=True, n_bootstrap=50)
     assert isinstance(result, pd.DataFrame)
     assert not result["se"].isnull().any()

--- a/tests/test_visualize.py
+++ b/tests/test_visualize.py
@@ -6,7 +6,6 @@ from sklearn.model_selection import KFold, train_test_split
 
 from causalml.metrics.visualize import get_cumlift, plot_tmlegain
 from causalml.inference.meta import LRSRegressor
-from causalml.metrics import rate_score
 
 
 def test_visualize_get_cumlift_errors_on_nan():
@@ -73,61 +72,3 @@ def test_plot_tmlegain(generate_regression_data, monkeypatch):
         ci=False,
     )
 
-
-def test_rate_score_basic():
-    np.random.seed(42)
-    n = 500
-    df = pd.DataFrame(
-        {
-            "y": np.random.binomial(1, 0.5, n),
-            "w": np.random.binomial(1, 0.5, n),
-            "tau": np.zeros(n),
-            "model_good": np.random.normal(1, 1, n),
-            "model_random": np.random.normal(0, 1, n),
-        }
-    )
-
-    result = rate_score(df)
-    assert isinstance(result, pd.Series)
-    assert set(result.index) == {"model_good", "model_random"}
-    assert result["model_good"] > result["model_random"]
-
-
-def test_rate_score_with_ci():
-    np.random.seed(42)
-    n = 500
-    df = pd.DataFrame(
-        {
-            "y": np.random.binomial(1, 0.5, n),
-            "w": np.random.binomial(1, 0.5, n),
-            "tau": np.zeros(n),
-            "model_good": np.random.normal(1, 1, n),
-            "model_random": np.random.normal(0, 1, n),
-        }
-    )
-
-    result = rate_score(df, return_ci=True, n_bootstrap=50)
-    assert isinstance(result, pd.DataFrame)
-    assert set(result.columns) == {"rate", "se", "ci_lower", "ci_upper", "p_value"}
-    assert (result["ci_lower"] < result["rate"]).all()
-    assert (result["ci_upper"] > result["rate"]).all()
-    assert (result["p_value"].between(0, 1)).all()
-
-
-def test_rate_score_invalid_weighting():
-    df = pd.DataFrame(
-        {
-            "y": [1, 0, 1],
-            "w": [1, 0, 1],
-            "tau": [0.1, 0.2, 0.3],
-            "model": [0.5, 0.3, 0.8],
-        }
-    )
-    with pytest.raises(ValueError, match="weighting must be"):
-        rate_score(df, weighting="invalid")
-
-
-def test_rate_score_no_model_cols():
-    df = pd.DataFrame({"y": [1, 0], "w": [1, 0], "tau": [0.1, 0.2]})
-    with pytest.raises(ValueError, match="No model prediction columns"):
-        rate_score(df)

--- a/tests/test_visualize.py
+++ b/tests/test_visualize.py
@@ -77,13 +77,15 @@ def test_plot_tmlegain(generate_regression_data, monkeypatch):
 def test_rate_score_basic():
     np.random.seed(42)
     n = 500
-    df = pd.DataFrame({
-        "y": np.random.binomial(1, 0.5, n),
-        "w": np.random.binomial(1, 0.5, n),
-        "tau": np.zeros(n),
-        "model_good": np.random.normal(1, 1, n),
-        "model_random": np.random.normal(0, 1, n),
-    })
+    df = pd.DataFrame(
+        {
+            "y": np.random.binomial(1, 0.5, n),
+            "w": np.random.binomial(1, 0.5, n),
+            "tau": np.zeros(n),
+            "model_good": np.random.normal(1, 1, n),
+            "model_random": np.random.normal(0, 1, n),
+        }
+    )
 
     result = rate_score(df)
     assert isinstance(result, pd.Series)
@@ -94,13 +96,15 @@ def test_rate_score_basic():
 def test_rate_score_with_ci():
     np.random.seed(42)
     n = 500
-    df = pd.DataFrame({
-        "y": np.random.binomial(1, 0.5, n),
-        "w": np.random.binomial(1, 0.5, n),
-        "tau": np.zeros(n),
-        "model_good": np.random.normal(1, 1, n),
-        "model_random": np.random.normal(0, 1, n),
-    })
+    df = pd.DataFrame(
+        {
+            "y": np.random.binomial(1, 0.5, n),
+            "w": np.random.binomial(1, 0.5, n),
+            "tau": np.zeros(n),
+            "model_good": np.random.normal(1, 1, n),
+            "model_random": np.random.normal(0, 1, n),
+        }
+    )
 
     result = rate_score(df, return_ci=True, n_bootstrap=50)
     assert isinstance(result, pd.DataFrame)
@@ -111,9 +115,14 @@ def test_rate_score_with_ci():
 
 
 def test_rate_score_invalid_weighting():
-    df = pd.DataFrame({
-        "y": [1, 0, 1], "w": [1, 0, 1], "tau": [0.1, 0.2, 0.3], "model": [0.5, 0.3, 0.8]
-    })
+    df = pd.DataFrame(
+        {
+            "y": [1, 0, 1],
+            "w": [1, 0, 1],
+            "tau": [0.1, 0.2, 0.3],
+            "model": [0.5, 0.3, 0.8],
+        }
+    )
     with pytest.raises(ValueError, match="weighting must be"):
         rate_score(df, weighting="invalid")
 

--- a/tests/test_visualize.py
+++ b/tests/test_visualize.py
@@ -71,4 +71,3 @@ def test_plot_tmlegain(generate_regression_data, monkeypatch):
         cv=kf,
         ci=False,
     )
-

--- a/tests/test_visualize.py
+++ b/tests/test_visualize.py
@@ -6,6 +6,7 @@ from sklearn.model_selection import KFold, train_test_split
 
 from causalml.metrics.visualize import get_cumlift, plot_tmlegain
 from causalml.inference.meta import LRSRegressor
+from causalml.metrics import rate_score
 
 
 def test_visualize_get_cumlift_errors_on_nan():
@@ -71,3 +72,53 @@ def test_plot_tmlegain(generate_regression_data, monkeypatch):
         cv=kf,
         ci=False,
     )
+
+
+def test_rate_score_basic():
+    np.random.seed(42)
+    n = 500
+    df = pd.DataFrame({
+        "y": np.random.binomial(1, 0.5, n),
+        "w": np.random.binomial(1, 0.5, n),
+        "tau": np.zeros(n),
+        "model_good": np.random.normal(1, 1, n),
+        "model_random": np.random.normal(0, 1, n),
+    })
+
+    result = rate_score(df)
+    assert isinstance(result, pd.Series)
+    assert set(result.index) == {"model_good", "model_random"}
+    assert result["model_good"] > result["model_random"]
+
+
+def test_rate_score_with_ci():
+    np.random.seed(42)
+    n = 500
+    df = pd.DataFrame({
+        "y": np.random.binomial(1, 0.5, n),
+        "w": np.random.binomial(1, 0.5, n),
+        "tau": np.zeros(n),
+        "model_good": np.random.normal(1, 1, n),
+        "model_random": np.random.normal(0, 1, n),
+    })
+
+    result = rate_score(df, return_ci=True, n_bootstrap=50)
+    assert isinstance(result, pd.DataFrame)
+    assert set(result.columns) == {"rate", "se", "ci_lower", "ci_upper", "p_value"}
+    assert (result["ci_lower"] < result["rate"]).all()
+    assert (result["ci_upper"] > result["rate"]).all()
+    assert (result["p_value"].between(0, 1)).all()
+
+
+def test_rate_score_invalid_weighting():
+    df = pd.DataFrame({
+        "y": [1, 0, 1], "w": [1, 0, 1], "tau": [0.1, 0.2, 0.3], "model": [0.5, 0.3, 0.8]
+    })
+    with pytest.raises(ValueError, match="weighting must be"):
+        rate_score(df, weighting="invalid")
+
+
+def test_rate_score_no_model_cols():
+    df = pd.DataFrame({"y": [1, 0], "w": [1, 0], "tau": [0.1, 0.2]})
+    with pytest.raises(ValueError, match="No model prediction columns"):
+        rate_score(df)


### PR DESCRIPTION
## Proposed changes

closes #889
extends the existing `rate_score()` in `causalml/metrics/rate.py` (added in #887) with bootstrap confidence intervals and p-values, as requested by @jeongyoonlee in the #887 review.

### What's added

- new parameters: `return_ci=False`, `n_bootstrap=200`, `alpha=0.05`
- when `return_ci=True`, uses half-sample bootstrap (m = n // 2, without replacement) to estimate standard errors and confidence intervals
- p-value tests H0: RATE = 0 via two-sided z-test
- refactored the integration logic into a `_compute_rate_from_toc()` helper to avoid code duplication between the point estimate and bootstrap paths
- 4 new tests added to `tests/test_rate.py`

## Types of changes

What types of changes does your code introduce to **CausalML**?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/uber/causalml/blob/master/CONTRIBUTING.md) doc
- [ ] I have signed the [CLA](https://cla-assistant.io/uber/causalml)
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc. This PR template is adopted from [appium](https://github.com/appium/appium).
