### PR TITLE
Add uplift split regularization to the kernel tree (n_reg/min_samples_treatment) (#947)

### DIFF
--- a/causalml/inference/tree/_uplift/_builder.pxd
+++ b/causalml/inference/tree/_uplift/_builder.pxd
@@ -1,0 +1,10 @@
+# cython: cdivision=True
+# cython: boundscheck=False
+# cython: wraparound=False
+# cython: language_level=3
+
+from .._tree._tree cimport Node, Tree, TreeBuilder
+from .._tree._splitter cimport Splitter, SplitRecord
+from .._tree._typedefs cimport intp_t, int32_t, int64_t, float32_t, float64_t
+from .._tree._tree cimport FrontierRecord, StackRecord
+from .._tree._tree cimport ParentInfo, _init_parent_record

--- a/causalml/inference/tree/_uplift/_builder.pyx
+++ b/causalml/inference/tree/_uplift/_builder.pyx
@@ -1,0 +1,596 @@
+# distutils: language = c++
+# cython: cdivision=True
+# cython: boundscheck=False
+# cython: wraparound=False
+# cython: language_level=3
+
+"""Kernel tree builders for uplift trees with parent-shrinkage regularization.
+
+These mirror the stock ``DepthFirstTreeBuilder`` / ``BestFirstTreeBuilder`` in
+``_tree/_tree.pyx`` (same stopping rules, same ``__cinit__`` signatures) with two
+uplift-specific changes:
+
+1. **Parent-summary threading.** The regularization in
+   :class:`UpliftClassificationCriterion` shrinks each node toward its parent's
+   *regularized* ``P(Y=1|T=g)``. That summary is not derivable from the raw leaf
+   values stored in ``tree.value`` (which stay raw for prediction parity with the
+   legacy tree), so the builder keeps a ``node_id -> regularized summary`` map: it
+   sets the parent summary on the criterion before each ``node_split`` and stores
+   this node's regularized summary after ``node_value``, for its children to read.
+
+2. **No divergence-based early-leaf.** The stock builders turn a node into a leaf
+   when ``impurity <= EPSILON``. For uplift the "impurity" is a constant placeholder
+   and growth is driven by the split gain; shrinkage further shrinks child
+   divergences toward zero, so keeping that check would prematurely stop growth and
+   diverge from the legacy tree (which leafs only on depth / min-samples / a
+   non-positive best gain). The check is therefore omitted here.
+"""
+
+from libc.stdint cimport INTPTR_MAX
+from libcpp cimport bool
+from libcpp.stack cimport stack
+from libcpp.vector cimport vector
+from libcpp.map cimport map
+from libcpp.algorithm cimport pop_heap
+from libcpp.algorithm cimport push_heap
+
+from ._criterion cimport UpliftClassificationCriterion
+
+import numpy as np
+cimport numpy as np
+np.import_array()
+
+
+cdef float64_t INFINITY = np.inf
+cdef float64_t EPSILON = np.finfo('double').eps
+
+cdef int IS_FIRST = 1
+cdef int IS_NOT_FIRST = 0
+cdef int IS_LEFT = 1
+cdef int IS_NOT_LEFT = 0
+
+TREE_LEAF = -1
+TREE_UNDEFINED = -2
+cdef intp_t _TREE_LEAF = TREE_LEAF
+cdef intp_t _TREE_UNDEFINED = TREE_UNDEFINED
+
+
+cdef class DepthFirstUpliftTreeBuilder(TreeBuilder):
+    """Build an uplift tree in depth-first fashion.
+
+    DepthFirstTreeBuilder with uplift parent-summary threading.
+    Source: https://github.com/scikit-learn/scikit-learn/blob/main/sklearn/tree/_tree.pyx
+    """
+
+    def __cinit__(self, Splitter splitter, intp_t min_samples_split,
+                  intp_t min_samples_leaf, float64_t min_weight_leaf,
+                  intp_t max_depth, float64_t min_impurity_decrease):
+        self.splitter = splitter
+        self.min_samples_split = min_samples_split
+        self.min_samples_leaf = min_samples_leaf
+        self.min_weight_leaf = min_weight_leaf
+        self.max_depth = max_depth
+        self.min_impurity_decrease = min_impurity_decrease
+
+    cpdef build(self, Tree tree, object X,
+                const float64_t[:, ::1] y,
+                const float64_t[:] sample_weight=None,
+                const unsigned char[::1] missing_values_in_feature_mask=None,
+                ):
+        """Build a decision tree from the training set (X, y)."""
+
+        # check input
+        X, y, sample_weight = self._check_input(X, y, sample_weight)
+
+        # Initial capacity
+        cdef intp_t init_capacity
+
+        if tree.max_depth <= 10:
+            init_capacity = <intp_t> (2 ** (tree.max_depth + 1)) - 1
+        else:
+            init_capacity = 2047
+
+        tree._resize(init_capacity)
+
+        # Parameters
+        cdef Splitter splitter = self.splitter
+        cdef intp_t max_depth = self.max_depth
+        cdef intp_t min_samples_leaf = self.min_samples_leaf
+        cdef float64_t min_weight_leaf = self.min_weight_leaf
+        cdef intp_t min_samples_split = self.min_samples_split
+        cdef float64_t min_impurity_decrease = self.min_impurity_decrease
+
+        # Recursive partition (without actual recursion)
+        splitter.init(X, y, sample_weight, missing_values_in_feature_mask)
+
+        cdef intp_t start
+        cdef intp_t end
+        cdef intp_t depth
+        cdef intp_t parent
+        cdef bint is_left
+        cdef intp_t n_node_samples = splitter.n_samples
+        cdef float64_t weighted_n_node_samples
+        cdef SplitRecord split
+        cdef intp_t node_id
+
+        cdef float64_t middle_value
+        cdef float64_t left_child_min
+        cdef float64_t left_child_max
+        cdef float64_t right_child_min
+        cdef float64_t right_child_max
+        cdef bint is_leaf
+        cdef bint first = 1
+        cdef intp_t max_depth_seen = -1
+        cdef int rc = 0
+
+        cdef stack[StackRecord] builder_stack
+        cdef StackRecord stack_record
+
+        cdef ParentInfo parent_record
+        _init_parent_record(&parent_record)
+
+        # Uplift regularization: parent regularized summary threading.
+        cdef map[intp_t, vector[float64_t]] reg_map
+        cdef vector[float64_t] node_summary
+        node_summary.resize(tree.n_outputs, 0.0)
+
+        with nogil:
+            # push root node onto stack
+            builder_stack.push({
+                "start": 0,
+                "end": n_node_samples,
+                "depth": 0,
+                "parent": _TREE_UNDEFINED,
+                "is_left": 0,
+                "impurity": INFINITY,
+                "n_constant_features": 0,
+                "lower_bound": -INFINITY,
+                "upper_bound": INFINITY,
+            })
+
+            while not builder_stack.empty():
+                stack_record = builder_stack.top()
+                builder_stack.pop()
+
+                start = stack_record.start
+                end = stack_record.end
+                depth = stack_record.depth
+                parent = stack_record.parent
+                is_left = stack_record.is_left
+                parent_record.impurity = stack_record.impurity
+                parent_record.n_constant_features = stack_record.n_constant_features
+                parent_record.lower_bound = stack_record.lower_bound
+                parent_record.upper_bound = stack_record.upper_bound
+
+                n_node_samples = end - start
+                splitter.node_reset(start, end, &weighted_n_node_samples)
+
+                # Thread the parent's regularized summary into the criterion before
+                # the split search (the root has none).
+                if parent == _TREE_UNDEFINED:
+                    (<UpliftClassificationCriterion> splitter.criterion).set_parent_summary(NULL, 0)
+                else:
+                    (<UpliftClassificationCriterion> splitter.criterion).set_parent_summary(&reg_map[parent][0], 1)
+
+                is_leaf = (depth >= max_depth or
+                           n_node_samples < min_samples_split or
+                           n_node_samples < 2 * min_samples_leaf or
+                           weighted_n_node_samples < 2 * min_weight_leaf)
+
+                if first:
+                    parent_record.impurity = splitter.node_impurity()
+                    first = 0
+
+                if not is_leaf:
+                    splitter.node_split(
+                        &parent_record,
+                        &split,
+                    )
+                    # If EPSILON=0 in the below comparison, float precision
+                    # issues stop splitting, producing trees that are
+                    # dissimilar to v0.18
+                    is_leaf = (is_leaf or split.pos >= end or
+                               (split.improvement + EPSILON <
+                                min_impurity_decrease))
+
+                node_id = tree._add_node(parent, is_left, is_leaf, split.feature,
+                                         split.threshold, parent_record.impurity,
+                                         n_node_samples, weighted_n_node_samples,
+                                         split.missing_go_to_left)
+
+                if node_id == INTPTR_MAX:
+                    rc = -1
+                    break
+
+                # Store value for all nodes, to facilitate tree/model
+                # inspection and interpretation
+                splitter.node_value(tree.value + node_id * tree.value_stride)
+                if splitter.with_monotonic_cst:
+                    splitter.clip_node_value(tree.value + node_id * tree.value_stride, parent_record.lower_bound, parent_record.upper_bound)
+
+                # Record this node's regularized summary for its children to shrink toward.
+                (<UpliftClassificationCriterion> splitter.criterion).compute_reg_summary(&node_summary[0])
+                reg_map[node_id] = node_summary
+
+                if not is_leaf:
+                    if (
+                        not splitter.with_monotonic_cst or
+                        splitter.monotonic_cst[split.feature] == 0
+                    ):
+                        # Split on a feature with no monotonicity constraint
+
+                        # Current bounds must always be propagated to both children.
+                        # If a monotonic constraint is active, bounds are used in
+                        # node value clipping.
+                        left_child_min = right_child_min = parent_record.lower_bound
+                        left_child_max = right_child_max = parent_record.upper_bound
+                    elif splitter.monotonic_cst[split.feature] == 1:
+                        # Split on a feature with monotonic increase constraint
+                        left_child_min = parent_record.lower_bound
+                        right_child_max = parent_record.upper_bound
+
+                        # Lower bound for right child and upper bound for left child
+                        # are set to the same value.
+                        middle_value = splitter.criterion.middle_value()
+                        right_child_min = middle_value
+                        left_child_max = middle_value
+                    else:  # i.e. splitter.monotonic_cst[split.feature] == -1
+                        # Split on a feature with monotonic decrease constraint
+                        right_child_min = parent_record.lower_bound
+                        left_child_max = parent_record.upper_bound
+
+                        # Lower bound for left child and upper bound for right child
+                        # are set to the same value.
+                        middle_value = splitter.criterion.middle_value()
+                        left_child_min = middle_value
+                        right_child_max = middle_value
+
+                    # Push right child on stack
+                    builder_stack.push({
+                        "start": split.pos,
+                        "end": end,
+                        "depth": depth + 1,
+                        "parent": node_id,
+                        "is_left": 0,
+                        "impurity": split.impurity_right,
+                        "n_constant_features": parent_record.n_constant_features,
+                        "lower_bound": right_child_min,
+                        "upper_bound": right_child_max,
+                    })
+
+                    # Push left child on stack
+                    builder_stack.push({
+                        "start": start,
+                        "end": split.pos,
+                        "depth": depth + 1,
+                        "parent": node_id,
+                        "is_left": 1,
+                        "impurity": split.impurity_left,
+                        "n_constant_features": parent_record.n_constant_features,
+                        "lower_bound": left_child_min,
+                        "upper_bound": left_child_max,
+                    })
+
+                if depth > max_depth_seen:
+                    max_depth_seen = depth
+
+            if rc >= 0:
+                rc = tree._resize_c(tree.node_count)
+
+            if rc >= 0:
+                tree.max_depth = max_depth_seen
+        if rc == -1:
+            raise MemoryError()
+
+
+cdef inline bool _compare_records(
+    const FrontierRecord& left,
+    const FrontierRecord& right,
+):
+    return left.improvement < right.improvement
+
+
+cdef inline void _add_to_frontier(
+    FrontierRecord rec,
+    vector[FrontierRecord]& frontier,
+) noexcept nogil:
+    """Adds record `rec` to the priority queue `frontier`."""
+    frontier.push_back(rec)
+    push_heap(frontier.begin(), frontier.end(), &_compare_records)
+
+
+cdef class BestFirstUpliftTreeBuilder(TreeBuilder):
+    """Build an uplift tree in best-first fashion.
+
+    The best node to expand is given by the node at the frontier that has the
+    highest split gain. BestFirstTreeBuilder with uplift parent-summary threading.
+    Source: https://github.com/scikit-learn/scikit-learn/blob/main/sklearn/tree/_tree.pyx
+    """
+    cdef intp_t max_leaf_nodes
+    # node_id -> regularized summary, threaded to each node's children. Instance
+    # state because it must survive across ``_add_split_node`` calls.
+    cdef map[intp_t, vector[float64_t]] reg_map
+
+    def __cinit__(self, Splitter splitter, intp_t min_samples_split,
+                  intp_t min_samples_leaf,  min_weight_leaf,
+                  intp_t max_depth, intp_t max_leaf_nodes,
+                  float64_t min_impurity_decrease):
+        self.splitter = splitter
+        self.min_samples_split = min_samples_split
+        self.min_samples_leaf = min_samples_leaf
+        self.min_weight_leaf = min_weight_leaf
+        self.max_depth = max_depth
+        self.max_leaf_nodes = max_leaf_nodes
+        self.min_impurity_decrease = min_impurity_decrease
+
+    cpdef build(
+        self,
+        Tree tree,
+        object X,
+        const float64_t[:, ::1] y,
+        const float64_t[:] sample_weight=None,
+        const unsigned char[::1] missing_values_in_feature_mask=None,
+    ):
+        """Build a decision tree from the training set (X, y)."""
+
+        # check input
+        X, y, sample_weight = self._check_input(X, y, sample_weight)
+
+        # Parameters
+        cdef Splitter splitter = self.splitter
+        cdef intp_t max_leaf_nodes = self.max_leaf_nodes
+
+        # Recursive partition (without actual recursion)
+        splitter.init(X, y, sample_weight, missing_values_in_feature_mask)
+
+        cdef vector[FrontierRecord] frontier
+        cdef FrontierRecord record
+        cdef FrontierRecord split_node_left
+        cdef FrontierRecord split_node_right
+        cdef float64_t left_child_min
+        cdef float64_t left_child_max
+        cdef float64_t right_child_min
+        cdef float64_t right_child_max
+
+        cdef intp_t n_node_samples = splitter.n_samples
+        cdef intp_t max_split_nodes = max_leaf_nodes - 1
+        cdef bint is_leaf
+        cdef intp_t max_depth_seen = -1
+        cdef int rc = 0
+        cdef Node* node
+
+        cdef ParentInfo parent_record
+        _init_parent_record(&parent_record)
+
+        self.reg_map.clear()
+
+        # Initial capacity
+        cdef intp_t init_capacity = max_split_nodes + max_leaf_nodes
+        tree._resize(init_capacity)
+
+        with nogil:
+            # add root to frontier
+            rc = self._add_split_node(
+                splitter=splitter,
+                tree=tree,
+                start=0,
+                end=n_node_samples,
+                is_first=IS_FIRST,
+                is_left=IS_LEFT,
+                parent=NULL,
+                depth=0,
+                parent_record=&parent_record,
+                res=&split_node_left,
+            )
+            if rc >= 0:
+                _add_to_frontier(split_node_left, frontier)
+
+            while not frontier.empty():
+                pop_heap(frontier.begin(), frontier.end(), &_compare_records)
+                record = frontier.back()
+                frontier.pop_back()
+
+                node = &tree.nodes[record.node_id]
+                is_leaf = (record.is_leaf or max_split_nodes <= 0)
+
+                if is_leaf:
+                    # Node is not expandable; set node as leaf
+                    node.left_child = _TREE_LEAF
+                    node.right_child = _TREE_LEAF
+                    node.feature = _TREE_UNDEFINED
+                    node.threshold = _TREE_UNDEFINED
+
+                else:
+                    # Node is expandable
+
+                    if (
+                        not splitter.with_monotonic_cst or
+                        splitter.monotonic_cst[node.feature] == 0
+                    ):
+                        # Split on a feature with no monotonicity constraint
+
+                        # Current bounds must always be propagated to both children.
+                        # If a monotonic constraint is active, bounds are used in
+                        # node value clipping.
+                        left_child_min = right_child_min = record.lower_bound
+                        left_child_max = right_child_max = record.upper_bound
+                    elif splitter.monotonic_cst[node.feature] == 1:
+                        # Split on a feature with monotonic increase constraint
+                        left_child_min = record.lower_bound
+                        right_child_max = record.upper_bound
+
+                        # Lower bound for right child and upper bound for left child
+                        # are set to the same value.
+                        right_child_min = record.middle_value
+                        left_child_max = record.middle_value
+                    else:  # i.e. splitter.monotonic_cst[split.feature] == -1
+                        # Split on a feature with monotonic decrease constraint
+                        right_child_min = record.lower_bound
+                        left_child_max = record.upper_bound
+
+                        # Lower bound for left child and upper bound for right child
+                        # are set to the same value.
+                        left_child_min = record.middle_value
+                        right_child_max = record.middle_value
+
+                    # Decrement number of split nodes available
+                    max_split_nodes -= 1
+
+                    # Compute left split node
+                    parent_record.lower_bound = left_child_min
+                    parent_record.upper_bound = left_child_max
+                    parent_record.impurity = record.impurity_left
+                    rc = self._add_split_node(
+                        splitter=splitter,
+                        tree=tree,
+                        start=record.start,
+                        end=record.pos,
+                        is_first=IS_NOT_FIRST,
+                        is_left=IS_LEFT,
+                        parent=node,
+                        depth=record.depth + 1,
+                        parent_record=&parent_record,
+                        res=&split_node_left,
+                    )
+                    if rc == -1:
+                        break
+
+                    # tree.nodes may have changed
+                    node = &tree.nodes[record.node_id]
+
+                    # Compute right split node
+                    parent_record.lower_bound = right_child_min
+                    parent_record.upper_bound = right_child_max
+                    parent_record.impurity = record.impurity_right
+                    rc = self._add_split_node(
+                        splitter=splitter,
+                        tree=tree,
+                        start=record.pos,
+                        end=record.end,
+                        is_first=IS_NOT_FIRST,
+                        is_left=IS_NOT_LEFT,
+                        parent=node,
+                        depth=record.depth + 1,
+                        parent_record=&parent_record,
+                        res=&split_node_right,
+                    )
+                    if rc == -1:
+                        break
+
+                    # Add nodes to queue
+                    _add_to_frontier(split_node_left, frontier)
+                    _add_to_frontier(split_node_right, frontier)
+
+                if record.depth > max_depth_seen:
+                    max_depth_seen = record.depth
+
+            if rc >= 0:
+                rc = tree._resize_c(tree.node_count)
+
+            if rc >= 0:
+                tree.max_depth = max_depth_seen
+
+        if rc == -1:
+            raise MemoryError()
+
+    cdef inline int _add_split_node(
+        self,
+        Splitter splitter,
+        Tree tree,
+        intp_t start,
+        intp_t end,
+        bint is_first,
+        bint is_left,
+        Node* parent,
+        intp_t depth,
+        ParentInfo* parent_record,
+        FrontierRecord* res
+    ) except -1 nogil:
+        """Adds node w/ partition ``[start, end)`` to the frontier. """
+        cdef SplitRecord split
+        cdef intp_t node_id
+        cdef intp_t n_node_samples
+        cdef float64_t min_impurity_decrease = self.min_impurity_decrease
+        cdef float64_t weighted_n_node_samples
+        cdef bint is_leaf
+
+        cdef vector[float64_t] node_summary
+
+        splitter.node_reset(start, end, &weighted_n_node_samples)
+
+        # Thread the parent's regularized summary into the criterion before the
+        # split search (the root has none).
+        if parent == NULL:
+            (<UpliftClassificationCriterion> splitter.criterion).set_parent_summary(NULL, 0)
+        else:
+            (<UpliftClassificationCriterion> splitter.criterion).set_parent_summary(&self.reg_map[parent - tree.nodes][0], 1)
+
+        # reset n_constant_features for this specific split before beginning split search
+        parent_record.n_constant_features = 0
+
+        if is_first:
+            parent_record.impurity = splitter.node_impurity()
+
+        n_node_samples = end - start
+        is_leaf = (depth >= self.max_depth or
+                   n_node_samples < self.min_samples_split or
+                   n_node_samples < 2 * self.min_samples_leaf or
+                   weighted_n_node_samples < 2 * self.min_weight_leaf
+                   )
+
+        if not is_leaf:
+            splitter.node_split(
+                parent_record,
+                &split,
+            )
+            # If EPSILON=0 in the below comparison, float precision issues stop
+            # splitting early, producing trees that are dissimilar to v0.18
+            is_leaf = (is_leaf or split.pos >= end or
+                       split.improvement + EPSILON < min_impurity_decrease)
+
+        node_id = tree._add_node(parent - tree.nodes
+                                 if parent != NULL
+                                 else _TREE_UNDEFINED,
+                                 is_left, is_leaf,
+                                 split.feature, split.threshold, parent_record.impurity,
+                                 n_node_samples, weighted_n_node_samples,
+                                 split.missing_go_to_left)
+        if node_id == INTPTR_MAX:
+            return -1
+
+        # compute values also for split nodes (might become leafs later).
+        splitter.node_value(tree.value + node_id * tree.value_stride)
+        if splitter.with_monotonic_cst:
+            splitter.clip_node_value(tree.value + node_id * tree.value_stride, parent_record.lower_bound, parent_record.upper_bound)
+
+        # Record this node's regularized summary for its children to shrink toward.
+        node_summary.resize(tree.n_outputs, 0.0)
+        (<UpliftClassificationCriterion> splitter.criterion).compute_reg_summary(&node_summary[0])
+        self.reg_map[node_id] = node_summary
+
+        res.node_id = node_id
+        res.start = start
+        res.end = end
+        res.depth = depth
+        res.impurity = parent_record.impurity
+        res.lower_bound = parent_record.lower_bound
+        res.upper_bound = parent_record.upper_bound
+        res.middle_value = splitter.criterion.middle_value()
+
+        if not is_leaf:
+            # is split node
+            res.pos = split.pos
+            res.is_leaf = 0
+            res.improvement = split.improvement
+            res.impurity_left = split.impurity_left
+            res.impurity_right = split.impurity_right
+
+        else:
+            # is leaf => 0 improvement
+            res.pos = end
+            res.is_leaf = 1
+            res.improvement = 0.0
+            res.impurity_left = parent_record.impurity
+            res.impurity_right = parent_record.impurity
+
+        return 0

--- a/causalml/inference/tree/_uplift/_criterion.pxd
+++ b/causalml/inference/tree/_uplift/_criterion.pxd
@@ -4,13 +4,39 @@
 # cython: language_level=3
 # distutils: language = c++
 
-from .._tree._typedefs cimport float64_t
+from libcpp.vector cimport vector
+
+from .._tree._typedefs cimport intp_t, float64_t
 from ..causal._criterion cimport CausalRegressionCriterion, NodeState
 
 
 cdef class UpliftClassificationCriterion(CausalRegressionCriterion):
+    # Rzepakowski et al. (2012) parent-shrinkage regularization. ``n_reg`` is the
+    # weight (in sample-size units) of the parent node's influence on a child;
+    # ``min_samples_treatment`` is both the shrinkage threshold and the minimum
+    # per-group size a candidate split's children must have to be admissible.
+    cdef public float64_t n_reg
+    cdef public intp_t min_samples_treatment
+
+    # Regularized positive-outcome probabilities of the *parent* node, threaded
+    # down by the builder before each ``node_split`` (control at index 0). Only
+    # valid when ``has_parent`` is non-zero (the root has no parent).
+    cdef bint has_parent
+    cdef vector[float64_t] parent_summary_p
+
+    # Scratch buffers (size n_outputs) for the regularized node / child summaries.
+    cdef vector[float64_t] _buf_node
+    cdef vector[float64_t] _buf_child
+
     # Divergence contribution of a single treatment-vs-control pair. Overridden
     # by each concrete criterion (KL / ED / Chi).
     cdef float64_t _pair_divergence(self, float64_t p_t, float64_t p_c) noexcept nogil
-    # Sum of pair divergences over all treatment groups for a node.
-    cdef float64_t _node_divergence(self, NodeState node) noexcept nogil
+    # Sum of pair divergences over all treatment groups for a probability vector.
+    cdef float64_t _divergence_of(self, float64_t* p) noexcept nogil
+    # Regularized P(Y=1|T=g) of ``node``, shrunk toward ``target_p`` (when
+    # ``has_target``), written into ``dest``.
+    cdef void _reg_summary(self, NodeState node, float64_t* target_p, bint has_target, float64_t* dest) noexcept nogil
+    # Builder API: set the parent summary before ``node_split``; read this node's
+    # regularized summary back out after ``node_value`` to thread to its children.
+    cdef void set_parent_summary(self, float64_t* src, bint has_parent) noexcept nogil
+    cdef void compute_reg_summary(self, float64_t* dest) noexcept nogil

--- a/causalml/inference/tree/_uplift/_criterion.pyx
+++ b/causalml/inference/tree/_uplift/_criterion.pyx
@@ -19,15 +19,35 @@ constant so the kernel builder's ``impurity <= EPSILON`` early-leaf never fires
 split), and the real work happens in ``children_impurity`` /
 ``impurity_improvement``.
 
