### PR TITLE
Make Cython line tracing opt-in to keep release wheels fast

### DIFF
--- a/causalml/inference/tree/_tree/_criterion.pxd
+++ b/causalml/inference/tree/_tree/_criterion.pxd
@@ -11,7 +11,6 @@
 # cython: boundscheck=False
 # cython: wraparound=False
 # cython: language_level=3
-# cython: linetrace=True
 
 # See _criterion.pyx for implementation details.
 from ._typedefs cimport float64_t, int8_t, int32_t, intp_t

--- a/causalml/inference/tree/_tree/_criterion.pyx
+++ b/causalml/inference/tree/_tree/_criterion.pyx
@@ -16,7 +16,6 @@
 # cython: boundscheck=False
 # cython: wraparound=False
 # cython: language_level=3
-# cython: linetrace=True
 
 from libc.string cimport memcpy
 from libc.string cimport memset

--- a/causalml/inference/tree/_tree/_splitter.pxd
+++ b/causalml/inference/tree/_tree/_splitter.pxd
@@ -12,7 +12,6 @@
 # cython: boundscheck=False
 # cython: wraparound=False
 # cython: language_level=3
-# cython: linetrace=True
 
 # See _splitter.pyx for details.
 from ._criterion cimport Criterion

--- a/causalml/inference/tree/_tree/_splitter.pyx
+++ b/causalml/inference/tree/_tree/_splitter.pyx
@@ -15,7 +15,6 @@
 # cython: boundscheck=False
 # cython: wraparound=False
 # cython: language_level=3
-# cython: linetrace=True
 
 from cython cimport final
 from libc.math cimport isnan

--- a/causalml/inference/tree/_tree/_tree.pxd
+++ b/causalml/inference/tree/_tree/_tree.pxd
@@ -13,7 +13,6 @@
 # cython: boundscheck=False
 # cython: wraparound=False
 # cython: language_level=3
-# cython: linetrace=True
 
 # See _tree.pyx for details.
 

--- a/causalml/inference/tree/_tree/_tree.pyx
+++ b/causalml/inference/tree/_tree/_tree.pyx
@@ -17,7 +17,6 @@
 # cython: boundscheck=False
 # cython: wraparound=False
 # cython: language_level=3
-# cython: linetrace=True
 
 from cpython cimport Py_INCREF, PyObject, PyTypeObject
 

--- a/causalml/inference/tree/_tree/_utils.pxd
+++ b/causalml/inference/tree/_tree/_utils.pxd
@@ -11,7 +11,6 @@
 # cython: boundscheck=False
 # cython: wraparound=False
 # cython: language_level=3
-# cython: linetrace=True
 
 # See _utils.pyx for details.
 

--- a/causalml/inference/tree/causal/_builder.pxd
+++ b/causalml/inference/tree/causal/_builder.pxd
@@ -2,7 +2,6 @@
 # cython: boundscheck=False
 # cython: wraparound=False
 # cython: language_level=3
-# cython: linetrace=True
 
 from .._tree._tree cimport Node, Tree, TreeBuilder
 from .._tree._splitter cimport Splitter, SplitRecord

--- a/causalml/inference/tree/causal/_builder.pyx
+++ b/causalml/inference/tree/causal/_builder.pyx
@@ -3,7 +3,6 @@
 # cython: boundscheck=False
 # cython: wraparound=False
 # cython: language_level=3
-# cython: linetrace=True
 
 
 from libc.stdint cimport INTPTR_MAX

--- a/causalml/inference/tree/causal/_criterion.pxd
+++ b/causalml/inference/tree/causal/_criterion.pxd
@@ -2,7 +2,6 @@
 # cython: boundscheck=False
 # cython: wraparound=False
 # cython: language_level=3
-# cython: linetrace=True
 # distutils: language = c++
 
 from libc.math cimport fabs

--- a/causalml/inference/tree/causal/_criterion.pyx
+++ b/causalml/inference/tree/causal/_criterion.pyx
@@ -2,7 +2,6 @@
 # cython: boundscheck=False
 # cython: wraparound=False
 # cython: language_level=3
-# cython: linetrace=True
 
 
 cdef int32_t CONTROL_GROUP_IDX = 0

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,15 @@ cython_modules = [
 ]
 # fmt: on
 
+# Cython line tracing is opt-in via the CYTHON_TRACE env var so that coverage
+# builds keep instrumentation while release wheels stay uninstrumented (and fast).
+# Hardcoding `# cython: linetrace=True` in the .pyx files would otherwise leak the
+# tracing hooks into published wheels, crippling nogil tree-building performance.
+linetrace = os.environ.get("CYTHON_TRACE", "0") not in ("0", "", "false", "False")
+define_macros = (
+    [("CYTHON_TRACE", "1"), ("CYTHON_TRACE_NOGIL", "1")] if linetrace else []
+)
+
 extensions = [
     Extension(
         name,
@@ -37,6 +46,7 @@ extensions = [
         libraries=[],
         include_dirs=[np.get_include()],
         extra_compile_args=["-O3"],
+        define_macros=define_macros,
     )
     for name, source in cython_modules
 ]
@@ -51,7 +61,12 @@ else:
 
 setup(
     packages=packages,
-    ext_modules=cythonize(extensions, annotate=True, nthreads=nthreads),
+    ext_modules=cythonize(
+        extensions,
+        annotate=True,
+        nthreads=nthreads,
+        compiler_directives={"linetrace": linetrace},
+    ),
     include_dirs=[np.get_include()],
     setup_requires=[
         "cython",


### PR DESCRIPTION
## Proposed changes

Fixes #913.

The 5 tree Cython sources hardcode # cython: linetrace=True (in the .pyx files and their .pxd headers), which compiles Cython's profiling hooks into the released wheels: on CPython the generated C sets CYTHON_PROFILE=1, inserting __Pyx_TraceCall/__Pyx_TraceSetupAndCall into the nogil tree-building loop. Those hooks take the GIL, so fitting CausalRandomForestRegressor with prefer="threads" serializes the workers and raising n_jobs makes it slower. (Line tracing, CYTHON_TRACE, would also need CYTHON_TRACE_NOGIL=1, which isn't set — the profiling path alone is enough.)

Confirmed by building from source and toggling only this one directive (same Cython, same machine): single-threaded fit 29.4s → 4.1s, n_jobs=4 190.9s → 1.7s. Numerical output unchanged (downstream T-Learner Qini matched to 6 d.p.); full suite passes.

The fix removes the directive from the .pyx/.pxd files and makes it opt-in via the CYTHON_TRACE env var, so coverage builds can still enable it.

## Types of changes

What types of changes does your code introduce to **CausalML**?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/uber/causalml/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/uber/causalml)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc. This PR template is adopted from [appium](https://github.com/appium/appium).
