### PR TITLE
Support CausalRandomForestRegressor.calculate_error() on scikit-learn >= 1.9

### DIFF
--- a/causalml/inference/tree/causal/causalforest.py
+++ b/causalml/inference/tree/causal/causalforest.py
@@ -1,5 +1,6 @@
 from typing import Union
 
+from contextlib import contextmanager
 import numpy as np
 import forestci as fci
 from joblib import Parallel, delayed
@@ -36,6 +37,48 @@ DTYPE = np.float32
 # behavior (the vendored `_parallel_build_trees` already applies the user's
 # `sample_weight` itself), keeping causal-forest results identical across versions.
 _SKLEARN_GE_19 = Version(sklearn_version) >= Version("1.9.0")
+
+
+@contextmanager
+def _forestci_sklearn19_compat():
+    """Make forestci's pre-1.9 sampler calls work under scikit-learn >= 1.9.
+
+    forestci (<= 0.7) calls scikit-learn's private ``_generate_sample_indices``
+    and ``_get_n_samples_bootstrap`` with their pre-1.9 arity (no
+    ``sample_weight``), which raises ``TypeError`` on scikit-learn >= 1.9 (the
+    same refactor handled elsewhere in this module). Until the upstream fix
+    (scikit-learn-contrib/forest-confidence-interval#122) ships in a release and
+    we can bump the ``forestci`` pin, temporarily wrap those names in forestci's
+    module namespace to supply ``sample_weight=None`` -- the pre-1.9
+    uniform-bootstrap default, so results are unchanged. This patches the exact
+    globals ``forestci.calc_inbag`` resolves at call time, covering both the
+    direct call and the recursive ``calibrate=True`` path. No-op on < 1.9.
+
+    Note: this mutates ``forestci.forestci`` module globals for the duration of
+    the call (restored in ``finally``); it is not safe under concurrent calls
+    from multiple threads.
+    """
+    if not _SKLEARN_GE_19:
+        yield
+        return
+
+    import forestci.forestci as _impl
+
+    def _gsi(random_state, n_samples, n_samples_bootstrap, sample_weight=None):
+        return _generate_sample_indices(
+            random_state, n_samples, n_samples_bootstrap, sample_weight
+        )
+
+    def _gnsb(n_samples, max_samples, sample_weight=None):
+        return _get_n_samples_bootstrap(n_samples, max_samples, sample_weight)
+
+    orig = (_impl._generate_sample_indices, _impl._get_n_samples_bootstrap)
+    _impl._generate_sample_indices, _impl._get_n_samples_bootstrap = _gsi, _gnsb
+    try:
+        yield
+    finally:
+        _impl._generate_sample_indices, _impl._get_n_samples_bootstrap = orig
+
 
 if Version(sklearn_version) >= Version("1.1.0"):
     _joblib_parallel_args = dict(prefer="threads")
@@ -532,10 +575,12 @@ class CausalRandomForestRegressor(ForestRegressor):
             calls scikit-learn's private ``_get_n_samples_bootstrap`` and
             ``_generate_sample_indices`` with their pre-1.9 signatures. Under
             scikit-learn >= 1.9 those helpers require an extra ``sample_weight``
