### PR TITLE
feature_selection: validate binary outcome in filter_LR / filter_D (#349)

### DIFF
--- a/causalml/feature_selection/filters.py
+++ b/causalml/feature_selection/filters.py
@@ -1,7 +1,24 @@
 """
-Filter feature selection methods for uplift modeling
+Filter feature selection methods for uplift modeling.
 
-- Currently only for classification problem: the outcome variable of uplift model is binary.
+These filters implement the bin-based and likelihood-based feature ranking
+described in Zhao et al. 2020 (https://arxiv.org/abs/2005.03447).
+
+.. note::
+    The current implementation only supports **binary** outcomes (values
+    coded as ``0`` and ``1``):
+
+    * ``filter_LR`` uses ``statsmodels`` ``Logit``, which assumes a binary
+      response.
+    * ``filter_D`` (KL / Chi / ED divergences) computes class probabilities
+      via ``_GetNodeSummary``, which only inspects ``y == 0`` and
+      ``y == 1`` counts and silently ignores other label values.
+
+    Passing a non-binary outcome used to fall through silently or behave
+    inconsistently per node. As of uber/causalml#349, ``filter_LR`` and
+    ``filter_D`` raise a clear ``ValueError`` if the outcome contains
+    values other than ``{0, 1}``. The ``filter_F`` (OLS) method tolerates
+    continuous outcomes and is unaffected.
 """
 
 import numpy as np
@@ -9,6 +26,41 @@ import pandas as pd
 import statsmodels.api as sm
 from scipy import stats
 from sklearn.impute import SimpleImputer
+
+
+def _check_binary_outcome(y, y_name="y"):
+    """Validate that an outcome vector contains only ``0`` and ``1``.
+
+    Used by ``filter_LR`` and ``filter_D`` to fail loudly when the user
+    passes a non-binary outcome — those filters silently mis-handle other
+    label sets (Logit assumes binary; ``_GetNodeSummary`` only counts
+    ``y == 0`` and ``y == 1``). See uber/causalml#349.
+
+    Args:
+        y (array-like): outcome values.
+        y_name (str): column name used in the error message.
+
+    Raises:
+        ValueError: if ``y`` contains any value other than ``0`` or ``1``.
+    """
+    arr = np.asarray(y)
+    # Drop NaNs from the validation set — they are handled separately
+    # (e.g. ``null_impute`` in ``_filter_D_one_feature``).
+    if arr.dtype.kind == "f":
+        arr = arr[~np.isnan(arr)]
+    unique = np.unique(arr)
+    # Allow either {0, 1}, {0}, or {1} — empty set is rejected too.
+    extra = set(np.atleast_1d(unique).tolist()) - {0, 1, 0.0, 1.0}
+    if extra or len(unique) == 0:
+        raise ValueError(
+            "Filter feature selection only supports binary outcomes "
+            "(values 0/1); column '{}' contains {}. See "
+            "uber/causalml#349 for the current limitation. Use "
+            "``filter_F`` (OLS) for continuous outcomes, or pre-process "
+            "your label (e.g. via ``pd.qcut``) into a binary indicator.".format(
+                y_name, sorted(unique.tolist())[:10]
+            )
+        )
 
 
 class FilterSelect:
@@ -241,6 +293,10 @@ class FilterSelect:
         """
         if order not in [1, 2, 3]:
             raise Exception("ValueError: order argument only takes value 1,2,3.")
+
+        # filter_LR uses statsmodels Logit which silently mis-handles
+        # non-binary outcomes; validate up-front per uber/causalml#349.
+        _check_binary_outcome(data[y_name], y_name=y_name)
 
         all_result = pd.DataFrame()
         for x_name_i in features:
@@ -549,6 +605,12 @@ class FilterSelect:
             all_result : pd.DataFrame
                 a data frame containing the feature importance statistics
         """
+
+        # The bin-based divergence filters (KL/ED/Chi) compute per-bin
+        # class probabilities via ``_GetNodeSummary``, which only counts
+        # ``y == 0`` and ``y == 1``. A non-binary outcome would silently
+        # produce nonsense scores. Validate up-front per uber/causalml#349.
+        _check_binary_outcome(data[y_name], y_name=y_name)
 
         all_result = pd.DataFrame()
 

--- a/tests/test_feature_selection.py
+++ b/tests/test_feature_selection.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pytest
 from causalml.feature_selection.filters import FilterSelect
 
 from .const import RANDOM_SEED, CONVERSION
@@ -42,6 +43,52 @@ def test_filter_lr(generate_classification_data):
     assert imp.shape[0] == len(X_names)
     assert imp["rank"].values[0] == 1
     assert imp["score"].values[0] >= imp["score"].values[1]
+
+
+@pytest.mark.parametrize("method", ["LR", "KL", "ED", "Chi"])
+def test_filter_rejects_non_binary_outcome(generate_classification_data, method):
+    """Regression test for uber/causalml#349.
+
+    Before the fix, passing a non-binary outcome to ``filter_LR`` /
+    ``filter_D`` (KL/ED/Chi) would silently mis-handle it: ``Logit`` would
+    raise a ``PerfectSeparationError`` deep inside statsmodels, and the
+    bin-based filters' ``_GetNodeSummary`` would only count ``y == 0``
+    and ``y == 1`` rows — producing meaningless scores when the label set
+    is e.g. ``{0, 1, 2, 3}``.
+
+    After the fix, the public entry points raise a clear ``ValueError``
+    that names the offending column and points the user at the limitation.
+    """
+    np.random.seed(RANDOM_SEED)
+    df, X_names = generate_classification_data()
+    y_name = CONVERSION
+
+    # Replace the binary outcome with a multi-class label set that includes
+    # 0 and 1 (so a naive value-counts check could miss the gap).
+    df = df.copy()
+    df[y_name] = np.random.randint(0, 4, size=df.shape[0])
+
+    filter_obj = FilterSelect()
+    with pytest.raises(ValueError, match="binary"):
+        filter_obj.get_importance(
+            df, X_names, y_name, method, treatment_group="treatment1"
+        )
+
+
+def test_filter_f_accepts_continuous_outcome(generate_classification_data):
+    """``filter_F`` uses OLS and is documented to tolerate continuous y;
+    the binary-outcome guard introduced for #349 must not affect it."""
+    np.random.seed(RANDOM_SEED)
+    df, X_names = generate_classification_data()
+    y_name = CONVERSION
+    df = df.copy()
+    df[y_name] = np.random.rand(df.shape[0])  # continuous outcome
+
+    filter_obj = FilterSelect()
+    imp = filter_obj.get_importance(
+        df, X_names, y_name, "F", treatment_group="treatment1"
+    )
+    assert imp.shape[0] == len(X_names)
 
 
 def test_filter_kl(generate_classification_data):


### PR DESCRIPTION
## Proposed changes

The likelihood-ratio filter (`filter_LR`) and bin-based divergence filters
(`filter_D` with method `KL` / `ED` / `Chi`) only support **binary** outcomes,
but the public API does not validate this. Passing a multi-class label set
(e.g. `{0, 1, 2, 3}`) silently produces meaningless feature-importance scores
or surfaces an inscrutable `statsmodels` error from deep in the call stack.

This PR adds a `_check_binary_outcome` validator at both `filter_LR` and
`filter_D` entry points so the user gets a clear `ValueError` naming the
offending column, the limitation, and the supported alternative
(`filter_F` for continuous outcomes). The module docstring is also updated
to document the constraint.

Fixes #349 — *Clarify the limitations (specifically the label) of the current
implementation of filter methods*

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] Documentation Update (if none of the other choices apply)

