### PR TITLE
Add CatBoost documentation and test coverage for Explainer

### DIFF
--- a/causalml/inference/meta/explainer.py
+++ b/causalml/inference/meta/explainer.py
@@ -47,7 +47,7 @@ class Explainer:
             X (np.matrix): a feature matrix
             tau (np.array): a treatment effect vector (estimated/actual)
             classes (dict): a mapping of treatment names to indices (used for indexing tau array)
-            model_tau (sklearn/lightgbm/xgboost model object): a model object
+            model_tau (sklearn/lightgbm/xgboost/catboost model object): a model object
             features (np.array): list/array of feature names. If None, an enumerated list will be used.
             normalize (bool): normalize by sum of importances if method=auto (defaults to True)
             test_size (float/int): if float, represents the proportion of the dataset to include in the test split.
@@ -79,12 +79,33 @@ class Explainer:
             self.create_feature_names()
             self.build_new_tau_models()
 
+    def _get_feature_importances(self, model):
+        """
+        Returns feature importances for supported tree-based estimators.
+
+        Supports:
+            - feature_importances_ (scikit-learn, LightGBM, XGBoost)
+            - get_feature_importance() (CatBoost)
+        """
+        if hasattr(model, "feature_importances_"):
+            return model.feature_importances_
+
+        if hasattr(model, "get_feature_importance"):
+            return model.get_feature_importance()
+
+        raise AttributeError(
+            "model_tau must expose feature importances via "
+            "`feature_importances_` or `get_feature_importance()` "
+            "(after fitting)."
+        )
+
     def check_conditions(self):
         """
         Checks for multiple conditions:
             - method is valid
             - X, tau, and classes are specified
-            - model_tau has feature_importances_ attribute after fitting
+            - model_tau exposes feature importances via feature_importances_ or
+              get_feature_importance() after fitting
         """
         assert self.method in VALID_METHODS, "Current supported methods: {}".format(
             ", ".join(VALID_METHODS)
@@ -97,10 +118,9 @@ class Explainer:
         model_test = deepcopy(self.model_tau)
         model_test.fit(
             [[0], [1]], [0, 1]
-        )  # Fit w/ dummy data to check for feature_importances_ below
-        assert hasattr(
-            model_test, "feature_importances_"
-        ), "model_tau must have the feature_importances_ method (after fitting)"
+        )  # Fit w/ dummy data to ensure feature importances are available
+
+        self._get_feature_importances(model_test)
 
     def create_feature_names(self):
         """
@@ -157,7 +177,9 @@ class Explainer:
         if self.r_learners is not None:
             self.models_tau = deepcopy(self.r_learners)
         for group, idx in self.classes.items():
-            importance_dict[group] = self.models_tau[group].feature_importances_
+            importance_dict[group] = self._get_feature_importances(
+                self.models_tau[group]
+            )
             if self.normalize:
                 importance_dict[group] = (
                     importance_dict[group] / importance_dict[group].sum()

--- a/causalml/inference/meta/explainer.py
+++ b/causalml/inference/meta/explainer.py
@@ -79,33 +79,12 @@ class Explainer:
             self.create_feature_names()
             self.build_new_tau_models()
 
-    def _get_feature_importances(self, model):
-        """
-        Returns feature importances for supported tree-based estimators.
-
-        Supports:
-            - feature_importances_ (scikit-learn, LightGBM, XGBoost)
-            - get_feature_importance() (CatBoost)
-        """
-        if hasattr(model, "feature_importances_"):
-            return model.feature_importances_
-
-        if hasattr(model, "get_feature_importance"):
-            return model.get_feature_importance()
-
-        raise AttributeError(
-            "model_tau must expose feature importances via "
-            "`feature_importances_` or `get_feature_importance()` "
-            "(after fitting)."
-        )
-
     def check_conditions(self):
         """
         Checks for multiple conditions:
             - method is valid
             - X, tau, and classes are specified
-            - model_tau exposes feature importances via feature_importances_ or
-              get_feature_importance() after fitting
+            - model_tau has feature_importances_ after fitting
         """
         assert self.method in VALID_METHODS, "Current supported methods: {}".format(
             ", ".join(VALID_METHODS)
@@ -120,7 +99,9 @@ class Explainer:
             [[0], [1]], [0, 1]
         )  # Fit w/ dummy data to ensure feature importances are available
 
-        self._get_feature_importances(model_test)
+        assert hasattr(
+            model_test, "feature_importances_"
+        ), "model_tau must have the feature_importances_ method (after fitting)"
 
     def create_feature_names(self):
         """
@@ -177,9 +158,7 @@ class Explainer:
         if self.r_learners is not None:
             self.models_tau = deepcopy(self.r_learners)
         for group, idx in self.classes.items():
-            importance_dict[group] = self._get_feature_importances(
-                self.models_tau[group]
-            )
+            importance_dict[group] = self.models_tau[group].feature_importances_
             if self.normalize:
                 importance_dict[group] = (
                     importance_dict[group] / importance_dict[group].sum()

--- a/tests/test_meta_learners.py
+++ b/tests/test_meta_learners.py
@@ -36,6 +36,7 @@ from causalml.inference.meta import TMLELearner
 from causalml.inference.meta import BaseDRLearner
 from causalml.inference.meta import BaseDRRegressor
 from causalml.inference.meta import BaseDRClassifier
+from causalml.inference.meta.explainer import Explainer
 from causalml.metrics import ape, auuc_score
 
 from .const import RANDOM_SEED, N_SAMPLE, ERROR_THRESHOLD, CONTROL_NAME, CONVERSION
@@ -638,6 +639,34 @@ def test_BaseRRegressor(generate_regression_data):
         normalize=True,
     )
     assert auuc["cate_p"] > 0.5
+
+
+def test_explainer_auto_importance_catboost(generate_regression_data):
+    catboost = pytest.importorskip("catboost")
+
+    y, X, treatment, tau, b, e = generate_regression_data()
+
+    model_tau = catboost.CatBoostRegressor(
+        iterations=10,
+        verbose=False,
+        random_seed=RANDOM_SEED,
+    )
+
+    explainer = Explainer(
+        method="auto",
+        control_name=CONTROL_NAME,
+        X=X,
+        tau=tau,
+        classes={CONTROL_NAME: 0},
+        model_tau=model_tau,
+    )
+
+    importance = explainer.get_importance()
+
+    assert len(importance) == 1
+    assert CONTROL_NAME in importance
+    assert isinstance(importance[CONTROL_NAME], pd.Series)
+    assert len(importance[CONTROL_NAME]) == X.shape[1]
 
 
 def test_BaseRLearner_without_p(generate_regression_data):


### PR DESCRIPTION
## Proposed Changes

this pr adds documentation and test coverage for using `CatBoostRegressor` as the `model_tau` estimator in the `Explainer` class when `method="auto"`

### what changed
- updated the `model_tau` docstring to mention catboost support
- added a regression test using `CatBoostRegressor`, guarded with `pytest.importorskip("catboost")`, to verify that `Explainer(method="auto")` works correctly and returns feature importances with the expected shape

### why
while investigating issue #826, i verified that current versions of catboost already expose the `feature_importances_` attribute after fitting, so `Explainer(method="auto")` works without any implementation changes
this pr adds documentation and a regression test to ensure catboost support remains covered and continues to work as expected

closes #826 

## Types of changes

What types of changes does your code introduce to **CausalML**?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/uber/causalml/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/uber/causalml)
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc. This PR template is adopted from [appium](https://github.com/appium/appium).
