### PR TITLE
Stop logloss from clipping the caller's prediction array in place

### DIFF
--- a/causalml/metrics/classification.py
+++ b/causalml/metrics/classification.py
@@ -1,4 +1,5 @@
 import logging
+import numpy as np
 from sklearn.metrics import log_loss, roc_auc_score
 
 from .const import EPS
@@ -16,8 +17,7 @@ def logloss(y, p):
         bounded log loss error
     """
 
-    p[p < EPS] = EPS
-    p[p > 1 - EPS] = 1 - EPS
+    p = np.clip(p, EPS, 1 - EPS)
     return log_loss(y, p)
 
 

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,5 +1,7 @@
+import numpy as np
 import pandas as pd
 from numpy import isclose
+from causalml.metrics.classification import logloss
 from causalml.metrics.visualize import qini_score
 
 
@@ -26,3 +28,21 @@ def test_qini_score():
     # for each learner, its qini score should stay same no matter calling with another model or calling separately
     assert isclose(full_result["learner_1"], learner_1_result["learner_1"])
     assert isclose(full_result["learner_2"], learner_2_result["learner_2"])
+
+
+def test_logloss_does_not_modify_prediction():
+    y = np.array([0, 1, 0, 1, 1])
+    p = np.array([0.0, 1.0, 0.2, 0.8, 0.9])
+    p_before = p.copy()
+
+    logloss(y, p)
+
+    # logloss clips p into (0, 1) and must do so on a copy, not on the caller's array
+    assert np.array_equal(p, p_before)
+
+
+def test_logloss_clips_degenerate_predictions():
+    y = np.array([0, 1])
+    p = np.array([0.0, 1.0])
+
+    assert np.isfinite(logloss(y, p))


### PR DESCRIPTION
## Proposed changes

No filed issue for this one. I was reading through `causalml/metrics` and noticed `logloss` bounds `p` with `p[p < EPS] = EPS` and `p[p > 1 - EPS] = 1 - EPS`, which write straight into whatever array the caller handed in. So calling the exported metric edits your predictions as a side effect wherever a value sits at or past the bounds:

```python
>>> p = np.array([0.0, 1.0, 0.2, 0.8, 0.9])
>>> logloss(np.array([0, 1, 0, 1, 1]), p)
>>> p
array([1.e-15, 1.e+00, 2.e-01, 8.e-01, 9.e-01])
```

That bites if you reuse `p` for another metric afterwards, or just look at it. `classification_metrics` happens to pass `p[w]`, which is already a copy, so the internal path never showed it.

Switched to `np.clip`, which returns a new array and keeps the same bounds. I checked old vs new over 200 random inputs including 0.0/1.0 values, and the clipped arrays and the resulting `log_loss` came out identical, so this drops the side effect and nothing else.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/uber/causalml/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/uber/causalml)
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

Two tests in `tests/test_metrics.py`. `test_logloss_does_not_modify_prediction` fails on master and passes here. `test_logloss_clips_degenerate_predictions` passes either way, it's just there so the clipping doesn't get dropped later.

`black` is clean.
