### PR TITLE
Validate binary outcome in filter_LR / filter_D (#349)

### DIFF
--- a/causalml/feature_selection/filters.py
+++ b/causalml/feature_selection/filters.py
@@ -1,7 +1,11 @@
-"""
-Filter feature selection methods for uplift modeling
+"""Filter feature selection methods for uplift modeling.
 
-- Currently only for classification problem: the outcome variable of uplift model is binary.
+.. note::
+    The likelihood-ratio filter (:func:`FilterSelect.filter_LR`) and the
+    divergence-based filters (:func:`FilterSelect.filter_D` -- ``KL``, ``ED``,
+    ``Chi``) require a **binary** outcome (values in ``{0, 1}``) and raise
+    ``ValueError`` otherwise. Use the F-test filter
+    (:func:`FilterSelect.filter_F`) for a continuous outcome.
 """
 
 import numpy as np
@@ -9,6 +13,34 @@ import pandas as pd
 import statsmodels.api as sm
 from scipy import stats
 from sklearn.impute import SimpleImputer
+
+
+def _check_binary_outcome(y, y_name="y"):
+    """Validate that an outcome column is binary (values in ``{0, 1}``).
+
+    The likelihood-ratio (``filter_LR``) and divergence-based (``filter_D``:
+    KL / ED / Chi) filters model a binary conversion outcome. A continuous or
+    multi-class outcome silently yields meaningless statistics, so fail fast
+    with a clear message. Use ``filter_F`` (OLS F-test) for continuous outcomes.
+
+    Args:
+        y (array-like): outcome values.
+        y_name (str): outcome column name, used in the error message.
+
+    Raises:
+        ValueError: if ``y`` is empty or contains any value other than 0 or 1.
+    """
+    y = np.asarray(y)
+    if np.issubdtype(y.dtype, np.floating):
+        y = y[~np.isnan(y)]
+    unique_values = set(np.unique(y).tolist())
+    if not unique_values or not unique_values.issubset({0, 1}):
+        raise ValueError(
+            "Outcome column '{}' must be binary (values in {{0, 1}}) for this "
+            "filter, but found {}. Use filter_F for a continuous outcome.".format(
+                y_name, sorted(unique_values)[:10]
+            )
+        )
 
 
 class FilterSelect:
@@ -241,6 +273,8 @@ class FilterSelect:
         """
         if order not in [1, 2, 3]:
             raise Exception("ValueError: order argument only takes value 1,2,3.")
+
+        _check_binary_outcome(data[y_name], y_name)
 
         all_result = pd.DataFrame()
         for x_name_i in features:
@@ -549,6 +583,8 @@ class FilterSelect:
             all_result : pd.DataFrame
                 a data frame containing the feature importance statistics
         """
+
+        _check_binary_outcome(data[y_name], y_name)
 
         all_result = pd.DataFrame()
 

--- a/tests/test_feature_selection.py
+++ b/tests/test_feature_selection.py
@@ -1,4 +1,6 @@
 import numpy as np
+import pytest
+
 from causalml.feature_selection.filters import FilterSelect
 
 from .const import RANDOM_SEED, CONVERSION
@@ -62,3 +64,39 @@ def test_filter_kl(generate_classification_data):
     assert imp.shape[0] == len(X_names)
     assert imp["rank"].values[0] == 1
     assert imp["score"].values[0] >= imp["score"].values[1]
+
+
+@pytest.mark.parametrize("method", ["LR", "KL", "ED", "Chi"])
+def test_filter_rejects_non_binary_outcome(generate_classification_data, method):
+    """Regression test for uber/causalml#349.
+
+    The likelihood-ratio (``LR``) and divergence-based (``KL``/``ED``/``Chi``)
+    filters model a binary outcome. A multi-class (or continuous) outcome
+    previously produced meaningless statistics silently; it should now raise a
+    clear ``ValueError``.
+    """
+    np.random.seed(RANDOM_SEED)
+    df, X_names = generate_classification_data()
+    df = df.copy()
+    # Turn the binary conversion outcome into a 4-class outcome.
+    df[CONVERSION] = np.random.randint(0, 4, size=df.shape[0])
+
+    filter_obj = FilterSelect()
+    with pytest.raises(ValueError, match="binary"):
+        filter_obj.get_importance(
+            df, X_names, CONVERSION, method, treatment_group="treatment1"
+        )
+
+
+def test_filter_f_accepts_continuous_outcome(generate_classification_data):
+    """``filter_F`` (OLS F-test) tolerates a continuous outcome (uber/causalml#349)."""
+    np.random.seed(RANDOM_SEED)
+    df, X_names = generate_classification_data()
+    df = df.copy()
+    df[CONVERSION] = np.random.normal(size=df.shape[0])
+
+    filter_obj = FilterSelect()
+    f_imp = filter_obj.get_importance(
+        df, X_names, CONVERSION, "F", treatment_group="treatment1"
+    )
+    assert f_imp.shape[0] == len(X_names)


### PR DESCRIPTION
## Proposed changes

The likelihood-ratio filter (`filter_LR`) and the divergence-based filters (`filter_D` — `KL` / `ED` / `Chi`) model a **binary** conversion outcome. Passing a continuous or multi-class outcome previously produced meaningless statistics **silently**, with no error.

This adds a module-level `_check_binary_outcome()` helper, called at the top of `filter_LR` and `filter_D`, that raises a clear `ValueError` naming the offending outcome column and pointing to `filter_F` (the OLS F-test filter, which tolerates continuous outcomes). The module docstring now documents the binary-only constraint. `filter_F` is unchanged.

Fixes #349.

## Credit

Reimplements the work of **@jbbqqf** in #898, which is CLA-blocked and cannot be merged directly. Full credit to @jbbqqf for the original implementation and analysis; this PR re-lands the same feature against current `master` under a CLA-clean author.

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## Tests

- New parametrized `test_filter_rejects_non_binary_outcome` over `["LR", "KL", "ED", "Chi"]` (4-class outcome → `ValueError` matching "binary") and `test_filter_f_accepts_continuous_outcome` (continuous outcome still works through `filter_F`). The rejects tests fail on `master` (no error raised), pass here.
- Full `tests/test_feature_selection.py` — 8 passed.
