### PR TITLE
Fix ATE column filled with NaN in SensitivitySelectionBias.summary

### DIFF
--- a/causalml/metrics/sensitivity.py
+++ b/causalml/metrics/sensitivity.py
@@ -565,9 +565,9 @@ class SensitivitySelectionBias(Sensitivity):
         sensitivity_summary["Method"] = sensitivity_summary[
             "Method"
         ] + sensitivity_summary["rsqs"].round(5).astype(str)
-        sensitivity_summary["ATE"] = sensitivity_summary[
-            sensitivity_summary.alpha == 0
-        ]["New ATE"]
+        sensitivity_summary["ATE"] = sensitivity_summary.loc[
+            sensitivity_summary.alpha == 0, "New ATE"
+        ].values[0]
         return sensitivity_summary[SUMMARY_COLS]
 
     @staticmethod

--- a/tests/test_sensitivity.py
+++ b/tests/test_sensitivity.py
@@ -228,6 +228,50 @@ def test_SensitivitySelectionBias():
     sens.plot(lls_bias_alignment, ci=True)
 
 
+def test_SensitivitySelectionBias_summary_ate():
+    # summary() used to assign the alpha == 0 "New ATE" as a Series, so pandas
+    # aligned it on index and every row other than alpha == 0 came back NaN.
+    np.random.seed(RANDOM_SEED)
+
+    y, X, treatment, tau, b, e = synthetic_data(
+        mode=1, n=100000, p=NUM_FEATURES, sigma=1.0
+    )
+
+    INFERENCE_FEATURES = ["feature_" + str(i) for i in range(NUM_FEATURES)]
+    df = pd.DataFrame(X, columns=INFERENCE_FEATURES)
+    df[TREATMENT_COL] = treatment
+    df[OUTCOME_COL] = y
+    df[SCORE_COL] = e
+
+    learner = BaseXLearner(LinearRegression())
+    sens = SensitivitySelectionBias(
+        df,
+        INFERENCE_FEATURES,
+        p_col=SCORE_COL,
+        treatment_col=TREATMENT_COL,
+        outcome_col=OUTCOME_COL,
+        learner=learner,
+        confound="alignment",
+        alpha_range=None,
+    )
+
+    summary = sens.summary()
+
+    assert not summary["ATE"].isna().any()
+
+    # summary() drops the alpha column, but Method carries the alpha it was
+    # built from, so the alpha == 0 row is still identifiable.
+    alphas = (
+        summary["Method"]
+        .str.extract(r"alpha@(-?[\d.eE+-]+),", expand=False)
+        .astype(float)
+    )
+    baseline = summary.loc[alphas == 0, "New ATE"]
+    assert len(baseline) == 1
+
+    assert np.allclose(summary["ATE"], baseline.values[0])
+
+
 def test_one_sided():
     y, X, treatment, tau, b, e = synthetic_data(
         mode=1, n=100000, p=NUM_FEATURES, sigma=1.0


### PR DESCRIPTION
`SensitivitySelectionBias.summary()` builds the `ATE` column from a filtered slice:

    sensitivity_summary["ATE"] = sensitivity_summary[
        sensitivity_summary.alpha == 0
    ]["New ATE"]

The right side is a Series holding only the `alpha == 0` row, and it keeps that row's index label. Assigning it back to the full frame aligns on the index, so only the `alpha == 0` row keeps a value and every other row ends up NaN. The `ATE` column is meant to be the baseline (unconfounded) ATE shown next to `New ATE` at each confounding level, so it should be that one value on every row.

Pulling the scalar out and letting pandas broadcast it fixes the summary:

    sensitivity_summary["ATE"] = sensitivity_summary.loc[
        sensitivity_summary.alpha == 0, "New ATE"
    ].values[0]

Before, on a small synthetic run, 10 of 11 rows in the ATE column were NaN. After, the alpha=0 estimate shows on every row, which is what you want when comparing it against New ATE across the alpha range.

Existing SelectionBias/PlaceboTreatment/RandomCause sensitivity tests still pass. Glad to add a small regression check on the summary output if that's useful.