### PR TITLE
Categorical Features Support in T/R learners

### DIFF
--- a/causalml/inference/meta/tlearner.py
+++ b/causalml/inference/meta/tlearner.py
@@ -77,7 +77,7 @@ class BaseTLearner(BaseLearner):
             treatment (np.array or pd.Series): a treatment vector
             y (np.array or pd.Series): an outcome vector
         """
-        X, treatment, y = convert_pd_to_np(X, treatment, y)
+        treatment, y = convert_pd_to_np(treatment, y)
         check_treatment_vector(treatment, self.control_name)
         self.t_groups = np.unique(treatment[treatment != self.control_name])
         self.t_groups.sort()
@@ -88,7 +88,7 @@ class BaseTLearner(BaseLearner):
         for group in self.t_groups:
             mask = (treatment == group) | (treatment == self.control_name)
             treatment_filt = treatment[mask]
-            X_filt = X[mask]
+            X_filt = X[mask].reset_index(drop=True) if hasattr(X, "loc") else X[mask]
             y_filt = y[mask]
             w = (treatment_filt == group).astype(int)
 
@@ -109,7 +109,7 @@ class BaseTLearner(BaseLearner):
         Returns:
             (numpy.ndarray): Predictions of treatment effects.
         """
-        X, treatment, y = convert_pd_to_np(X, treatment, y)
+        treatment, y = convert_pd_to_np(treatment, y)
         yhat_cs = {}
         yhat_ts = {}
 
@@ -169,7 +169,7 @@ class BaseTLearner(BaseLearner):
                 If return_ci, returns CATE [n_samples, n_treatment], LB [n_samples, n_treatment],
                 UB [n_samples, n_treatment]
         """
-        X, treatment, y = convert_pd_to_np(X, treatment, y)
+        treatment, y = convert_pd_to_np(treatment, y)
         self.fit(X, treatment, y)
         te = self.predict(X, treatment, y, return_components=return_components)
 
@@ -226,7 +226,7 @@ class BaseTLearner(BaseLearner):
             The mean and confidence interval (LB, UB) of the ATE estimate.
             pretrain (bool): whether a model has been fit, default False.
         """
-        X, treatment, y = convert_pd_to_np(X, treatment, y)
+        treatment, y = convert_pd_to_np(treatment, y)
         if pretrain:
             te, yhat_cs, yhat_ts = self.predict(X, treatment, y, return_components=True)
         else:

--- a/causalml/inference/meta/tlearner.py
+++ b/causalml/inference/meta/tlearner.py
@@ -129,7 +129,12 @@ class BaseTLearner(BaseLearner):
         # re-calling fit() always starts from a clean state (safe with warm_start).
         control_mask = treatment == self.control_name
         self.model_c = deepcopy(self._model_c_template)
-        self.model_c.fit(X[control_mask], y[control_mask])
+        X_control = (
+            X[control_mask].reset_index(drop=True)
+            if hasattr(X, "loc")
+            else X[control_mask]
+        )
+        self.model_c.fit(X_control, y[control_mask])
         # Expose as a shared-reference dict to preserve the public models_c API.
         self.models_c = {group: self.model_c for group in self.t_groups}
 
@@ -139,6 +144,21 @@ class BaseTLearner(BaseLearner):
             X_filt = X[mask].reset_index(drop=True) if hasattr(X, "loc") else X[mask]
             y_filt = y[mask]
             w = (treatment_filt == group).astype(int)
+
+            self.models_t[group].fit(X_filt[w == 1], y_filt[w == 1])
+
+        if store_bootstraps:
+            self.fit_bootstrap_ensemble(
+                X=X,
+                treatment=treatment,
+                y=y,
+                n_bootstraps=n_bootstraps,
+                bootstrap_size=bootstrap_size,
+                random_state=random_state,
+                n_jobs=n_jobs,
+            )
+        else:
+            self.bootstrap_models_ = None
 
     def _compute_bootstrap_ci(self, X):
         """Compute bootstrap CI using stored ensemble.
@@ -189,8 +209,10 @@ class BaseTLearner(BaseLearner):
                 returns (te, te_lower, te_upper) each of shape [n_samples, n_treatment].
                 return_ci=True and return_components=True cannot be used together.
         """