## Context

The OP cited `causalml/feature_selection/filters.py:210` (the `sm.Logit` line,
now around L199 on master) and noted:

> the filter method will appear to work without error unless a particular node
> has no 0,1 labels in it.

The bin-based path is even more silent: `_GetNodeSummary` (filters.py:302) does
`results_series = data.groupby([experiment_group_column, y_name]).size()` and
then `results[ti].get(1, 0)` / `results[ti].get(0, 0)` — every value other
than 0 or 1 is silently dropped from the per-bin probability calculation.

`filter_F` uses OLS and is documented as compatible with continuous outcomes,
so it is **not** validated. A new test guards against accidentally tightening
that.

## Changes

- `causalml/feature_selection/filters.py`
  - Module docstring rewritten with an explicit `note::` block documenting
    the binary-outcome constraint and pointing to `filter_F` for continuous
    outcomes.
  - New module-level helper `_check_binary_outcome(y, y_name)` that drops
    NaNs, computes the unique label set, and raises `ValueError` if any
    value other than `{0, 1}` is present.
  - `filter_LR` and `filter_D` call the validator before any work.
- `tests/test_feature_selection.py`
  - Parametrized regression test `test_filter_rejects_non_binary_outcome`
    covering `LR`, `KL`, `ED`, `Chi` — each fails on `master` (no `ValueError`
    is raised) and passes on this branch.
  - New `test_filter_f_accepts_continuous_outcome` to lock in that `filter_F`
    is unaffected.

