### PR TITLE
Kernel-backed uplift criteria (KL/ED/Chi) with legacy parity (#946)

### DIFF
--- a/causalml/inference/tree/_uplift/_criterion.pxd
+++ b/causalml/inference/tree/_uplift/_criterion.pxd
@@ -1,0 +1,16 @@
+# cython: cdivision=True
+# cython: boundscheck=False
+# cython: wraparound=False
+# cython: language_level=3
+# distutils: language = c++
+
+from .._tree._typedefs cimport float64_t
+from ..causal._criterion cimport CausalRegressionCriterion, NodeState
+
+
+cdef class UpliftClassificationCriterion(CausalRegressionCriterion):
+    # Divergence contribution of a single treatment-vs-control pair. Overridden
+    # by each concrete criterion (KL / ED / Chi).
+    cdef float64_t _pair_divergence(self, float64_t p_t, float64_t p_c) noexcept nogil
+    # Sum of pair divergences over all treatment groups for a node.
+    cdef float64_t _node_divergence(self, NodeState node) noexcept nogil

--- a/causalml/inference/tree/_uplift/_criterion.pyx
+++ b/causalml/inference/tree/_uplift/_criterion.pyx
@@ -1,0 +1,155 @@
+# cython: cdivision=True
+# cython: boundscheck=False
+# cython: wraparound=False
+# cython: language_level=3
+# distutils: language = c++
+
+"""Uplift classification split criteria on top of the shared ``_tree`` kernel.
+
+These criteria reuse the causal criterion's per-group state machine
+(:class:`NodeState` / :class:`NodeSplitState` in ``causal/_criterion.pyx``). For a
+binary uplift outcome encoded as the causal-style ``(n_samples, n_groups)``
+NaN-masked matrix (control at column 0), ``NodeState.outcome_mean(g)`` is exactly
+``P(Y=1 | T=g)`` -- which is all the KL / Euclidean / Chi-squared divergences need.
+
+Growth is driven entirely by ``impurity_improvement`` (the uplift split *gain*),
+following the ``TTest`` criterion pattern: ``node_impurity`` is a positive
+constant so the kernel builder's ``impurity <= EPSILON`` early-leaf never fires
+(an uplift node with zero treatment/control divergence must still be allowed to
+split), and the real work happens in ``children_impurity`` /
+``impurity_improvement``.
+
+Legacy references in ``uplift.pyx``: ``kl_divergence`` (line ~86),
+``evaluate_KL`` / ``evaluate_ED`` / ``evaluate_Chi`` (~1032-1184), and the split
+gain ``p * D_left + (1 - p) * D_right - D_node`` in ``growDecisionTreeFrom``
+(~2308-2316).
+"""
+
+from libc.math cimport log
+
+from .._tree._typedefs cimport int32_t
+
+
+# Matches ``max(0.1 ** 6, ...)`` in the legacy Chi-squared criterion and the
+# ``eps`` clamp in the legacy ``kl_divergence``.
+cdef float64_t EPS = 1e-6
+
+# Constant node impurity. Uplift trees are grown by maximizing the split gain in
+# ``impurity_improvement``; the node's own "impurity" carries no meaning, so we
+# return a fixed positive value purely to keep every node splittable (the kernel
+# ``DepthFirstTreeBuilder`` turns a node into a leaf when ``impurity <= EPSILON``,
+# which would wrongly stop growth at any node whose treatment and control
+# outcomes happen to coincide).
+cdef float64_t NODE_IMPURITY = 1.0
+
+
+cdef class UpliftClassificationCriterion(CausalRegressionCriterion):
+    """Base class for kernel-backed uplift split criteria."""
+
+    cdef float64_t _pair_divergence(self, float64_t p_t, float64_t p_c) noexcept nogil:
+        # Overridden by each concrete criterion.
+        return 0.0
+
+    cdef float64_t _node_divergence(self, NodeState node) noexcept nogil:
+        """Sum the treatment-vs-control divergence over all treatment groups.
+
+        Empty groups fall back to ``P(Y=1) = 0`` (mirrors the legacy
+        ``n_pos / n if n > 0 else 0`` guard used at split evaluation with
+        ``n_reg = 0`` / ``min_samples_treatment = 0``).
+        """
+        cdef float64_t p_c, p_t
+        cdef float64_t d = 0.0
+        cdef int32_t t
+
+        if node.count_1d[0] > 0:
+            p_c = node.y_sum_1d[0] / node.count_1d[0]
+        else:
+            p_c = 0.0
+
+        for t in range(1, self.n_outputs):
+            if node.count_1d[t] > 0:
+                p_t = node.y_sum_1d[t] / node.count_1d[t]
+            else:
+                p_t = 0.0
+            d += self._pair_divergence(p_t, p_c)
+        return d
+
+    cdef float64_t node_impurity(self) noexcept nogil:
+        return NODE_IMPURITY
+
+    cdef void children_impurity(
+        self,
+        float64_t * impurity_left,
+        float64_t * impurity_right,
+    ) noexcept nogil:
+        """Store the split gain in ``state.left.split_metric``.
+
+        gain = p * D_left + (1 - p) * D_right - D_node, where p is the fraction of
+        samples routed to the left child. ``impurity_left`` / ``impurity_right``
+        are set to the child divergences for interpretability only; the builder
+        reads the gain via :meth:`impurity_improvement`.
+        """
+        cdef float64_t p = self.weighted_n_left / self.weighted_n_node_samples
+        cdef float64_t d_node = self._node_divergence(self.state.node)
+        cdef float64_t d_left = self._node_divergence(self.state.left)
+        cdef float64_t d_right = self._node_divergence(self.state.right)
+
+        impurity_left[0] = d_left
+        impurity_right[0] = d_right
+        self.state.left.split_metric = p * d_left + (1.0 - p) * d_right - d_node
+
+    cdef float64_t impurity_improvement(
+        self,
+        float64_t impurity_parent,
+        float64_t impurity_left,
+        float64_t impurity_right,
+    ) noexcept nogil:
+        return self.state.left.split_metric
+
+    cdef float64_t proxy_impurity_improvement(self) noexcept nogil:
+        cdef float64_t impurity_left
+        cdef float64_t impurity_right
+        self.children_impurity(&impurity_left, &impurity_right)
+        return self.state.left.split_metric
+
+
+cdef class KLCriterion(UpliftClassificationCriterion):
+    """Kullback-Leibler divergence (legacy ``kl_divergence`` / ``evaluate_KL``)."""
+
+    cdef float64_t _pair_divergence(self, float64_t p_t, float64_t p_c) noexcept nogil:
+        cdef float64_t qk, s
+
+        if p_c == 0.0:
+            return 0.0
+
+        qk = p_c
+        if qk < EPS:
+            qk = EPS
+        elif qk > 1.0 - EPS:
+            qk = 1.0 - EPS
+
+        if p_t == 0.0:
+            s = -log(1.0 - qk)
+        elif p_t == 1.0:
+            s = -log(qk)
+        else:
+            s = p_t * log(p_t / qk) + (1.0 - p_t) * log((1.0 - p_t) / (1.0 - qk))
+        return s
+
+
+cdef class EDCriterion(UpliftClassificationCriterion):
+    """Euclidean distance (legacy ``evaluate_ED``)."""
+
+    cdef float64_t _pair_divergence(self, float64_t p_t, float64_t p_c) noexcept nogil:
+        cdef float64_t diff = p_t - p_c
+        return 2.0 * diff * diff
+
+
+cdef class ChiCriterion(UpliftClassificationCriterion):
+    """Chi-squared statistic (legacy ``evaluate_Chi``)."""
+
+    cdef float64_t _pair_divergence(self, float64_t p_t, float64_t p_c) noexcept nogil:
+        cdef float64_t diff_sq = (p_t - p_c) * (p_t - p_c)
+        cdef float64_t denom_pc = p_c if p_c > EPS else EPS
+        cdef float64_t denom_1_pc = (1.0 - p_c) if (1.0 - p_c) > EPS else EPS
+        return diff_sq / denom_pc + diff_sq / denom_1_pc

--- a/causalml/inference/tree/_uplift/_tree.py
+++ b/causalml/inference/tree/_uplift/_tree.py
@@ -1,0 +1,229 @@
+"""Kernel-backed base class for uplift decision trees (experimental).
+
+Mirrors ``causal/_tree.py`` but wires the shared ``_tree`` kernel to the uplift
+criteria and the *stock* kernel builders/splitters -- no uplift-specific
+regularization yet (``min_samples_treatment`` / ``n_reg`` land in a follow-up
+issue). This module is internal; it is not exported from ``tree/__init__.py``
+and the legacy ``UpliftTreeClassifier`` remains the public default.
+"""
+
+import numbers
+import warnings
+from math import ceil
+from typing import Union
+
+import numpy as np
+from scipy.sparse import issparse
+from sklearn.utils import check_random_state
+from sklearn.utils.validation import _check_sample_weight, validate_data
+
+from .._tree._classes import DTYPE, DOUBLE
+from .._tree._classes import SPARSE_SPLITTERS, DENSE_SPLITTERS
+from .._tree._classes import Tree, BaseDecisionTree
+from .._tree._splitter import Splitter
+from .._tree._tree import DepthFirstTreeBuilder, BestFirstTreeBuilder
+
+from ._criterion import KLCriterion, EDCriterion, ChiCriterion
+
+UPLIFT_TREE_CRITERIA = {
+    "KL": KLCriterion,
+    "ED": EDCriterion,
+    "Chi": ChiCriterion,
+}
+
+
+def get_check_y_params() -> dict:
+    """Prepares flags for sklearn 1.6+."""
+    return dict(ensure_2d=False, dtype=None, ensure_all_finite=False)
+
+
+class BaseUpliftDecisionTree(BaseDecisionTree):
+    """Base class for kernel-backed uplift trees.
+
+    Source: https://github.com/scikit-learn/scikit-learn/blob/main/sklearn/tree/_classes.py
+    (adapted, following ``causal/_tree.py``).
+    """
+
+    def _support_missing_values(self, X) -> bool:
+        return False
+
+    def fit(
+        self,
+        X: np.ndarray,
+        y: np.ndarray,
+        sample_weight: Union[np.ndarray, None] = None,
+        check_input: bool = True,
+    ):
+        random_state = check_random_state(self.random_state)
+
+        if self.ccp_alpha < 0.0:
+            raise ValueError("ccp_alpha must be greater than or equal to 0")
+
+        if check_input:
+            check_X_params = dict(dtype=DTYPE, accept_sparse="csc")
+            check_y_params = get_check_y_params()
+            X, y = validate_data(
+                self, X, y, validate_separately=(check_X_params, check_y_params)
+            )
+            if issparse(X):
+                X.sort_indices()
+                if X.indices.dtype != np.intc or X.indptr.dtype != np.intc:
+                    raise ValueError(
+                        "No support for np.int64 index based sparse matrices"
+                    )
+
+            if self.criterion not in UPLIFT_TREE_CRITERIA.keys():
+                raise ValueError(
+                    f"Only {list(UPLIFT_TREE_CRITERIA.keys())} criteria are supported"
+                )
+
+        n_samples, self.n_features_ = X.shape
+        self.n_features_in_ = self.n_features_
+
+        y = np.atleast_1d(y)
+
+        # n_outputs_ is the number of groups [control, treatment_1, ..., treatment_{n-1}]
+        self.n_outputs_ = y.shape[1]
+
+        if getattr(y, "dtype", None) != DOUBLE or not y.flags.contiguous:
+            y = np.ascontiguousarray(y, dtype=DOUBLE)
+
+        max_depth = np.iinfo(np.int32).max if self.max_depth is None else self.max_depth
+        max_leaf_nodes = -1 if self.max_leaf_nodes is None else self.max_leaf_nodes
+
+        if isinstance(self.min_samples_leaf, numbers.Integral):
+            if not 1 <= self.min_samples_leaf:
+                raise ValueError(
+                    "min_samples_leaf must be at least 1 "
+                    "or in (0, 0.5], got %s" % self.min_samples_leaf
+                )
+            min_samples_leaf = self.min_samples_leaf
+        else:  # float
+            if not 0.0 < self.min_samples_leaf <= 0.5:
+                raise ValueError(
+                    "min_samples_leaf must be at least 1 "
+                    "or in (0, 0.5], got %s" % self.min_samples_leaf
+                )
+            min_samples_leaf = int(ceil(self.min_samples_leaf * n_samples))
+
+        if isinstance(self.min_samples_split, numbers.Integral):
+            if not 2 <= self.min_samples_split:
+                raise ValueError(
+                    "min_samples_split must be an integer "
+                    "greater than 1 or a float in (0.0, 1.0]; "
+                    "got the integer %s" % self.min_samples_split
+                )
+            min_samples_split = self.min_samples_split
+        else:  # float
+            if not 0.0 < self.min_samples_split <= 1.0:
+                raise ValueError(
+                    "min_samples_split must be an integer "
+                    "greater than 1 or a float in (0.0, 1.0]; "
+                    "got the float %s" % self.min_samples_split
+                )
+            min_samples_split = int(ceil(self.min_samples_split * n_samples))
+            min_samples_split = max(2, min_samples_split)
+
+        min_samples_split = max(min_samples_split, 2 * min_samples_leaf)
+
+        if isinstance(self.max_features, str):
+            if self.max_features == "sqrt":
+                max_features = max(1, int(np.sqrt(self.n_features_)))
+            elif self.max_features == "log2":
+                max_features = max(1, int(np.log2(self.n_features_)))
+            else:
+                raise ValueError(
+                    "Invalid value for max_features. "
+                    "Allowed string values are 'sqrt' or 'log2'."
+                )
+        elif self.max_features is None:
+            max_features = self.n_features_
+        elif isinstance(self.max_features, numbers.Integral):
+            max_features = self.max_features
+        else:  # float
+            if self.max_features > 0.0:
+                max_features = max(1, int(self.max_features * self.n_features_))
+            else:
+                max_features = 0
+
+        self.max_features_ = max_features
+
+        if len(y) != n_samples:
+            raise ValueError(
+                "Number of labels=%d does not match "
+                "number of samples=%d" % (len(y), n_samples)
+            )
+        if not 0 <= self.min_weight_fraction_leaf <= 0.5:
+            raise ValueError("min_weight_fraction_leaf must in [0, 0.5]")
+        if max_depth <= 0:
+            raise ValueError("max_depth must be greater than zero. ")
+        if not (0 < max_features <= self.n_features_):
+            raise ValueError("max_features must be in (0, n_features]")
+        if not isinstance(max_leaf_nodes, numbers.Integral):
+            raise ValueError(
+                "max_leaf_nodes must be integral number but was %r" % max_leaf_nodes
+            )
+        if -1 < max_leaf_nodes < 2:
+            raise ValueError(
+                ("max_leaf_nodes {0} must be either None or larger than 1").format(
+                    max_leaf_nodes
+                )
+            )
+
+        if sample_weight is not None:
+            sample_weight = _check_sample_weight(sample_weight, X, dtype=DOUBLE)
+
+        if sample_weight is None:
+            min_weight_leaf = self.min_weight_fraction_leaf * n_samples
+        else:
+            min_weight_leaf = self.min_weight_fraction_leaf * np.sum(sample_weight)
+
+        # Build tree
+        criterion = self.criterion
+        if isinstance(criterion, str):
+            criterion = UPLIFT_TREE_CRITERIA[criterion](self.n_outputs_, n_samples)
+
+        SPLITTERS = SPARSE_SPLITTERS if issparse(X) else DENSE_SPLITTERS
+
+        splitter = self.splitter
+        if not isinstance(self.splitter, Splitter):
+            splitter = SPLITTERS[self.splitter](
+                criterion,
+                self.max_features_,
+                min_samples_leaf,
+                min_weight_leaf,
+                random_state,
+                monotonic_cst=None,
+            )
+            self.tree_ = Tree(
+                self.n_features_,
+                np.array([1] * self.n_outputs_, dtype=np.intp),
+                self.n_outputs_,
+            )
+
+        # Use BestFirst if max_leaf_nodes given; use DepthFirst otherwise
+        if max_leaf_nodes < 0:
+            builder = DepthFirstTreeBuilder(
+                splitter,
+                min_samples_split,
+                min_samples_leaf,
+                min_weight_leaf,
+                max_depth,
+                self.min_impurity_decrease,
+            )
+        else:
+            builder = BestFirstTreeBuilder(
+                splitter,
+                min_samples_split,
+                min_samples_leaf,
+                min_weight_leaf,
+                max_depth,
+                max_leaf_nodes,
+                self.min_impurity_decrease,
+            )
+        # First column of y is always the control group.
+        builder.build(self.tree_, X, y, sample_weight)
+
+        self._prune_tree()
+
+        return self

--- a/causalml/inference/tree/_uplift/uplifttree.py
+++ b/causalml/inference/tree/_uplift/uplifttree.py
@@ -1,0 +1,130 @@
+"""Experimental kernel-backed uplift tree classifier.
+
+Not part of the public API -- this exists to prove numerical parity of the
+kernel-backed KL / ED / Chi criteria against the legacy ``UpliftTreeClassifier``
+before the public classes are switched over. Regularization, normalization,
+honesty, pruning, and the forest are handled in later issues of the epic.
+"""
+
+from typing import Union
+
+import numpy as np
+from numpy import float32 as DTYPE
+from sklearn.utils import check_array
+
+from causalml.inference.meta.utils import check_treatment_vector
+
+from ._tree import BaseUpliftDecisionTree
+
+
+class _KernelUpliftTreeClassifier(BaseUpliftDecisionTree):
+    """A single uplift tree grown on the shared ``_tree`` Cython kernel."""
+
+    def __init__(
+        self,
+        *,
+        criterion: str = "KL",
+        control_name: Union[int, str] = "control",
+        max_depth: int = 3,
+        min_samples_leaf: int = 100,
+        min_samples_split: Union[int, float] = 2,
+        max_features: Union[int, float, str, None] = None,
+        min_weight_fraction_leaf: float = 0.0,
+        random_state: int = None,
+    ):
+        self.control_name = control_name
+        super().__init__(
+            criterion=criterion,
+            splitter="best",
+            max_depth=max_depth,
+            min_samples_split=min_samples_split,
+            min_samples_leaf=min_samples_leaf,
+            min_weight_fraction_leaf=min_weight_fraction_leaf,
+            max_features=max_features,
+            max_leaf_nodes=None,
+            random_state=random_state,
+            min_impurity_decrease=0.0,
+            ccp_alpha=0.0,
+        )
+
+    def fit(
+        self,
+        X: np.ndarray,
+        treatment: np.ndarray,
+        y: np.ndarray,
+        sample_weight: Union[np.ndarray, None] = None,
+        check_input: bool = True,
+    ):
+        """Fit the uplift tree.
+
+        Args:
+            X (np.ndarray): feature matrix
+            treatment (np.ndarray): treatment vector, includes the control group
+            y (np.ndarray): binary outcome vector (coerced to {0, 1})
+            sample_weight (np.ndarray): optional sample weights
+            check_input (bool): default True
+        Returns:
+            self
+        """
+        X, y = self._prepare_data(X=X, treatment=treatment, y=y)
+        super().fit(X=X, y=y, sample_weight=sample_weight, check_input=check_input)
+        return self
+
+    def predict_proba_by_group(
+        self, X: np.ndarray, check_input: bool = True
+    ) -> np.ndarray:
+        """Per-group leaf probabilities P(Y=1 | T=g).
+
+        Returns:
+            np.ndarray, shape (n_samples, n_groups); column 0 is the control
+            group, columns 1..k the treatment groups in sorted order.
+        """
+        return BaseUpliftDecisionTree.predict(self, X, check_input=check_input)
+
+    def predict(self, X: np.ndarray, check_input: bool = True) -> np.ndarray:
+        """Per-treatment individual treatment effect P(Y=1|T=t) - P(Y=1|control).
+
+        Returns:
+            np.ndarray, shape (n_samples, n_treatments).
+        """
+        proba = self.predict_proba_by_group(X, check_input=check_input)
+        return proba[:, 1:] - proba[:, [0]]
+
+    def _prepare_data(
+        self,
+        X: np.ndarray,
+        treatment: np.ndarray,
+        y: np.ndarray,
+    ) -> tuple:
+        """Encode (X, treatment, y) as (X, group-matrix y).
+
+        The outcome is coerced to binary and reshaped to a
+        ``(n_samples, n_groups)`` NaN-masked matrix with the control group in
+        column 0 -- the same encoding the causal trees use.
+        """
+        if y.shape[0] != treatment.shape[0]:
+            raise ValueError(
+                f"The number of `treatment` and `y` rows are not equal: "
+                f"{y.shape[0]} {treatment.shape[0]}"
+            )
+        check_treatment_vector(treatment, self.control_name)
+        self.unique_groups = list(set(treatment))
+        self.unique_treatments = sorted(
+            [x for x in self.unique_groups if x != self.control_name]
+        )
+        self._group2index = {
+            self.control_name: 0,
+            **{treatment: i + 1 for i, treatment in enumerate(self.unique_treatments)},
+        }
+        self.classes_ = [self.control_name] + self.unique_treatments
+
+        X = check_array(X, dtype=DTYPE, accept_sparse="csc")
+        y = check_array(y, ensure_2d=False, dtype=None)
+        y = (y > 0).astype(np.float64)
+        self.n_samples, self.n_features = X.shape
+
+        y_2dim = np.zeros((self.n_samples, len(self.unique_treatments) + 1))
+        for group, group_index in self._group2index.items():
+            y_2dim[:, group_index] = np.where(treatment == group, y, np.nan)
+
+        return X, y_2dim

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ cython_modules = [
     ("causalml.inference.tree._tree._utils", "causalml/inference/tree/_tree/_utils.pyx"),
     ("causalml.inference.tree.causal._criterion", "causalml/inference/tree/causal/_criterion.pyx"),
     ("causalml.inference.tree.causal._builder", "causalml/inference/tree/causal/_builder.pyx"),
+    ("causalml.inference.tree._uplift._criterion", "causalml/inference/tree/_uplift/_criterion.pyx"),
     ("causalml.inference.tree.uplift", "causalml/inference/tree/uplift.pyx"),
 ]
 # fmt: on

--- a/tests/test_uplift_trees_kernel.py
+++ b/tests/test_uplift_trees_kernel.py
@@ -1,0 +1,157 @@
+"""Numerical parity tests for the kernel-backed uplift trees (epic #945, issue #946).
+
+These assert that the experimental ``_KernelUpliftTreeClassifier`` -- which grows an
+uplift tree on the shared ``_tree`` Cython kernel via the new
+``UpliftClassificationCriterion`` -- reproduces the legacy ``UpliftTreeClassifier``
+predictions exactly for the KL / ED / Chi criteria, with regularization,
+normalization, honesty, and pruning all disabled.
+
+Design notes
+------------
+* **Binary features.** The kernel's exhaustive midpoint split search and the
+  legacy tree's percentile-candidate search only evaluate the *same* set of
+  partitions when features are low-cardinality. With binary features the two
+  candidate sets coincide, so exact whole-tree parity is achievable; on
+  continuous features they diverge (kernel considers strictly more thresholds)
+  and only the per-node criterion math would match.
+* **Depth convention.** The legacy builder counts depth from 1 and stops at
+  ``depth < max_depth`` (so ``max_depth=D`` allows ``D-1`` splits deep), while the
+  kernel counts from 0 and stops at ``depth >= max_depth``. Identical structure
+  therefore needs ``legacy_max_depth = kernel_max_depth + 1``.
+"""
+
+import numpy as np
+import pytest
+from numpy.testing import assert_array_almost_equal
+
+from causalml.inference.tree.uplift import UpliftTreeClassifier
+from causalml.inference.tree._uplift.uplifttree import _KernelUpliftTreeClassifier
+
+from .const import RANDOM_SEED, CONTROL_NAME
+
+KERNEL_UPLIFT_CRITERIA = ["KL", "ED", "Chi"]
+
+# legacy_max_depth = kernel_max_depth + LEGACY_DEPTH_OFFSET (see module docstring).
+LEGACY_DEPTH_OFFSET = 1
+
+
+def _make_binary_feature_data(
+    n_samples=3000, n_features=5, treatment_names=("treatment1",), seed=RANDOM_SEED
+):
+    """Generate uplift data with binary features and heterogeneous, group-specific lifts."""
+    rng = np.random.RandomState(seed)
+    X = rng.randint(0, 2, size=(n_samples, n_features)).astype(np.float32)
+    groups = [CONTROL_NAME, *treatment_names]
+    treatment = np.array(groups)[rng.randint(0, len(groups), size=n_samples)]
+
+    base = 0.3 + 0.1 * X[:, 1] - 0.05 * X[:, 2]
+    p = base.copy()
+    for i, tr in enumerate(treatment_names):
+        feat = min(3 + i, n_features - 1)
+        lift = 0.25 * X[:, 0] + 0.1 * X[:, feat]
+        p = np.where(treatment == tr, base + lift, p)
+    y = (rng.rand(n_samples) < np.clip(p, 0.0, 1.0)).astype(int)
+    return X, treatment, y
+
+
+def _fit_pair(X, treatment, y, criterion, kernel_max_depth, min_samples_leaf=100):
+    """Fit the kernel-backed tree and the parity-configured legacy tree."""
+    kern = _KernelUpliftTreeClassifier(
+        criterion=criterion,
+        control_name=CONTROL_NAME,
+        max_depth=kernel_max_depth,
+        min_samples_leaf=min_samples_leaf,
+        random_state=RANDOM_SEED,
+    )
+    kern.fit(X, treatment, y)
+
+    legacy = UpliftTreeClassifier(
+        control_name=CONTROL_NAME,
+        evaluationFunction=criterion,
+        max_depth=kernel_max_depth + LEGACY_DEPTH_OFFSET,
+        min_samples_leaf=min_samples_leaf,
+        min_samples_treatment=0,
+        n_reg=0,
+        normalization=False,
+        honesty=False,
+        random_state=RANDOM_SEED,
+    )
+    legacy.fit(X, treatment, y)
+    return kern, legacy
+
+
+@pytest.mark.parametrize("criterion", KERNEL_UPLIFT_CRITERIA)
+@pytest.mark.parametrize("kernel_max_depth", [1, 2, 3])
+def test_kernel_uplift_parity_single_treatment(criterion, kernel_max_depth):
+    X, treatment, y = _make_binary_feature_data()
+    kern, legacy = _fit_pair(X, treatment, y, criterion, kernel_max_depth)
+
+    kernel_proba = kern.predict_proba_by_group(X)
+    legacy_proba = legacy.predict(X)
+
+    # Same leaf P(Y=1|T=g) for every group, hence identical trees.
+    assert_array_almost_equal(kernel_proba, legacy_proba, decimal=8)
+
+
+@pytest.mark.parametrize("criterion", KERNEL_UPLIFT_CRITERIA)
+def test_kernel_uplift_parity_multi_treatment(criterion):
+    X, treatment, y = _make_binary_feature_data(
+        n_samples=4500,
+        n_features=6,
+        treatment_names=("treatment1", "treatment2"),
+        seed=7,
+    )
+    kern, legacy = _fit_pair(X, treatment, y, criterion, kernel_max_depth=2)
+
+    kernel_proba = kern.predict_proba_by_group(X)
+    legacy_proba = legacy.predict(X)
+
+    assert kernel_proba.shape[1] == 3  # control + 2 treatments
+    assert_array_almost_equal(kernel_proba, legacy_proba, decimal=8)
+
+
+@pytest.mark.parametrize("criterion", KERNEL_UPLIFT_CRITERIA)
+def test_kernel_uplift_predict_deltas(criterion):
+    """`predict` returns per-treatment deltas P(Y=1|T=t) - P(Y=1|control)."""
+    X, treatment, y = _make_binary_feature_data()
+    kern, legacy = _fit_pair(X, treatment, y, criterion, kernel_max_depth=2)
+
+    proba = kern.predict_proba_by_group(X)
+    deltas = kern.predict(X)
+
+    assert deltas.shape == (X.shape[0], proba.shape[1] - 1)
+    assert_array_almost_equal(deltas, proba[:, 1:] - proba[:, [0]], decimal=12)
+    # deltas match legacy-derived deltas too.
+    legacy_proba = legacy.predict(X)
+    assert_array_almost_equal(
+        deltas, legacy_proba[:, 1:] - legacy_proba[:, [0]], decimal=8
+    )
+
+
+def test_kernel_uplift_zero_divergence_root_still_splits():
+    """A near-zero-ATE root must still split (regression guard).
+
+    The stock kernel builder turns a node into a leaf when its impurity is
+    ~0; uplift growth is instead driven by the split gain, so a root with no
+    overall treatment/control divergence must still be splittable when a split
+    creates divergent children.
+    """
+    rng = np.random.RandomState(RANDOM_SEED)
+    n = 4000
+    X = rng.randint(0, 2, size=(n, 3)).astype(np.float32)
+    treatment = np.where(rng.rand(n) < 0.5, CONTROL_NAME, "treatment1")
+    is_t = treatment == "treatment1"
+    # Effect flips sign with X[:,0] => overall ATE ~ 0 at the root, strong
+    # heterogeneity below it.
+    p = 0.4 + np.where(X[:, 0] > 0, 0.2, -0.2) * is_t
+    y = (rng.rand(n) < np.clip(p, 0.0, 1.0)).astype(int)
+
+    kern = _KernelUpliftTreeClassifier(
+        criterion="ED",
+        control_name=CONTROL_NAME,
+        max_depth=2,
+        min_samples_leaf=100,
+        random_state=RANDOM_SEED,
+    )
+    kern.fit(X, treatment, y)
+    assert kern.tree_.node_count > 1  # root actually split


### PR DESCRIPTION
## What

First implementation step of the tree-base unification epic (#945) — **Closes #946**.

Grows uplift trees on the shared scikit-learn-1.5.2-vendored `_tree/` Cython kernel (the same kernel the causal trees already ride) instead of the standalone 2.7 KLoC `uplift.pyx` node/builder, for the three simplest criteria (**KL**, **ED**, **Chi**), and proves exact numerical parity against the legacy `UpliftTreeClassifier`.

Everything lives in a **new, non-exported** package `causalml/inference/tree/_uplift/` that coexists with `uplift.pyx`; the public `UpliftTreeClassifier`/`UpliftRandomForestClassifier` are untouched and remain the default. Regularization, normalization, honesty, pruning, the forest, plotting, serialization, and the final switchover are the follow-up issues #947–#955.

## How

- **`_criterion.pyx`/`.pxd` (C++)** — `UpliftClassificationCriterion` reuses the causal criterion's per-group `NodeState`/`NodeSplitState` state machine. For a binary outcome encoded as the causal-style `(n_samples, n_groups)` NaN-masked matrix (control at column 0), `NodeState.outcome_mean(g)` **is** `P(Y=1|T=g)` — all the KL/ED/Chi divergences need. Concrete `KLCriterion`/`EDCriterion`/`ChiCriterion` port the legacy `evaluate_KL/ED/Chi` formulas.
  - Growth is driven by the uplift split *gain* `p·D_left + (1−p)·D_right − D_node` returned from `impurity_improvement` (the existing `TTest` criterion pattern). `node_impurity` returns a positive constant so the kernel builder's `impurity <= EPSILON` early-leaf never fires — an uplift node whose treatment/control outcomes coincide (e.g. a zero-ATE root with strong heterogeneity below it) must still be allowed to split.
- **`_tree.py`** — `BaseUpliftDecisionTree(BaseDecisionTree)` + `UPLIFT_TREE_CRITERIA` map + `fit()` wiring the **stock** kernel splitters and `DepthFirst`/`BestFirst` builders (no uplift regularization yet).
- **`uplifttree.py`** — experimental `_KernelUpliftTreeClassifier` (`fit(X, treatment, y)` → group-matrix encoding → kernel fit; `predict` returns per-treatment deltas, `predict_proba_by_group` the raw leaf `P(Y=1|T)`).
- **`setup.py`** — registers the new C++ extension.

## Testing

`tests/test_uplift_trees_kernel.py` (16 tests, all pass) asserts exact parity vs `UpliftTreeClassifier(evaluationFunction=…, normalization=False, honesty=False, min_samples_treatment=0, n_reg=0)`:

- KL/ED/Chi × depths 1–3 (single treatment) and multi-treatment (3 groups) — identical leaf `P(Y=1|T=g)` (`assert_array_almost_equal`, 8 dp).
- A zero-ATE-root regression guard (the node must still split).

Parity uses **binary features** so the kernel's exhaustive midpoint search and the legacy tree's percentile-candidate search evaluate the same partitions (on continuous features they diverge — the kernel considers strictly more thresholds — so only per-node criterion math would match, not whole-tree structure). The legacy/kernel depth conventions differ by one (`legacy_max_depth = kernel_max_depth + 1`), documented in the test.

Existing `tests/test_uplift_trees.py` + `tests/test_causal_trees.py` (47 tests) still pass — no changes to the legacy or causal code paths.

Part of #945.