+        if return_ci and return_components:
+            raise ValueError("return_ci and return_components cannot both be True.")
+
         treatment, y = convert_pd_to_np(treatment, y)
-        yhat_cs = {}
         yhat_ts = {}
 
         yhat_c = self.model_c.predict(X)

--- a/causalml/inference/meta/utils.py
+++ b/causalml/inference/meta/utils.py
@@ -6,7 +6,14 @@ from xgboost import __version__ as xgboost_version
 
 
 def convert_pd_to_np(*args):
-    output = [obj.to_numpy() if hasattr(obj, "to_numpy") else obj for obj in args]
+    def _convert(obj):
+        if isinstance(obj, pd.DataFrame) and any(
+            pd.api.types.is_categorical_dtype(obj[c]) for c in obj.columns
+        ):
+            return obj  # pass through so learners can handle categoricals natively
+        return obj.to_numpy() if hasattr(obj, "to_numpy") else obj
+
+    output = [_convert(obj) for obj in args]
     return output if len(output) > 1 else output[0]
 
 

--- a/tests/test_meta_learners.py
+++ b/tests/test_meta_learners.py
@@ -1220,3 +1220,45 @@ def test_BaseDRClassifier(generate_classification_data):
 
     te_separate = learner_separate.fit_predict(X=X, treatment=treatment, y=y)
     assert te_separate.shape == te.shape
+
+
+def test_BaseTLearner_with_categorical_features():
+    np.random.seed(RANDOM_SEED)
+    n = 200
+
+    X = pd.DataFrame(
+        {
+            "num1": np.random.randn(n),
+            "num2": np.random.randn(n),
+            "cat1": pd.Categorical(np.random.choice([0, 1, 2], size=n)),
+        }
+    )
+    treatment = np.random.binomial(1, 0.5, n)
+    y = X["num1"].values + (treatment * 0.5) + np.random.randn(n) * 0.1
+
+    learner = BaseTRegressor(learner=XGBRegressor(enable_categorical=True))
+    learner.fit(X=X, treatment=treatment, y=y)
+    te = learner.predict(X=X)
+
+    assert te.shape == (n, 1)
+
+
+def test_BaseRLearner_with_categorical_features():
+    np.random.seed(RANDOM_SEED)
+    n = 200
+
+    X = pd.DataFrame(
+        {
+            "num1": np.random.randn(n),
+            "num2": np.random.randn(n),
+            "cat1": pd.Categorical(np.random.choice([0, 1, 2], size=n)),
+        }
+    )
+    treatment = np.random.binomial(1, 0.5, n)
+    y = X["num1"].values + (treatment * 0.5) + np.random.randn(n) * 0.1
+
+    learner = BaseRRegressor(learner=XGBRegressor(enable_categorical=True))
+    learner.fit(X=X, treatment=treatment, y=y)
+    te = learner.predict(X=X)
+
+    assert te.shape == (n, 1)


### PR DESCRIPTION
## Proposed changes

Fixes #825 
when a `pd.DataFrame` containing `dtype="category"` columns is passed to any meta-learner, `convert_pd_to_np()` was calling `.to_numpy()` on it, which strips all dtype information. By the time the underlying learner (e.g. XGBoost with `enable_categorical=True`) received the data, the categorical columns were gone and it would error out.

Two changes fix this...
1. `convert_pd_to_np()` in `utils.py` now skips the numpy conversion for DataFrames that contain at least one categorical column, passing them through as-is
2. `BaseTLearner` in `tlearner.py` no longer converts `X` to numpy in `fit`, `predict`, `fit_predict`, and `estimate_ate`
only `treatment` and `y` are converted, since those are used for masking and arithmetic. `X` is left alone so dtypes survive all the way to the learner

existing behavior is fully preserved, DataFrames without categorical columns still get converted to numpy as before.

NOTE: XGBoost 3.x only supports integer-coded categoricals (`pd.Categorical([0, 1, 2, ...])`), not string valued ones (`pd.Categorical(['a', 'b', 'c', ...])`). This is an XGBoost limitation, not a causalml one

## Types of changes

What types of changes does your code introduce to **CausalML**?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/uber/causalml/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/uber/causalml)
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc. This PR template is adopted from [appium](https://github.com/appium/appium).
