### PR TITLE
Widen the propensity model's cross-validated C grid

### DIFF
--- a/causalml/propensity.py
+++ b/causalml/propensity.py
@@ -97,7 +97,7 @@ class LogisticRegressionPropensityModel(PropensityModel):
         kwargs = {
             "penalty": "elasticnet",
             "solver": "saga",
-            "Cs": np.logspace(1e-3, 1 - 1e-3, 4),
+            "Cs": 4,
             "l1_ratios": np.linspace(1e-3, 1 - 1e-3, 4),
             "cv": StratifiedKFold(
                 n_splits=(

--- a/tests/test_propensity.py
+++ b/tests/test_propensity.py
@@ -1,3 +1,5 @@
+import numpy as np
+
 from causalml.propensity import (
     ElasticNetPropensityModel,
     GradientBoostedPropensityModel,
@@ -24,6 +26,22 @@ def test_logistic_regression_propensity_model_model_kwargs(generate_regression_d
     pm = LogisticRegressionPropensityModel(random_state=123)
 
     assert pm.model.random_state == 123
+
+
+def test_logistic_regression_propensity_model_cs_grid():
+    # The cross-validated C grid should span both strong (C < 1) and weak
+    # (C > 1) regularization so that LogisticRegressionCV can actually tune
+    # the penalty. A grid confined to C >= 1 can never pick strong
+    # regularization.
+    rng = np.random.RandomState(RANDOM_SEED)
+    X = rng.normal(size=(200, 5))
+    w = (X[:, 0] + rng.normal(size=200) > 0).astype(int)
+
+    pm = ElasticNetPropensityModel(calibrate=False, random_state=RANDOM_SEED)
+    pm.fit(X, w)
+
+    grid = pm.model.Cs_
+    assert grid.min() < 1 < grid.max()
 
 
 def test_elasticnet_propensity_model(generate_regression_data):


### PR DESCRIPTION
## Proposed changes

No filed issue, I was reading through `causalml/propensity` and the `Cs` value on `LogisticRegressionPropensityModel` looked off:

```python
"Cs": np.logspace(1e-3, 1 - 1e-3, 4),
```

That expands to about `[1.00, 2.16, 4.64, 9.98]`, so every candidate is `C >= 1`. `LogisticRegressionCV` searches `C` (the inverse of regularization strength), so this grid only ever lets it choose weak regularization and it can never reach `C < 1`. The whole search sits inside a single order of magnitude on the weak side.

It reads like the `1e-3` / `1 - 1e-3` bounds got carried over from the `l1_ratios` line right below it (where a `[0, 1]` range is exactly right) and from `clip_bounds`. For `Cs` those numbers land in the exponent of `logspace`, which is what collapses the range.

I changed it to `Cs=4`, which hands the job back to `LogisticRegressionCV`: it builds its own log grid between `1e-4` and `1e4` and keeps four points. Fitted models now search across both strong and weak regularization. This does shift the chosen penalty on existing pipelines, but toward the range the CV was meant to cover.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/uber/causalml/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/uber/causalml)
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

Added `test_logistic_regression_propensity_model_cs_grid` in `tests/test_propensity.py`. It fits the model and asserts the resulting `model.Cs_` spans `min < 1 < max`. On master the grid is `[1.00, 2.16, 4.64, 9.98]` so it fails; with this change `Cs_` is `[1e-4, 4.6e-2, 21.5, 1e4]` and it passes. `black` is clean.

Happy to use an explicit grid like `np.logspace(-4, 4, 4)` instead if you'd rather keep it spelled out, or bump the point count.
