### PR TITLE
Fix NearestNeighborMatch crash when the control pool runs below `ratio`

### DIFF
--- a/causalml/match.py
+++ b/causalml/match.py
@@ -206,8 +206,17 @@ class NearestNeighborMatch:
                     match_to.loc[match_to.unmatched, score_col]
                     - match_from.loc[from_idx, score_col]
                 )
-                # Gets self.ratio lowest dists
-                to_np_idx_list = np.argpartition(dist, self.ratio)[: self.ratio]
+                # Stop early once the control pool is exhausted; otherwise
+                # np.argpartition below would be called on an empty array.
+                if len(dist) == 0:
+                    break
+                # Gets up to self.ratio lowest dists. Cap the partition index at
+                # the last available position so argpartition does not raise
+                # "kth out of bounds" when fewer than self.ratio controls remain
+                # (e.g. balanced 1:1 matching, where the final treatment unit
+                # sees a single unmatched control).
+                kth = min(self.ratio, len(dist) - 1)
+                to_np_idx_list = np.argpartition(dist, kth)[: self.ratio]
                 to_idx_list = dist.index[to_np_idx_list]
                 for i, to_idx in enumerate(to_idx_list):
                     if dist[to_idx] <= sdcal:

--- a/tests/test_match.py
+++ b/tests/test_match.py
@@ -78,6 +78,44 @@ def test_nearest_neighbor_match_control_to_treatment(generate_unmatched_data):
     assert 2 * sum(matched[TREATMENT_COL] == 0) == sum(matched[TREATMENT_COL] != 0)
 
 
+def test_nearest_neighbor_match_exhausts_control_pool():
+    """Matching without replacement should not crash when the pool of
+    unmatched controls shrinks below `ratio` during the loop.
+
+    With a balanced 1:1 dataset the last treatment unit sees a single
+    remaining control, which previously made np.argpartition raise
+    "kth out of bounds". See match.py::NearestNeighborMatch.match.
+    """
+    df = pd.DataFrame(
+        {
+            SCORE_COL: [0.10, 0.40, 0.80, 0.12, 0.42, 0.83],
+            TREATMENT_COL: [1, 1, 1, 0, 0, 0],
+        }
+    )
+
+    psm = NearestNeighborMatch(
+        replace=False, ratio=1, shuffle=False, random_state=RANDOM_SEED
+    )
+    matched = psm.match(data=df, treatment_col=TREATMENT_COL, score_cols=[SCORE_COL])
+
+    # All three balanced pairs are recovered.
+    assert sum(matched[TREATMENT_COL] == 1) == 3
+    assert sum(matched[TREATMENT_COL] == 0) == 3
+
+    # More treatment than control: matching stops once controls run out
+    # instead of raising.
+    df_scarce = pd.DataFrame(
+        {
+            SCORE_COL: [0.10, 0.40, 0.80, 0.90, 0.12, 0.42],
+            TREATMENT_COL: [1, 1, 1, 1, 0, 0],
+        }
+    )
+    matched_scarce = psm.match(
+        data=df_scarce, treatment_col=TREATMENT_COL, score_cols=[SCORE_COL]
+    )
+    assert sum(matched_scarce[TREATMENT_COL] == 0) == 2
+
+
 def test_match_optimizer(generate_unmatched_data):
     df, features = generate_unmatched_data()
 


### PR DESCRIPTION
## Summary

`NearestNeighborMatch.match()` with `replace=False` crashes on datasets where the pool of still-unmatched controls shrinks to `ratio` or fewer units. It calls `np.argpartition(dist, self.ratio)` on the remaining controls, and once that pool holds `ratio` or fewer elements argpartition raises `ValueError: kth(=...) out of bounds`. A balanced 1:1 dataset hits this on the very last treatment unit, so plain 1:1 matching without replacement fails on any balanced (or control-scarce) input.

The fix caps the partition index at the last available position and stops early once no unmatched controls remain. The abundant-control path is untouched, so existing behavior and the current tests are unchanged.

## Test plan

- Added a regression test in `tests/test_match.py` covering the balanced 1:1 case (previously raised `kth out of bounds`) and the control-scarce case.
- `pytest tests/test_match.py` passes locally.
