### PR TITLE
docs: document JAX backend for DragonNet

### DIFF
--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -15,6 +15,7 @@ Follow the below links for an approximate ordering of example tutorials from int
     examples/feature_interpretations_example
     examples/validation_with_tmle
     examples/dragonnet_example
+    examples/dragonnet_jax_vs_tf
     examples/iv_nlsym_synthetic_data
     examples/sensitivity_example_with_synthetic_data
     examples/counterfactual_unit_selection

--- a/docs/examples/dragonnet_jax_vs_tf.ipynb
+++ b/docs/examples/dragonnet_jax_vs_tf.ipynb
@@ -18,7 +18,7 @@
    "id": "2613c834",
    "metadata": {},
    "source": [
-    "## Installation\n",
+    "## Setup\n",
     "\n",
     "**TF backend:**\n",
     "```\n",

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -4,7 +4,7 @@ Installation
 
 Installation with ``conda`` or ``pip`` is recommended.  Developers can follow the **Install from source** instructions below.  If building from source, consider doing so within a conda environment and then exporting the environment for reproducibility.
 
-To use models under the ``inference.tf`` or ``inference.torch`` module (e.g. ``DragonNet`` or ``CEVAE``), additional dependency of ``tensorflow`` or ``torch`` is required. For detailed instructions, see below.
+To use models under the ``inference.tf``, ``inference.torch`` or ``inference.jax`` module (e.g. ``DragonNet`` or ``CEVAE``), additional dependency of ``tensorflow``, ``torch`` or ``jax`` is required. For detailed instructions, see below.
 
 System Requirements
 -------------------
@@ -67,6 +67,13 @@ Install ``causalml`` with ``torch`` for ``CEVAE`` from ``PyPI``
 
     pip install causalml[torch]
 
+Install ``causalml`` with ``jax`` for ``DragonNet`` from ``PyPI``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. code-block:: bash
+
+    pip install causalml[jax]
+
 
 Install using `uv <https://github.com/astral-sh/uv/blob/main/README.md>`_
 ---------------------
@@ -89,6 +96,13 @@ Install ``causalml`` with ``torch`` for ``CEVAE`` using `uv <https://github.com/
 .. code-block:: bash
 
     uv add "causalml[torch]"
+
+Install ``causalml`` with ``jax`` for ``DragonNet`` using `uv <https://github.com/astral-sh/uv/blob/main/README.md>`_
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. code-block:: bash
+
+    uv add "causalml[jax]"
     
 
 
@@ -126,6 +140,12 @@ with ``torch`` for ``CEVAE``:
 
     pip install -e ".[torch]"
 
+with ``jax`` for ``DragonNet``:
+
+.. code-block:: bash
+
+    pip install -e ".[jax]"
+
 =======
 
 Windows
@@ -149,7 +169,7 @@ Run all tests with:
 
     pytest -vs tests/ --cov causalml/
 
-Add ``--runtf`` and/or ``--runtorch`` to run optional tensorflow/torch tests which will be skipped by default.
+Add ``--runtf``, ``--runtorch`` and/or ``--runjax`` to run optional tensorflow/torch/jax tests which will be skipped by default.
 
 You can also run tests via make:
 


### PR DESCRIPTION
## Proposed changes

Follow-up to #918 addressing the two documentation gaps flagged by @jeongyoonlee during review of the JAX/flax.nnx DragonNet backend.

## Types of changes

- [x] Documentation update (non-breaking change which adds documentation)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/uber/causalml/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/uber/causalml)
- [x] Lint and unit tests pass locally with my changes
- [x] I have added necessary documentation (if appropriate)

## Changes

- `docs/examples.rst`: add `examples/dragonnet_jax_vs_tf` to the toctree so Sphinx renders the JAX vs TF benchmark notebook (previously omitted, as noted by @jeongyoonlee).
- `docs/installation.rst`: document the `jax` extra alongside `tf`/`torch`:
  - intro paragraph now mentions `inference.jax`
  - `pip install causalml[jax]` (PyPI)
  - `uv add "causalml[jax]"` (uv)
  - `pip install -e ".[jax]"` (Install from source)
  - `--runjax` added to the Running Tests section
- `docs/examples/dragonnet_jax_vs_tf.ipynb`: rename the `## Installation` markdown heading to `## Setup` to avoid an `autosectionlabel` collision with `installation.rst` that the new toctree entry surfaces (the label `installation` was duplicated).

## Tests

No code changes (`.rst` + `.ipynb` markdown only), so no new tests are required. Verified the documentation build locally:

```bash
pip install -r docs/requirements.txt
sphinx-build -b html -D nbsphinx_execute=never docs/ docs/_build/html
```

```
python -m http.server 8000 --directory docs/_build/html
```

Result: build succeeds (exit 0). No new warnings introduced (870 vs 872 baseline warnings — the reduction comes from the heading rename removing a duplicate-label collision). The `dragonnet_jax_vs_tf` notebook now renders and is linked from the Examples page.

## Dependencies

None. No new dependencies are added; the `jax` extra already exists in `pyproject.toml` from #918.

## References

- Predecessor PR: #918 (Add JAX/flax.nnx backend for DragonNet)
- Review comment by @jeongyoonlee requesting these two doc follow-ups (toctree entry + `pip install causalml[jax]`).
- Agreed plan: handle in a separate follow-up PR dedicated to documentation.