### PR TITLE
Fix PyPI trusted publishing: add id-token: write to upload_all

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -58,6 +58,8 @@ jobs:
   upload_all:
     needs: [build_wheels, make_sdist]
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write  # required for PyPI trusted publishing (OIDC)
     if: github.event_name == 'release' && github.event.action == 'published'
     steps:
       - uses: actions/download-artifact@v7


### PR DESCRIPTION
## Fix PyPI trusted publishing (`id-token: write`)

The **v0.17.0** publish workflow [failed](https://github.com/uber/causalml/actions/runs/28697792319) at the `upload_all` step:

```
Trusted publishing exchange failure:
OpenID Connect token retrieval failed: missing or insufficient OIDC token permissions,
the ACTIONS_ID_TOKEN_REQUEST_TOKEN environment variable was unset
```

The `upload_all` job was missing `id-token: write`, which PyPI trusted publishing (OIDC) requires. #871 switched from an API token to trusted publishing but never added the permission, and v0.17.0 was the first release to actually exercise it — so all wheels built successfully but the PyPI upload failed (nothing was published).

This adds the job-level permission. After merge, the v0.17.0 release will be re-cut to re-trigger the publish.
