### PR TITLE
ci: declare workflow-level `contents: read` on 4 workflows

### DIFF
--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -2,6 +2,9 @@ name: Lint
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/python-test.yaml
+++ b/.github/workflows/python-test.yaml
@@ -2,6 +2,9 @@ name: build
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     # [macos-latest, macos-latest, windows-latest]

--- a/.github/workflows/test-build-from-source.yml
+++ b/.github/workflows/test-build-from-source.yml
@@ -6,6 +6,9 @@ on:
       - 'envs/*.yml'
       - '.github/workflows/test-build-from-source.yml'
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: ${{ matrix.os }}${{ matrix.tf-label }}-py${{ matrix.python-version }}

--- a/.github/workflows/test-pypi-install.yml
+++ b/.github/workflows/test-pypi-install.yml
@@ -4,6 +4,9 @@ on:
   schedule:
     - cron: '0 0 1 * *'
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: ${{ matrix.os }}-py${{ matrix.python-version }}


### PR DESCRIPTION
Pins the default `GITHUB_TOKEN` to `contents: read` on 4 workflows in `.github/workflows/` that don't call a GitHub API beyond the initial checkout.

## Why

CVE-2025-30066 (March 2025 `tj-actions/changed-files` supply-chain compromise) exfiltrated `GITHUB_TOKEN` from workflow logs. Pinning per workflow caps runtime authority irrespective of the repo or org default, gives drift protection if the default ever widens, and is credited per-file by the OpenSSF Scorecard `Token-Permissions` check.

YAML validated locally with `yaml.safe_load` on each touched file.