-            argument, so ``forestci`` (<= 0.7) raises ``TypeError`` here. The error
-            originates upstream and is not yet fixed; ``calculate_error`` is therefore
-            unsupported on scikit-learn >= 1.9 until ``forestci`` is updated. ``fit``
-            and ``predict`` are unaffected. See
+            argument, so ``forestci`` (<= 0.7) would raise ``TypeError`` here. As a
+            temporary measure this call runs inside ``_forestci_sklearn19_compat()``,
+            which patches those helpers to pass ``sample_weight=None`` (the pre-1.9
+            uniform-bootstrap default, so results are unchanged), pending the upstream
+            fix (forest-confidence-interval#122) and a ``forestci`` pin bump. The shim
+            is not thread-safe (see its docstring). See
             https://github.com/uber/causalml/issues/906.
         """
         if self.n_outputs_ != 1:
@@ -543,13 +588,14 @@ class CausalRandomForestRegressor(ForestRegressor):
                 f"forestci supports n_outputs=1. n_outputs={self.n_outputs_}"
             )
 
-        var = fci.random_forest_error(
-            self,
-            X_train,
-            X_test,
-            inbag=inbag,
-            calibrate=calibrate,
-            memory_constrained=memory_constrained,
-            memory_limit=memory_limit,
-        )
+        with _forestci_sklearn19_compat():
+            var = fci.random_forest_error(
+                self,
+                X_train,
+                X_test,
+                inbag=inbag,
+                calibrate=calibrate,
+                memory_constrained=memory_constrained,
+                memory_limit=memory_limit,
+            )
         return var

--- a/tests/test_causal_trees.py
+++ b/tests/test_causal_trees.py
@@ -4,19 +4,12 @@ from abc import abstractmethod
 import numpy as np
 import pandas as pd
 import pytest
-from packaging.version import parse as Version
-from sklearn import __version__ as sklearn_version
 from sklearn.model_selection import train_test_split
 
 from causalml.inference.tree import CausalTreeRegressor, CausalRandomForestRegressor
 from causalml.metrics import ape
 from causalml.metrics import qini_score
 from .const import RANDOM_SEED, ERROR_THRESHOLD, N_SAMPLE
-
-# scikit-learn >= 1.9 changed the private forest sampler signatures; forestci (<= 0.7)
-# still calls them with the pre-1.9 arity, so CausalRandomForestRegressor.calculate_error()
-# raises TypeError until forestci is updated upstream.
-SKLEARN_GE_19 = Version(sklearn_version) >= Version("1.9.0")
 
 
 class CausalTreeBase:
@@ -264,7 +257,7 @@ class TestCausalRandomForestCase(CausalTreeBase):
         )
 
     def test_unbiased_sampling_error(
-        self, request, generate_regression_data, n_estimators: int, n_treatments: int
+        self, generate_regression_data, n_estimators: int, n_treatments: int
     ):
         crforest = self.prepare_model(n_estimators=n_estimators)
         data = self.prepare_multi_treatment_data(generate_regression_data, n_treatments)
@@ -278,19 +271,6 @@ class TestCausalRandomForestCase(CausalTreeBase):
         ) = self.split_data(data)
         crforest.fit(X=X_train, treatment=treatment_train, y=y_train)
         if n_treatments == 1:
-            if SKLEARN_GE_19:
-                # calculate_error() delegates to forestci, which calls sklearn's private
-                # samplers with the pre-1.9 signature and raises TypeError on >= 1.9.
-                # Run the code (non-strict xfail) so this XPASSes once forestci is fixed.
-                request.node.add_marker(
-                    pytest.mark.xfail(
-                        reason="forestci (<= 0.7) is incompatible with scikit-learn >= 1.9; "
-                        "calculate_error() unsupported until forestci is updated upstream "
-                        "(see https://github.com/uber/causalml/issues/906)",
-                        raises=TypeError,
-                        strict=False,
-                    )
-                )
             crforest_test_var = crforest.calculate_error(X_train=X_train, X_test=X_test)
             assert (crforest_test_var > 0).all()
             assert crforest_test_var.shape[0] == y_test.shape[0]


### PR DESCRIPTION
## Summary

`CausalRandomForestRegressor.calculate_error()` raised `TypeError` under scikit-learn ≥ 1.9, even after #907 fixed `fit()`/`predict()`. The break is **inside `forestci`** (we pin `forestci==0.6`): its `calc_inbag()` calls scikit-learn's private `_generate_sample_indices` / `_get_n_samples_bootstrap` with their pre-1.9 arity, which [scikit-learn#31529](https://github.com/scikit-learn/scikit-learn/pull/31529) made invalid on 1.9 — the same refactor #907 handled in our vendored `_fit`.

Rather than block on the upstream fix landing in a release (and the subsequent `forestci` pin bump), this applies that fix locally as a small, scoped, version-guarded shim, so `calculate_error()` works on the **current `forestci==0.6` pin** today.

Addresses #906. Builds on #907 (merged).

## Why a precomputed `inbag` isn't sufficient

`calculate_error(calibrate=True)` (the default) recurses: the calibration branch calls `random_forest_error(..., calibrate=False)` with `inbag=None`, which re-enters `calc_inbag()` and hits the private samplers again. So the sampler calls themselves must be made to work — passing a precomputed `inbag` only sidesteps the non-default `calibrate=False` path.

## Changes

`causalml/inference/tree/causal/causalforest.py`
- Add a module-level context manager `_forestci_sklearn19_compat()`. On scikit-learn ≥ 1.9 only, it temporarily wraps `forestci.forestci._generate_sample_indices` / `_get_n_samples_bootstrap` to pass `sample_weight=None` (the pre-1.9 uniform-bootstrap default), restoring them in `finally`. It patches the exact module globals `calc_inbag` resolves at call time, covering both the direct and the recursive `calibrate=True` path. No-op on < 1.9.
- Wrap the `fci.random_forest_error(...)` call in `calculate_error()` with it; update the docstring `Note`.

`tests/test_causal_trees.py`
- Remove the `xfail` scaffolding added in #907 for the two `test_unbiased_sampling_error[*-1]` cases — `calculate_error()` now passes on all supported scikit-learn versions.

## Behavior preserved

`sample_weight=None` reproduces the pre-1.9 uniform bootstrap exactly, so variance estimates are unchanged. This mirrors the upstream fix ([forest-confidence-interval#122](https://github.com/scikit-learn-contrib/forest-confidence-interval/pull/122)) byte-for-byte.

## Testing

`tests/test_causal_trees.py`, run against a real install of each version:

- **scikit-learn 1.7.0** (shim is a no-op): 20 passed
- **scikit-learn 1.9.0** (shim active): 20 passed — previously 18 passed + 2 xfailed; the two `test_unbiased_sampling_error[*-1]` cases now pass

## Note on scope (temporary shim)

The shim mutates `forestci.forestci` module globals for the duration of the call (restored in `finally`) and is therefore not thread-safe; `calculate_error()` is a single-threaded post-hoc call. It is intentionally throwaway: once [forest-confidence-interval#122](https://github.com/scikit-learn-contrib/forest-confidence-interval/pull/122) ships in a release, we should bump the `forestci==0.6` pin to it (adapting to forestci 0.7's `random_forest_error(forest, X_train_shape, ...)` API change), then delete `_forestci_sklearn19_compat` and its wrapper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
