### PR TITLE
Use custom propensity_learner on R-learner's first fit

### DIFF
--- a/causalml/inference/meta/rlearner.py
+++ b/causalml/inference/meta/rlearner.py
@@ -115,6 +115,12 @@ class BaseRLearner(BaseLearner):
         self.t_groups = np.unique(treatment_np[treatment_np != self.control_name])
         self.t_groups.sort()
 
+        # Resolve model_p before fitting propensity models so a user-supplied
+        # propensity_learner is honored on the first fit. _set_propensity_models
+        # reads self.model_p, so setting it afterwards meant the first fit of a
+        # fresh object silently fell back to the default ElasticNet.
+        self.model_p = self.propensity_learner
+
         if p is None:
             self._set_propensity_models(X=X, treatment=treatment_np, y=y_np)
             p = self.propensity
@@ -134,7 +140,6 @@ class BaseRLearner(BaseLearner):
             if self.effect_learner is not None
             else deepcopy(self.learner)
         )
-        self.model_p = self.propensity_learner
         # Build CV splitter from stored n_fold / random_state.
         self.cv = KFold(
             n_splits=self.n_fold, shuffle=True, random_state=self.random_state
@@ -516,6 +521,10 @@ class BaseRClassifier(BaseRLearner):
         self.t_groups = np.unique(treatment_np[treatment_np != self.control_name])
         self.t_groups.sort()
 
+        # Set model_p before _set_propensity_models runs so a custom
+        # propensity_learner is used on the first fit (see BaseRLearner.fit).
+        self.model_p = self.propensity_learner
+
         if p is None:
             self._set_propensity_models(X=X, treatment=treatment_np, y=y_np)
             p = self.propensity
@@ -527,7 +536,6 @@ class BaseRClassifier(BaseRLearner):
         # Resolve base models from stored constructor args.
         self.model_mu = self.outcome_learner
         self.model_tau = self.effect_learner
-        self.model_p = self.propensity_learner
         self.cv = KFold(
             n_splits=self.n_fold, shuffle=True, random_state=self.random_state
         )
@@ -709,6 +717,10 @@ class XGBRRegressor(BaseRRegressor):
         self.t_groups = np.unique(treatment_np[treatment_np != self.control_name])
         self.t_groups.sort()
 
+        # Set model_p before _set_propensity_models runs so a custom
+        # propensity_learner is used on the first fit (see BaseRLearner.fit).
+        self.model_p = self.propensity_learner
+
         if p is None:
             self._set_propensity_models(X=X, treatment=treatment_np, y=y_np)
             p = self.propensity
@@ -743,7 +755,6 @@ class XGBRRegressor(BaseRRegressor):
 
         self.model_mu = outcome_learner
         self.model_tau = effect_learner
-        self.model_p = self.propensity_learner
         self.cv = KFold(
             n_splits=self.n_fold, shuffle=True, random_state=self.random_state
         )

--- a/tests/test_meta_learners.py
+++ b/tests/test_meta_learners.py
@@ -600,6 +600,30 @@ def test_BaseRLearner(generate_regression_data):
     )  # might need to look into higher ape
 
 
+def test_BaseRLearner_uses_custom_propensity_learner_on_first_fit(
+    generate_regression_data,
+):
+    # Regression test: a user-supplied propensity_learner must be used on the
+    # very first fit of a fresh object. Previously model_p was assigned after
+    # _set_propensity_models ran, so the first fit silently fell back to the
+    # default ElasticNet and only a second fit of the same object honored it.
+    from causalml.propensity import ElasticNetPropensityModel
+
+    class MarkerPropensityModel(ElasticNetPropensityModel):
+        pass
+
+    y, X, treatment, tau, b, e = generate_regression_data()
+
+    learner = BaseRLearner(
+        learner=XGBRegressor(),
+        propensity_learner=MarkerPropensityModel(),
+    )
+    learner.fit(X=X, treatment=treatment, y=y, p=None)
+
+    for group in learner.t_groups:
+        assert isinstance(learner.propensity_model[group], MarkerPropensityModel)
+
+
 def test_BaseRRegressor(generate_regression_data):
     y, X, treatment, tau, b, e = generate_regression_data()
 


### PR DESCRIPTION
## Proposed changes

The R-learner ignores a user-supplied `propensity_learner` on the first `fit()` of a fresh object. In each `fit()` override the line `self.model_p = self.propensity_learner` runs *after* `_set_propensity_models()`, but `_set_propensity_models` reads `self.model_p` (via `hasattr`) to decide whether to use the custom propensity model or fall back to the default `ElasticNetPropensityModel`. On a new object `model_p` doesn't exist yet, so the first fit quietly uses the default and the custom learner is dropped.

Because the attribute persists on the object, a second `fit()` of the same instance *does* pick up the custom learner, so the same call gives different nuisance estimates depending on fit order. The fix moves the `model_p` assignment ahead of the propensity-model fitting in all three affected paths (`BaseRLearner`, `BaseRClassifier`, `XGBRRegressor`).

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Test plan

- Added `test_BaseRLearner_uses_custom_propensity_learner_on_first_fit` in `tests/test_meta_learners.py`: it fits a fresh R-learner with a distinctive `ElasticNetPropensityModel` subclass and asserts the trained `propensity_model` is that subclass. It fails on `master` (default ElasticNet is used) and passes with this change.
- The R-learner test subset (`-k "RLearner or RRegressor or RClassifier"`, 21 tests) passes locally.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/uber/causalml/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/uber/causalml)
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
