### PR TITLE
Improve SensitivityMSM robustness and test coverage

### DIFF
--- a/causalml/metrics/sensitivity.py
+++ b/causalml/metrics/sensitivity.py
@@ -255,18 +255,19 @@ class Sensitivity:
 
         return summary_df
 
-    # Learners whose fit_predict(return_components=True) does NOT return
-    # potential-outcome regressions (mu0, mu1). X-learner returns two CATE
-    # estimates from its tau models instead (xlearner.py); R-learner has no
-    # outcome-regression decomposition at all. Both are rejected explicitly
-    # rather than silently misinterpreted.
-    _UNSUPPORTED_POTENTIAL_OUTCOME_LEARNERS = (
-        "BaseXLearner",
-        "BaseXRegressor",
-        "BaseXClassifier",
-        "BaseRLearner",
-        "BaseRRegressor",
-        "BaseRClassifier",
+    # Learner families whose fit_predict(return_components=True)
+    # exposes potential-outcome regressions (mu0_hat, mu1_hat).
+    # Unknown learner types are rejected rather than assumed compatible.
+    _SUPPORTED_POTENTIAL_OUTCOME_LEARNERS = (
+        "BaseSLearner",
+        "BaseSRegressor",
+        "BaseSClassifier",
+        "BaseTLearner",
+        "BaseTRegressor",
+        "BaseTClassifier",
+        "BaseDRLearner",
+        "BaseDRRegressor",
+        "BaseDRClassifier",
     )
 
     def get_potential_outcome_predictions(self, X, p, treatment, y):
@@ -291,7 +292,7 @@ class Sensitivity:
         learner = self.learner
         learner_name = type(learner).__name__
 
-        if learner_name in self._UNSUPPORTED_POTENTIAL_OUTCOME_LEARNERS:
+        if learner_name not in self._SUPPORTED_POTENTIAL_OUTCOME_LEARNERS:
             raise NotImplementedError(
                 "SensitivityMSM does not support {} yet: it needs potential-"
                 "outcome regressions (mu0_hat, mu1_hat), which this learner's "
@@ -744,6 +745,11 @@ class SensitivityMSM(Sensitivity):
             (tuple of float): (ate_lower, ate_upper)
         """
         p_lower, p_upper = msm_propensity_bounds(p, gamma)
+
+        eps = np.finfo(float).eps
+        p_lower = np.clip(p_lower, eps, 1.0 - eps)
+        p_upper = np.clip(p_upper, eps, 1.0 - eps)
+
         resid_t = y - mu1_hat
         resid_c = y - mu0_hat
 

--- a/causalml/metrics/sensitivity.py
+++ b/causalml/metrics/sensitivity.py
@@ -4,12 +4,6 @@ import pandas as pd
 import matplotlib.pyplot as plt
 from importlib import import_module
 
-from causalml.inference.meta import (
-    BaseSLearner,
-    BaseTLearner,
-    BaseDRLearner,
-)
-
 logger = logging.getLogger("sensitivity")
 
 SUMMARY_COLS = ["Method", "ATE", "New ATE", "New ATE LB", "New ATE UB"]
@@ -286,14 +280,12 @@ class Sensitivity:
         """
         learner = self.learner
         learner_name = type(learner).__name__
+        mro_names = {cls.__name__ for cls in type(learner).__mro__}
 
-        if not isinstance(
-            learner,
-            (
-                BaseSLearner,
-                BaseTLearner,
-                BaseDRLearner,
-            ),
+        if not (
+            "BaseSLearner" in mro_names
+            or "BaseTLearner" in mro_names
+            or "BaseDRLearner" in mro_names
         ):
             raise NotImplementedError(
                 "SensitivityMSM does not support {} yet: it needs potential-"

--- a/causalml/metrics/sensitivity.py
+++ b/causalml/metrics/sensitivity.py
@@ -4,6 +4,12 @@ import pandas as pd
 import matplotlib.pyplot as plt
 from importlib import import_module
 
+from causalml.inference.meta import (
+    BaseSLearner,
+    BaseTLearner,
+    BaseDRLearner,
+)
+
 logger = logging.getLogger("sensitivity")
 
 SUMMARY_COLS = ["Method", "ATE", "New ATE", "New ATE LB", "New ATE UB"]
@@ -258,17 +264,6 @@ class Sensitivity:
     # Learner families whose fit_predict(return_components=True)
     # exposes potential-outcome regressions (mu0_hat, mu1_hat).
     # Unknown learner types are rejected rather than assumed compatible.
-    _SUPPORTED_POTENTIAL_OUTCOME_LEARNERS = (
-        "BaseSLearner",
-        "BaseSRegressor",
-        "BaseSClassifier",
-        "BaseTLearner",
-        "BaseTRegressor",
-        "BaseTClassifier",
-        "BaseDRLearner",
-        "BaseDRRegressor",
-        "BaseDRClassifier",
-    )
 
     def get_potential_outcome_predictions(self, X, p, treatment, y):
         """Return separate potential-outcome predictions mu1_hat, mu0_hat.
@@ -292,7 +287,14 @@ class Sensitivity:
         learner = self.learner
         learner_name = type(learner).__name__
 
-        if learner_name not in self._SUPPORTED_POTENTIAL_OUTCOME_LEARNERS:
+        if not isinstance(
+            learner,
+            (
+                BaseSLearner,
+                BaseTLearner,
+                BaseDRLearner,
+            ),
+        ):
             raise NotImplementedError(
                 "SensitivityMSM does not support {} yet: it needs potential-"
                 "outcome regressions (mu0_hat, mu1_hat), which this learner's "

--- a/tests/test_sensitivity.py
+++ b/tests/test_sensitivity.py
@@ -7,6 +7,7 @@ from causalml.dataset import synthetic_data
 from causalml.inference.meta import (
     BaseSLearner,
     BaseTLearner,
+    BaseDRLearner,
     XGBTRegressor,
     BaseXLearner,
     BaseRLearner,
@@ -28,7 +29,13 @@ from causalml.metrics.sensitivity import (
     alignment_att,
 )
 
-from .const import TREATMENT_COL, SCORE_COL, OUTCOME_COL, NUM_FEATURES
+from .const import (
+    TREATMENT_COL,
+    SCORE_COL,
+    OUTCOME_COL,
+    NUM_FEATURES,
+    RANDOM_SEED,
+)
 
 
 @pytest.mark.parametrize(
@@ -261,7 +268,16 @@ def test_alignment_att():
     assert y.shape == adj.shape
 
 
-def test_SensitivityMSM():
+@pytest.mark.parametrize(
+    "learner",
+    [
+        BaseSLearner(LinearRegression()),
+        BaseTLearner(LinearRegression()),
+        BaseDRLearner(LinearRegression()),
+    ],
+)
+def test_SensitivityMSM(learner):
+    np.random.seed(RANDOM_SEED)
     y, X, treatment, tau, b, e = synthetic_data(
         mode=1, n=100000, p=NUM_FEATURES, sigma=1.0
     )
@@ -271,7 +287,6 @@ def test_SensitivityMSM():
     df[OUTCOME_COL] = y
     df[SCORE_COL] = e
 
-    learner = BaseTLearner(LinearRegression())
     sens = SensitivityMSM(
         df=df,
         inference_features=INFERENCE_FEATURES,
@@ -298,6 +313,8 @@ def test_SensitivityMSM():
 
 
 def test_SensitivityMSM_unsupported_learner():
+    np.random.seed(RANDOM_SEED)
+
     y, X, treatment, tau, b, e = synthetic_data(
         mode=1, n=100000, p=NUM_FEATURES, sigma=1.0
     )

--- a/tests/test_sensitivity.py
+++ b/tests/test_sensitivity.py
@@ -274,6 +274,7 @@ def test_alignment_att():
         BaseSLearner(LinearRegression()),
         BaseTLearner(LinearRegression()),
         BaseDRLearner(LinearRegression()),
+        XGBTRegressor(),
     ],
 )
 def test_SensitivityMSM(learner):


### PR DESCRIPTION
## Proposed changes
follow ups on the review comments from #925 
This addresses several non-blocking follow-up suggestions from the review of the `SensitivityMSM` implementation.
changes focus on improving robustness, numerical stability, and test coverage without changing the public API or the underlying MSM estimation logic

Specifically,
- replaces the unsupported-learner blocklist with an explicit allowlist of supported learner families (S-, T-, and DR-learners), so unknown learner types fail safely instead of being treated as supported
- expands `test_SensitivityMSM` to cover S-, T-, and DR-learners instead of only the T-learner
- makes the MSM tests deterministic by seeding the synthetic data generation using `RANDOM_SEED`
- clips propensity bounds before division in the MSM bound computation to avoid numerical issues when propensity estimates are extremely close to 0 or 1

The documentation wording regarding the theoretical sharpness of the bound and the minor double-fit optimization are intentionally left for future work, as discussed in the previous review

## Types of changes

What types of changes does your code introduce to **CausalML**?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/uber/causalml/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/uber/causalml)
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc. This PR template is adopted from [appium](https://github.com/appium/appium).