-Legacy references in ``uplift.pyx``: ``kl_divergence`` (line ~86),
-``evaluate_KL`` / ``evaluate_ED`` / ``evaluate_Chi`` (~1032-1184), and the split
-gain ``p * D_left + (1 - p) * D_right - D_node`` in ``growDecisionTreeFrom``
-(~2308-2316).
+Regularization (issue #947)
+---------------------------
+The gain is computed on *regularized* per-group probabilities, following
+Rzepakowski et al. (2012) and the legacy ``UpliftTreeClassifier``:
+
+* ``n_reg`` shrinks each group's ``P(Y=1|T=g)`` toward the parent node's
+  regularized probability, with weight ``n_reg`` in sample-size units.
+* ``min_samples_treatment`` is the shrinkage threshold (a group at/below it falls
+  back entirely to the parent's probability) *and* a hard admissibility floor: a
+  candidate split whose left/right child has any group below it is rejected (its
+  gain is ``-inf``), so the split search never selects it.
+
+The parent's regularized summary is threaded down the tree by the builder (see
+``_uplift/_builder.pyx``): it is set via :meth:`set_parent_summary` before each
+``node_split`` and read back via :meth:`compute_reg_summary` after ``node_value``.
+The stored leaf *prediction* (``node_value``, inherited from the causal
+criterion) remains the raw ``P(Y=1|T=g)`` -- matching the legacy tree, which
+regularizes only the split evaluation, not the leaf estimate.
+
+Legacy references in ``uplift.pyx``: ``tree_node_summary`` (~1735, the shrinkage
+rule), ``uplift_classification_results`` (~1942, the raw leaf estimate),
+``kl_divergence`` / ``evaluate_KL`` / ``evaluate_ED`` / ``evaluate_Chi``
+(~1032-1184), and the split gain ``p * D_left + (1 - p) * D_right - D_node`` plus
+the ``min_samples_treatment`` reject in ``growDecisionTreeFrom`` (~2270-2316).
 """
 
-from libc.math cimport log
+from libc.math cimport log, INFINITY
 
-from .._tree._typedefs cimport int32_t
+from .._tree._typedefs cimport int32_t, intp_t
 
 
 # Matches ``max(0.1 ** 6, ...)`` in the legacy Chi-squared criterion and the
@@ -46,33 +66,70 @@ cdef float64_t NODE_IMPURITY = 1.0
 cdef class UpliftClassificationCriterion(CausalRegressionCriterion):
     """Base class for kernel-backed uplift split criteria."""
 
+    def __cinit__(self, intp_t n_outputs, intp_t n_samples):
+        # The base ``__cinit__`` chain (RegressionCriterion -> CausalRegression
+        # Criterion) has already run, so ``self.n_outputs`` and ``self.state``
+        # exist. Regularization is off by default; the Python layer sets ``n_reg``
+        # / ``min_samples_treatment`` before fitting.
+        self.n_reg = 0.0
+        self.min_samples_treatment = 0
+        self.has_parent = 0
+        self.parent_summary_p.resize(n_outputs, 0.0)
+        self._buf_node.resize(n_outputs, 0.0)
+        self._buf_child.resize(n_outputs, 0.0)
+
     cdef float64_t _pair_divergence(self, float64_t p_t, float64_t p_c) noexcept nogil:
         # Overridden by each concrete criterion.
         return 0.0
 
-    cdef float64_t _node_divergence(self, NodeState node) noexcept nogil:
-        """Sum the treatment-vs-control divergence over all treatment groups.
-
-        Empty groups fall back to ``P(Y=1) = 0`` (mirrors the legacy
-        ``n_pos / n if n > 0 else 0`` guard used at split evaluation with
-        ``n_reg = 0`` / ``min_samples_treatment = 0``).
-        """
-        cdef float64_t p_c, p_t
+    cdef float64_t _divergence_of(self, float64_t* p) noexcept nogil:
+        """Sum the treatment-vs-control divergence over all treatment groups."""
+        cdef float64_t p_c = p[0]
         cdef float64_t d = 0.0
         cdef int32_t t
 
-        if node.count_1d[0] > 0:
-            p_c = node.y_sum_1d[0] / node.count_1d[0]
-        else:
-            p_c = 0.0
-
         for t in range(1, self.n_outputs):
-            if node.count_1d[t] > 0:
-                p_t = node.y_sum_1d[t] / node.count_1d[t]
-            else:
-                p_t = 0.0
-            d += self._pair_divergence(p_t, p_c)
+            d += self._pair_divergence(p[t], p_c)
         return d
+
+    cdef void _reg_summary(
+        self,
+        NodeState node,
+        float64_t* target_p,
+        bint has_target,
+        float64_t* dest,
+    ) noexcept nogil:
+        """Regularized P(Y=1|T=g) for every group, written into ``dest``.
+
+        Mirrors the legacy ``tree_node_summary`` shrinkage rule: with no target
+        (root) use the raw rate; otherwise shrink toward ``target_p`` with weight
+        ``n_reg``, unless the group is at/below ``min_samples_treatment``, in which
+        case fall back entirely to the target.
+        """
+        cdef int32_t g
+        cdef float64_t n, n_pos
+
+        for g in range(self.n_outputs):
+            n = node.count_1d[g]
+            n_pos = node.y_sum_1d[g]
+            if not has_target:
+                dest[g] = n_pos / n if n > 0 else 0.0
+            elif n > self.min_samples_treatment:
+                dest[g] = (n_pos + target_p[g] * self.n_reg) / (n + self.n_reg)
+            else:
+                dest[g] = target_p[g]
+
+    cdef void set_parent_summary(self, float64_t* src, bint has_parent) noexcept nogil:
+        """Store the parent node's regularized summary for the next split search."""
+        cdef int32_t g
+        self.has_parent = has_parent
+        if has_parent:
+            for g in range(self.n_outputs):
+                self.parent_summary_p[g] = src[g]
+
+    cdef void compute_reg_summary(self, float64_t* dest) noexcept nogil:
+        """This node's regularized summary (shrunk toward the current parent)."""
+        self._reg_summary(self.state.node, &self.parent_summary_p[0], self.has_parent, dest)
 
     cdef float64_t node_impurity(self) noexcept nogil:
         return NODE_IMPURITY
@@ -85,15 +142,49 @@ cdef class UpliftClassificationCriterion(CausalRegressionCriterion):
         """Store the split gain in ``state.left.split_metric``.
 
         gain = p * D_left + (1 - p) * D_right - D_node, where p is the fraction of
-        samples routed to the left child. ``impurity_left`` / ``impurity_right``
-        are set to the child divergences for interpretability only; the builder
-        reads the gain via :meth:`impurity_improvement`.
-        """
-        cdef float64_t p = self.weighted_n_left / self.weighted_n_node_samples
-        cdef float64_t d_node = self._node_divergence(self.state.node)
-        cdef float64_t d_left = self._node_divergence(self.state.left)
-        cdef float64_t d_right = self._node_divergence(self.state.right)
+        samples routed to the left child and each ``D`` is the divergence of the
+        corresponding *regularized* summary: the node shrinks toward its parent,
+        the children shrink toward the node. A candidate split whose left or right
+        child has any group below ``min_samples_treatment`` is inadmissible and
+        gets gain ``-inf`` so the split search never selects it.
 
+        ``impurity_left`` / ``impurity_right`` are set to the child divergences for
+        interpretability only; the builder reads the gain via
+        :meth:`impurity_improvement`.
+        """
+        cdef int32_t g
+        cdef float64_t cnt
+        cdef float64_t min_left = self.state.left.count_1d[0]
+        cdef float64_t min_right = self.state.right.count_1d[0]
+        cdef float64_t* s_node = &self._buf_node[0]
+        cdef float64_t* s_child = &self._buf_child[0]
+        cdef float64_t d_node, d_left, d_right, p
+
+        for g in range(1, self.n_outputs):
+            cnt = self.state.left.count_1d[g]
+            if cnt < min_left:
+                min_left = cnt
+            cnt = self.state.right.count_1d[g]
+            if cnt < min_right:
+                min_right = cnt
+
+        if min_left < self.min_samples_treatment or min_right < self.min_samples_treatment:
+            impurity_left[0] = 0.0
+            impurity_right[0] = 0.0
+            self.state.left.split_metric = -INFINITY
+            return
+
+        self._reg_summary(self.state.node, &self.parent_summary_p[0], self.has_parent, s_node)
+        d_node = self._divergence_of(s_node)
+
+        # Children always shrink toward the (regularized) current node.
+        self._reg_summary(self.state.left, s_node, 1, s_child)
+        d_left = self._divergence_of(s_child)
+
+        self._reg_summary(self.state.right, s_node, 1, s_child)
+        d_right = self._divergence_of(s_child)
+
+        p = self.weighted_n_left / self.weighted_n_node_samples
         impurity_left[0] = d_left
         impurity_right[0] = d_right
         self.state.left.split_metric = p * d_left + (1.0 - p) * d_right - d_node

--- a/causalml/inference/tree/_uplift/_tree.py
+++ b/causalml/inference/tree/_uplift/_tree.py
@@ -1,10 +1,12 @@
 """Kernel-backed base class for uplift decision trees (experimental).
 
 Mirrors ``causal/_tree.py`` but wires the shared ``_tree`` kernel to the uplift
-criteria and the *stock* kernel builders/splitters -- no uplift-specific
-regularization yet (``min_samples_treatment`` / ``n_reg`` land in a follow-up
-issue). This module is internal; it is not exported from ``tree/__init__.py``
-and the legacy ``UpliftTreeClassifier`` remains the public default.
+criteria and the uplift builders (``_uplift/_builder.py``), which thread the
+Rzepakowski ``n_reg`` / ``min_samples_treatment`` parent-shrinkage regularization
+down the tree. This module is internal; it is not exported from
+``tree/__init__.py`` and the legacy ``UpliftTreeClassifier`` remains the public
+default. Normalization, honesty, and the forest are handled in later issues of the
+epic.
 """
 
 import numbers
@@ -21,8 +23,8 @@ from .._tree._classes import DTYPE, DOUBLE
 from .._tree._classes import SPARSE_SPLITTERS, DENSE_SPLITTERS
 from .._tree._classes import Tree, BaseDecisionTree
 from .._tree._splitter import Splitter
-from .._tree._tree import DepthFirstTreeBuilder, BestFirstTreeBuilder
 
+from ._builder import DepthFirstUpliftTreeBuilder, BestFirstUpliftTreeBuilder
 from ._criterion import KLCriterion, EDCriterion, ChiCriterion
 
 UPLIFT_TREE_CRITERIA = {
@@ -182,6 +184,9 @@ class BaseUpliftDecisionTree(BaseDecisionTree):
         criterion = self.criterion
         if isinstance(criterion, str):
             criterion = UPLIFT_TREE_CRITERIA[criterion](self.n_outputs_, n_samples)
+            # Rzepakowski parent-shrinkage regularization (issue #947).
+            criterion.n_reg = getattr(self, "n_reg", 0)
+            criterion.min_samples_treatment = getattr(self, "min_samples_treatment", 0)
 
         SPLITTERS = SPARSE_SPLITTERS if issparse(X) else DENSE_SPLITTERS
 
@@ -203,7 +208,7 @@ class BaseUpliftDecisionTree(BaseDecisionTree):
 
         # Use BestFirst if max_leaf_nodes given; use DepthFirst otherwise
         if max_leaf_nodes < 0:
-            builder = DepthFirstTreeBuilder(
+            builder = DepthFirstUpliftTreeBuilder(
                 splitter,
                 min_samples_split,
                 min_samples_leaf,
@@ -212,7 +217,7 @@ class BaseUpliftDecisionTree(BaseDecisionTree):
                 self.min_impurity_decrease,
             )
         else:
-            builder = BestFirstTreeBuilder(
+            builder = BestFirstUpliftTreeBuilder(
                 splitter,
                 min_samples_split,
                 min_samples_leaf,

--- a/causalml/inference/tree/_uplift/uplifttree.py
+++ b/causalml/inference/tree/_uplift/uplifttree.py
@@ -2,8 +2,9 @@
 
 Not part of the public API -- this exists to prove numerical parity of the
 kernel-backed KL / ED / Chi criteria against the legacy ``UpliftTreeClassifier``
-before the public classes are switched over. Regularization, normalization,
-honesty, pruning, and the forest are handled in later issues of the epic.
+before the public classes are switched over. It supports the Rzepakowski
+``n_reg`` / ``min_samples_treatment`` regularization; normalization, honesty,
+pruning, and the forest are handled in later issues of the epic.
 """
 
 from typing import Union
@@ -28,11 +29,15 @@ class _KernelUpliftTreeClassifier(BaseUpliftDecisionTree):
         max_depth: int = 3,
         min_samples_leaf: int = 100,
         min_samples_split: Union[int, float] = 2,
+        min_samples_treatment: int = 10,
+        n_reg: int = 100,
         max_features: Union[int, float, str, None] = None,
         min_weight_fraction_leaf: float = 0.0,
         random_state: int = None,
     ):
         self.control_name = control_name
