### PR TITLE
Expose matched index pairs as NearestNeighborMatch.matched_indexes_ (#621)

### DIFF
--- a/causalml/match.py
+++ b/causalml/match.py
@@ -97,6 +97,19 @@ class NearestNeighborMatch:
             seed
         n_jobs (int): The number of parallel jobs to run for neighbors search.
             None means 1 unless in a joblib.parallel_backend context. -1 means using all processors
+
+    Fitted attributes (populated after :meth:`match`):
+        matched_indexes_ (pandas.DataFrame): two-column dataframe with the
+            ``(from, to)`` pairs of original data indices produced by the most
+            recent :meth:`match` call. ``from`` corresponds to the matching
+            source group (treatment if ``treatment_to_control`` else control);
+            ``to`` is the matched counterpart from the opposite group. Each row
+            is one matched pair, so with ``ratio > 1`` a single ``from`` index
+            can appear multiple times against distinct ``to`` indices. Useful
+            for joining matched pairs back to upstream metadata or auditing the
+            matching outcome (see uber/causalml#621). ``match_by_group`` calls
+            :meth:`match` once per group, so the attribute reflects the last
+            group processed.
     """
 
     def __init__(
@@ -179,10 +192,15 @@ class NearestNeighborMatch:
             match_from_scaled = pd.concat([match_from_scaled] * self.ratio, axis=0)
 
             cond = (distances / np.sqrt(len(score_cols))) < sdcal
+            # Capture the full (from, to) pair mapping before deduplicating the
+            # from-side, so ``matched_indexes_`` (set below) can expose every
+            # matched pair -- not just the unique from-indices.
+            from_pairs = np.array(match_from_scaled.loc[cond].index)
+            to_pairs = np.array(match_to_scaled.iloc[indices[cond]].index)
             # Deduplicate the indices of the treatment group
-            from_idx_matched = np.unique(match_from_scaled.loc[cond].index)
+            from_idx_matched = np.unique(from_pairs)
             # XXX: Should we deduplicate the indices of the control group too?
-            to_idx_matched = np.array(match_to_scaled.iloc[indices[cond]].index)
+            to_idx_matched = to_pairs
         else:
             assert len(score_cols) == 1, (
                 "Matching on multiple columns is only supported using the "
@@ -199,6 +217,12 @@ class NearestNeighborMatch:
 
             from_idx_matched = []
             to_idx_matched = []
+            # Track each accepted (from, to) pair so ``matched_indexes_`` can
+            # report the actual row-aligned pairing: ``from_idx_matched`` only
+            # records a from-index the first time it is accepted (``i == 0``),
+            # so it cannot be repeated to recover pairs under ``ratio > 1``.
+            from_pairs_list = []
+            to_pairs_list = []
             match_to["unmatched"] = True
 
             for from_idx in from_indices:
@@ -223,7 +247,22 @@ class NearestNeighborMatch:
                         if i == 0:
                             from_idx_matched.append(from_idx)
                         to_idx_matched.append(to_idx)
+                        from_pairs_list.append(from_idx)
+                        to_pairs_list.append(to_idx)
                         match_to.loc[to_idx, "unmatched"] = False
+
+        # Persist the (from, to) pair mapping so callers can join matched pairs
+        # back onto the original data without re-running the matching. See
+        # uber/causalml#621.
+        if self.replace:
+            self.matched_indexes_ = pd.DataFrame({"from": from_pairs, "to": to_pairs})
+        else:
+            self.matched_indexes_ = pd.DataFrame(
+                {
+                    "from": np.array(from_pairs_list),
+                    "to": np.array(to_pairs_list),
+                }
+            )
 
         return data.loc[
             np.concatenate([np.array(from_idx_matched), np.array(to_idx_matched)])

--- a/tests/test_match.py
+++ b/tests/test_match.py
@@ -78,6 +78,46 @@ def test_nearest_neighbor_match_control_to_treatment(generate_unmatched_data):
     assert 2 * sum(matched[TREATMENT_COL] == 0) == sum(matched[TREATMENT_COL] != 0)
 
 
+def test_nearest_neighbor_match_exposes_matched_indexes(generate_unmatched_data):
+    """Regression test for uber/causalml#621.
+
+    ``match()`` computes the (from, to) index pairs internally but previously
+    discarded them; only the joined dataframe was returned. This asserts the
+    pairs are now exposed as the fitted attribute ``matched_indexes_`` for both
+    the replacement and no-replacement paths, that the exposed indices are
+    consistent with the returned matched dataframe, and that with
+    ``replace=True, ratio=2`` the attribute captures the *pair* mapping (a
+    single ``from`` index paired against multiple ``to`` indices) rather than
+    the deduplicated from-set.
+    """
+    df, features = generate_unmatched_data()
+
+    # Replacement path with ratio=2 -- exercises the NearestNeighbors branch.
+    psm = NearestNeighborMatch(replace=True, ratio=2, random_state=RANDOM_SEED)
+    matched = psm.match(data=df, treatment_col=TREATMENT_COL, score_cols=[SCORE_COL])
+
+    assert hasattr(psm, "matched_indexes_")
+    assert isinstance(psm.matched_indexes_, pd.DataFrame)
+    assert set(psm.matched_indexes_.columns) == {"from", "to"}
+    assert len(psm.matched_indexes_) > 0
+
+    # Every from/to in the pair table must appear in the matched dataframe.
+    matched_idx = set(matched.index)
+    assert set(psm.matched_indexes_["from"].unique()).issubset(matched_idx)
+    assert set(psm.matched_indexes_["to"].unique()).issubset(matched_idx)
+
+    # ratio=2, replace=True: at least one `from` should pair with two `to`s.
+    counts_per_from = psm.matched_indexes_["from"].value_counts()
+    assert (counts_per_from >= 2).any()
+
+    # No-replacement path (caliper loop) is also populated with the schema.
+    psm2 = NearestNeighborMatch(replace=False, ratio=1, random_state=RANDOM_SEED)
+    psm2.match(data=df, treatment_col=TREATMENT_COL, score_cols=[SCORE_COL])
+    assert hasattr(psm2, "matched_indexes_")
+    assert set(psm2.matched_indexes_.columns) == {"from", "to"}
+    assert len(psm2.matched_indexes_) > 0
+
+
 def test_nearest_neighbor_match_exhausts_control_pool():
     """Matching without replacement should not crash when the pool of
     unmatched controls shrinks below `ratio` during the loop.


### PR DESCRIPTION
## Proposed changes

Expose the matched index pairs computed inside `NearestNeighborMatch.match()` as a fitted attribute `matched_indexes_` — a two-column `pandas.DataFrame` (`from`, `to`) where each row is one matched pair. Useful for joining matched pairs back to upstream metadata or auditing the matching outcome without re-running the algorithm.

Previously these `(from, to)` pairs were computed and then discarded; only the joined DataFrame was returned. Under `ratio > 1` a single `from` index can appear multiple times against distinct `to` indices, so the attribute captures the pair mapping (not just the deduplicated from-set). Both the replacement (`NearestNeighbors`) and no-replacement (caliper-loop) paths are covered. `match_by_group` calls `match()` per group, so the attribute reflects the most recent call.

Fixes #621.

## Credit

Reimplements the work of **@jbbqqf** in #897, which is CLA-blocked and cannot be merged directly. Full credit to @jbbqqf for the original implementation and analysis; this PR re-lands the same feature against current `master` under a CLA-clean author.

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## Tests

- New `test_nearest_neighbor_match_exposes_matched_indexes` in `tests/test_match.py` covering both branches (schema, consistency with the returned matched frame, and pair-level granularity under `replace=True, ratio=2`). Fails on `master` with `AttributeError`, passes here.
- Full `tests/test_match.py` — 6 passed.