## Reproduce BEFORE/AFTER yourself (copy-paste)

```bash
# --- one-time setup ---
git clone https://github.com/uber/causalml.git /tmp/repro-349 && cd /tmp/repro-349
python -m venv .venv && source .venv/bin/activate
pip install -e '.[test]'

# Define the test payload once — the only thing that changes between
# BEFORE and AFTER is the checked-out git ref.
cat > /tmp/repro-349-snippet.py <<'PY'
import numpy as np, pandas as pd
from causalml.feature_selection import FilterSelect
np.random.seed(0)
n = 200
df = pd.DataFrame({
    "x1": np.random.rand(n),
    "x2": np.random.rand(n),
    "treatment_group_key": np.random.choice(["control", "treatment1"], size=n),
    # Non-binary outcome (4 classes including 0 and 1)
    "conversion": np.random.randint(0, 4, size=n),
})
fs = FilterSelect()
try:
    out = fs.get_importance(df, ["x1", "x2"], "conversion", "KL", treatment_group="treatment1")
    print("RESULT:", out.to_dict("records"))
except Exception as e:
    print(f"RAISED {type(e).__name__}: {e}")
PY

# --- BEFORE (origin/master) ---
git checkout origin/master
python /tmp/repro-349-snippet.py
# Expected: silent run; nonsensical scores from values 2/3 ignored, no warning.

# --- AFTER (this PR) ---
git fetch https://github.com/jbbqqf/causalml.git feat/349-filter-binary-y-validation
git checkout FETCH_HEAD
pip install -e '.[test]'
python /tmp/repro-349-snippet.py
# Expected: RAISED ValueError: Filter feature selection only supports binary outcomes ...
```

## What I ran locally

- `pytest tests/test_feature_selection.py -v` →
  **8/8 passed** on this branch (was 3/3 before; added 5 parametrized + lock-in tests).
- `pytest tests/test_feature_selection.py::test_filter_rejects_non_binary_outcome -v`
  on `origin/master` → **4/4 FAIL** (no `ValueError` raised; silent or wrong-error path).
- `black --fast causalml/feature_selection/filters.py tests/test_feature_selection.py` → clean.

## Edge cases tested

| # | Scenario | Expected | Verified by |
|---|----------|----------|-------------|
| 1 | LR filter, multi-class outcome | `ValueError("...binary...")` | `test_filter_rejects_non_binary_outcome[LR]` |
| 2 | KL/ED/Chi filter, multi-class outcome | `ValueError("...binary...")` | `test_filter_rejects_non_binary_outcome[KL/ED/Chi]` |
| 3 | F filter, **continuous** outcome | normal run, no error | `test_filter_f_accepts_continuous_outcome` |
| 4 | LR filter, well-formed binary outcome | normal run | `test_filter_lr` (existing, unchanged) |
| 5 | KL filter, well-formed binary outcome | normal run | `test_filter_kl` (existing, unchanged) |

## Risk / blast radius

- New validation at two public entry points. Existing tests with binary
  outcomes are unaffected.
- The error message names the column and points the user at `filter_F`
  for the continuous-outcome use case, so the user-experience improvement
  is two-way: the limitation is documented (issue #349's primary ask)
  *and* the failure mode becomes loud rather than silent.

## Release note

```release-note
`FilterSelect.filter_LR` and `FilterSelect.filter_D` now raise a clear
`ValueError` when the outcome column contains values other than `{0, 1}`.
Use `filter_F` for continuous outcomes (Zhao et al. 2020, this library's
binary-only assumption is documented in `feature_selection/filters.py`).
```

---

*PR drafted with assistance from Claude Code. The change was reviewed manually
against `causalml/feature_selection/filters.py` (the `sm.Logit` and
`_GetNodeSummary` paths cited in the issue) and the existing
`tests/test_feature_selection.py` patterns. The reproducer block above was
used during development; it is the same one a reviewer can paste verbatim.*