+        self.min_samples_treatment = min_samples_treatment
+        self.n_reg = n_reg
         super().__init__(
             criterion=criterion,
             splitter="best",

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ cython_modules = [
     ("causalml.inference.tree.causal._criterion", "causalml/inference/tree/causal/_criterion.pyx"),
     ("causalml.inference.tree.causal._builder", "causalml/inference/tree/causal/_builder.pyx"),
     ("causalml.inference.tree._uplift._criterion", "causalml/inference/tree/_uplift/_criterion.pyx"),
+    ("causalml.inference.tree._uplift._builder", "causalml/inference/tree/_uplift/_builder.pyx"),
     ("causalml.inference.tree.uplift", "causalml/inference/tree/uplift.pyx"),
 ]
 # fmt: on

--- a/tests/test_uplift_trees_kernel.py
+++ b/tests/test_uplift_trees_kernel.py
@@ -54,13 +54,29 @@ def _make_binary_feature_data(
     return X, treatment, y
 
 
-def _fit_pair(X, treatment, y, criterion, kernel_max_depth, min_samples_leaf=100):
-    """Fit the kernel-backed tree and the parity-configured legacy tree."""
+def _fit_pair(
+    X,
+    treatment,
+    y,
+    criterion,
+    kernel_max_depth,
+    min_samples_leaf=100,
+    n_reg=0,
+    min_samples_treatment=0,
+):
+    """Fit the kernel-backed tree and the parity-configured legacy tree.
+
+    ``n_reg`` / ``min_samples_treatment`` are passed identically to both trees so
+    the Rzepakowski parent-shrinkage regularization (issue #947) can be exercised;
+    the defaults (0, 0) disable it for the no-regularization parity cases.
+    """
     kern = _KernelUpliftTreeClassifier(
         criterion=criterion,
         control_name=CONTROL_NAME,
         max_depth=kernel_max_depth,
         min_samples_leaf=min_samples_leaf,
+        min_samples_treatment=min_samples_treatment,
+        n_reg=n_reg,
         random_state=RANDOM_SEED,
     )
     kern.fit(X, treatment, y)
@@ -70,8 +86,8 @@ def _fit_pair(X, treatment, y, criterion, kernel_max_depth, min_samples_leaf=100
         evaluationFunction=criterion,
         max_depth=kernel_max_depth + LEGACY_DEPTH_OFFSET,
         min_samples_leaf=min_samples_leaf,
-        min_samples_treatment=0,
-        n_reg=0,
+        min_samples_treatment=min_samples_treatment,
+        n_reg=n_reg,
         normalization=False,
         honesty=False,
         random_state=RANDOM_SEED,
@@ -155,3 +171,90 @@ def test_kernel_uplift_zero_divergence_root_still_splits():
     )
     kern.fit(X, treatment, y)
     assert kern.tree_.node_count > 1  # root actually split
+
+
+# --- Regularization parity (issue #947) -------------------------------------
+# Legacy public defaults: n_reg=100, min_samples_treatment=10.
+LEGACY_N_REG = 100
+LEGACY_MIN_SAMPLES_TREATMENT = 10
+
+
+@pytest.mark.parametrize("criterion", KERNEL_UPLIFT_CRITERIA)
+@pytest.mark.parametrize("kernel_max_depth", [1, 2, 3])
+def test_kernel_uplift_parity_regularized(criterion, kernel_max_depth):
+    """Whole-tree parity with Rzepakowski parent-shrinkage regularization on."""
+    X, treatment, y = _make_binary_feature_data()
+    kern, legacy = _fit_pair(
+        X,
+        treatment,
+        y,
+        criterion,
+        kernel_max_depth,
+        n_reg=LEGACY_N_REG,
+        min_samples_treatment=LEGACY_MIN_SAMPLES_TREATMENT,
+    )
+
+    kernel_proba = kern.predict_proba_by_group(X)
+    legacy_proba = legacy.predict(X)
+
+    assert_array_almost_equal(kernel_proba, legacy_proba, decimal=8)
+
+
+@pytest.mark.parametrize("criterion", KERNEL_UPLIFT_CRITERIA)
+def test_kernel_uplift_parity_regularized_multi_treatment(criterion):
+    X, treatment, y = _make_binary_feature_data(
+        n_samples=4500,
+        n_features=6,
+        treatment_names=("treatment1", "treatment2"),
+        seed=7,
+    )
+    kern, legacy = _fit_pair(
+        X,
+        treatment,
+        y,
+        criterion,
+        kernel_max_depth=2,
+        n_reg=LEGACY_N_REG,
+        min_samples_treatment=LEGACY_MIN_SAMPLES_TREATMENT,
+    )
+
+    kernel_proba = kern.predict_proba_by_group(X)
+    legacy_proba = legacy.predict(X)
+
+    assert kernel_proba.shape[1] == 3  # control + 2 treatments
+    assert_array_almost_equal(kernel_proba, legacy_proba, decimal=8)
+
+
+def test_kernel_uplift_min_samples_treatment_gates_splits():
+    """``min_samples_treatment`` rejects splits whose child groups are too small.
+
+    With the floor set above any achievable per-group child size, no candidate
+    split is admissible and the tree collapses to its root; dropping the floor to
+    zero (same data / depth / leaf size) lets it grow -- proving the gate, not some
+    other stopping rule, is what prevented growth.
+    """
+    X, treatment, y = _make_binary_feature_data()
+
+    gated = _KernelUpliftTreeClassifier(
+        criterion="ED",
+        control_name=CONTROL_NAME,
+        max_depth=3,
+        min_samples_leaf=1,
+        min_samples_treatment=X.shape[0],
+        n_reg=0,
+        random_state=RANDOM_SEED,
+    )
+    gated.fit(X, treatment, y)
+    assert gated.tree_.node_count == 1
+
+    ungated = _KernelUpliftTreeClassifier(
+        criterion="ED",
+        control_name=CONTROL_NAME,
+        max_depth=3,
+        min_samples_leaf=1,
+        min_samples_treatment=0,
+        n_reg=0,
+        random_state=RANDOM_SEED,
+    )
+    ungated.fit(X, treatment, y)
+    assert ungated.tree_.node_count > 1


### PR DESCRIPTION
## Summary

Second step of the tree-unification epic (#945, follows #946/#959). Ports the
Rzepakowski et al. (2012) **parent-shrinkage regularization** onto the
kernel-backed uplift tree so it reproduces the legacy `UpliftTreeClassifier`
with regularization **on** — the prior PR only proved parity with it off.

Two knobs, matching the public `UpliftTreeClassifier`:

- **`n_reg`** (default 100): each node's `P(Y=1|T=g)` shrinks toward its parent's
  regularized probability with weight `n_reg` (in sample-size units) when
  evaluating a split's gain.
- **`min_samples_treatment`** (default 10): the shrinkage threshold *and* a hard
  admissibility floor — a candidate split whose left/right child has any group
  below it is rejected.

Still internal/experimental (`_KernelUpliftTreeClassifier`); the public default
remains the legacy tree.

## How it works

- **`_uplift/_criterion.pyx`** — the split gain
  `p·D_left + (1−p)·D_right − D_node` is now computed on *regularized* per-group
  probabilities: the node shrinks toward its parent, the children shrink toward
  the node (exact port of legacy `tree_node_summary` + the KL/ED/Chi
  `evaluate_*`). A split with any child group `< min_samples_treatment` gets gain
  `−inf`, so the search never selects it — the kernel analogue of the legacy
  `node_mst < min_samples_treatment → continue`. **Leaf predictions
  (`node_value`) stay raw** `n_pos/n`, matching legacy
  `uplift_classification_results` (regularization affects only growth, not the
  leaf estimate).

- **`_uplift/_builder.pyx`** (new) — `DepthFirst`/`BestFirst` builders that thread
  each node's regularized summary down to its children. The summary can't live in
  `tree.value` (which must stay raw for prediction), so the builder keeps a
  `node_id → regularized summary` map, setting it on the criterion before each
  `node_split` and reading it back after `node_value`. They also omit the stock
  `impurity ≤ EPSILON` early-leaf, which is incompatible with uplift growth
  (driven by the split gain; shrinkage further shrinks child divergences toward
  zero, which would otherwise stop growth prematurely and diverge from legacy).

- **`_tree.py` / `uplifttree.py`** — wire the new builders and expose `n_reg` /
  `min_samples_treatment`.

## Testing

`pytest tests/test_uplift_trees_kernel.py` — 29 passed.

- **New**: exact whole-tree parity (`decimal=8`) with legacy `n_reg=100`,
  `min_samples_treatment=10` for KL/ED/Chi — single-treatment (depths 1–3) and
  multi-treatment — plus a gate test showing `min_samples_treatment` prevents
  splits (and that the same config without it grows).
- The no-regularization parity tests from #946/#959 now pass `n_reg=0` /
  `min_samples_treatment=0` explicitly and still hold.
- Legacy `tests/test_uplift_trees.py` and `tests/test_causal_trees.py` — 47
  passed (no regression from the shared rebuild).

Part of #945. Closes #947.
