### PR TITLE
Add kernel uplift normalization (arr_normI) and CTS criterion (#948)

### DIFF
--- a/causalml/inference/tree/_uplift/_criterion.pxd
+++ b/causalml/inference/tree/_uplift/_criterion.pxd
@@ -18,6 +18,11 @@ cdef class UpliftClassificationCriterion(CausalRegressionCriterion):
     cdef public float64_t n_reg
     cdef public intp_t min_samples_treatment
 
+    # Rzepakowski et al. (2012) normalization: when set, the split gain is divided
+    # by the treatment-vs-control distribution divergence ``_norm_factor`` (issue
+    # #948). Not applied by criteria whose ``_normalizable`` returns 0 (e.g. CTS).
+    cdef public bint normalization
+
     # Regularized positive-outcome probabilities of the *parent* node, threaded
     # down by the builder before each ``node_split`` (control at index 0). Only
     # valid when ``has_parent`` is non-zero (the root has no parent).
@@ -33,6 +38,14 @@ cdef class UpliftClassificationCriterion(CausalRegressionCriterion):
     cdef float64_t _pair_divergence(self, float64_t p_t, float64_t p_c) noexcept nogil
     # Sum of pair divergences over all treatment groups for a probability vector.
     cdef float64_t _divergence_of(self, float64_t* p) noexcept nogil
+    # Per-node split metric: gain = p*M(left) + (1-p)*M(right) - M(node). Defaults
+    # to ``_divergence_of``; CTS overrides it with the max over groups.
+    cdef float64_t _node_metric(self, float64_t* p) noexcept nogil
+    # Whether ``_norm_factor`` normalization applies (0 for CTS).
+    cdef bint _normalizable(self) noexcept nogil
+    # Rzepakowski normalization factor from the raw node / one-child group counts
+    # (the child matching legacy ``arr_normI``'s asymmetric "left" = X >= value).
+    cdef float64_t _norm_factor(self) noexcept nogil
     # Regularized P(Y=1|T=g) of ``node``, shrunk toward ``target_p`` (when
     # ``has_target``), written into ``dest``.
     cdef void _reg_summary(self, NodeState node, float64_t* target_p, bint has_target, float64_t* dest) noexcept nogil

--- a/causalml/inference/tree/_uplift/_criterion.pyx
+++ b/causalml/inference/tree/_uplift/_criterion.pyx
@@ -62,6 +62,48 @@ cdef float64_t EPS = 1e-6
 # outcomes happen to coincide).
 cdef float64_t NODE_IMPURITY = 1.0
 
+# Weight balancing the parts of the Rzepakowski normalization factor (legacy
+# ``arr_normI(..., alpha=0.9)``).
+cdef float64_t NORM_ALPHA = 0.9
+
+
+cdef inline float64_t _entropy_h(float64_t p, float64_t q) noexcept nogil:
+    """Legacy ``entropyH(p, q=-1)`` (``uplift.pyx`` ~124).
+
+    Single-argument entropy ``-p*log(p)`` is requested by passing ``q = -1``.
+    """
+    if q == -1.0 and p > 0.0:
+        return -p * log(p)
+    elif q > 0.0:
+        return -p * log(q)
+    else:
+        return 0.0
+
+
+cdef inline float64_t _kl_divergence(float64_t pk, float64_t qk) noexcept nogil:
+    """Legacy scalar ``kl_divergence(pk, qk)`` (``uplift.pyx`` ~86).
+
+    Used by the normalization factor for every divergence criterion (KL/ED/Chi),
+    independent of the criterion's own ``_pair_divergence``.
+    """
+    cdef float64_t s
+
+    if qk == 0.0:
+        return 0.0
+
+    if qk < EPS:
+        qk = EPS
+    elif qk > 1.0 - EPS:
+        qk = 1.0 - EPS
+
+    if pk == 0.0:
+        s = -log(1.0 - qk)
+    elif pk == 1.0:
+        s = -log(qk)
+    else:
+        s = pk * log(pk / qk) + (1.0 - pk) * log((1.0 - pk) / (1.0 - qk))
+    return s
+
 
 cdef class UpliftClassificationCriterion(CausalRegressionCriterion):
     """Base class for kernel-backed uplift split criteria."""
@@ -73,6 +115,7 @@ cdef class UpliftClassificationCriterion(CausalRegressionCriterion):
         # / ``min_samples_treatment`` before fitting.
         self.n_reg = 0.0
         self.min_samples_treatment = 0
+        self.normalization = 0
         self.has_parent = 0
         self.parent_summary_p.resize(n_outputs, 0.0)
         self._buf_node.resize(n_outputs, 0.0)
@@ -91,6 +134,67 @@ cdef class UpliftClassificationCriterion(CausalRegressionCriterion):
         for t in range(1, self.n_outputs):
             d += self._pair_divergence(p[t], p_c)
         return d
+
+    cdef float64_t _node_metric(self, float64_t* p) noexcept nogil:
+        """Per-node quantity M in the split gain ``p*M_left + (1-p)*M_right - M_node``.
+
+        Defaults to the summed treatment-vs-control divergence (KL/ED/Chi); CTS
+        overrides it with the max over groups.
+        """
+        return self._divergence_of(p)
+
+    cdef bint _normalizable(self) noexcept nogil:
+        """Whether Rzepakowski normalization applies to this criterion."""
+        return 1
+
+    cdef float64_t _norm_factor(self) noexcept nogil:
+        """Rzepakowski normalization factor (legacy ``arr_normI`` else-branch).
+
+        Computed from the *raw* group counts of the current node and one child
+        (``uplift.pyx`` ~1673-1733). ``arr_normI`` is asymmetric -- it reads only
+        the child legacy calls "left", i.e. the ``col_vals >= value`` partition
+        (``group_counts_by_divide`` ~286). The sklearn splitter's left child is
+        the complementary ``X <= threshold`` side, so legacy-left is the kernel's
+        ``state.right``; the factor must be built from ``state.right``. Always
+        >= 0.5, so dividing the gain by it preserves the gain's sign while
+        re-ranking splits.
+        """
+        cdef int32_t i
+        cdef float64_t n_c = self.state.node.count_1d[0]
+        cdef float64_t n_c_gt = self.state.right.count_1d[0]
+        cdef float64_t sum_n_t = 0.0
+        cdef float64_t sum_n_t_gt = 0.0
+        cdef float64_t n_t_i, pt_a, pc_a, pt_a_i
+        cdef float64_t norm_res = 0.0
+
+        for i in range(1, self.n_outputs):
+            sum_n_t += self.state.node.count_1d[i]
+            sum_n_t_gt += self.state.right.count_1d[i]
+
+        pt_a = sum_n_t_gt / (sum_n_t + 0.1)
+        pc_a = n_c_gt / (n_c + 0.1)
+
+        # Part 1
+        norm_res += (
+            NORM_ALPHA
+            * _entropy_h(sum_n_t / (sum_n_t + n_c), n_c / (sum_n_t + n_c))
+            * _kl_divergence(pt_a, pc_a)
+        )
+        # Parts 2 & 3
+        for i in range(1, self.n_outputs):
+            n_t_i = self.state.node.count_1d[i]
+            pt_a_i = self.state.right.count_1d[i] / (n_t_i + 0.1)
+            norm_res += (
+                (1.0 - NORM_ALPHA)
+                * _entropy_h(n_t_i / (n_t_i + n_c), n_c / (n_t_i + n_c))
+                * _kl_divergence(pt_a_i, pc_a)
+            )
+            norm_res += n_t_i / (sum_n_t + n_c) * _entropy_h(pt_a_i, -1.0)
+        # Part 4
+        norm_res += n_c / (sum_n_t + n_c) * _entropy_h(pc_a, -1.0)
+        # Part 5
+        norm_res += 0.5
+        return norm_res
 
     cdef void _reg_summary(
         self,
@@ -141,14 +245,16 @@ cdef class UpliftClassificationCriterion(CausalRegressionCriterion):
     ) noexcept nogil:
         """Store the split gain in ``state.left.split_metric``.
 
-        gain = p * D_left + (1 - p) * D_right - D_node, where p is the fraction of
-        samples routed to the left child and each ``D`` is the divergence of the
-        corresponding *regularized* summary: the node shrinks toward its parent,
-        the children shrink toward the node. A candidate split whose left or right
-        child has any group below ``min_samples_treatment`` is inadmissible and
-        gets gain ``-inf`` so the split search never selects it.
+        gain = p * M_left + (1 - p) * M_right - M_node, where p is the fraction of
+        samples routed to the left child and each ``M`` (:meth:`_node_metric`) is
+        evaluated on the corresponding *regularized* summary: the node shrinks
+        toward its parent, the children shrink toward the node. When normalization
+        is enabled (and the criterion is normalizable) the gain is divided by
+        :meth:`_norm_factor`. A candidate split whose left or right child has any
+        group below ``min_samples_treatment`` is inadmissible and gets gain
+        ``-inf`` so the split search never selects it.
 
-        ``impurity_left`` / ``impurity_right`` are set to the child divergences for
+        ``impurity_left`` / ``impurity_right`` are set to the child metrics for
         interpretability only; the builder reads the gain via
         :meth:`impurity_improvement`.
         """
@@ -158,7 +264,7 @@ cdef class UpliftClassificationCriterion(CausalRegressionCriterion):
         cdef float64_t min_right = self.state.right.count_1d[0]
         cdef float64_t* s_node = &self._buf_node[0]
         cdef float64_t* s_child = &self._buf_child[0]
-        cdef float64_t d_node, d_left, d_right, p
+        cdef float64_t m_node, m_left, m_right, p, gain
 
         for g in range(1, self.n_outputs):
             cnt = self.state.left.count_1d[g]
@@ -175,19 +281,23 @@ cdef class UpliftClassificationCriterion(CausalRegressionCriterion):
             return
 
         self._reg_summary(self.state.node, &self.parent_summary_p[0], self.has_parent, s_node)
-        d_node = self._divergence_of(s_node)
+        m_node = self._node_metric(s_node)
 
         # Children always shrink toward the (regularized) current node.
         self._reg_summary(self.state.left, s_node, 1, s_child)
-        d_left = self._divergence_of(s_child)
+        m_left = self._node_metric(s_child)
 
         self._reg_summary(self.state.right, s_node, 1, s_child)
-        d_right = self._divergence_of(s_child)
+        m_right = self._node_metric(s_child)
 
         p = self.weighted_n_left / self.weighted_n_node_samples
-        impurity_left[0] = d_left
-        impurity_right[0] = d_right
-        self.state.left.split_metric = p * d_left + (1.0 - p) * d_right - d_node
+        gain = p * m_left + (1.0 - p) * m_right - m_node
+        if self.normalization and self._normalizable():
+            gain = gain / self._norm_factor()
+
+        impurity_left[0] = m_left
+        impurity_right[0] = m_right
+        self.state.left.split_metric = gain
 
     cdef float64_t impurity_improvement(
         self,
@@ -244,3 +354,23 @@ cdef class ChiCriterion(UpliftClassificationCriterion):
         cdef float64_t denom_pc = p_c if p_c > EPS else EPS
         cdef float64_t denom_1_pc = (1.0 - p_c) if (1.0 - p_c) > EPS else EPS
         return diff_sq / denom_pc + diff_sq / denom_1_pc
+
+
+cdef class CTSCriterion(UpliftClassificationCriterion):
+    """Contextual Treatment Selection (legacy ``evaluate_CTS`` / ``arr_evaluate_CTS``).
+
+    The node metric is the max over *all* groups (control included) of
+    ``P(Y=1|T=g)``, so the gain ``p*max_left + (1-p)*max_right - max_node`` favors
+    splits that raise the best achievable outcome. Legacy never normalizes CTS.
+    """
+
+    cdef float64_t _node_metric(self, float64_t* p) noexcept nogil:
+        cdef float64_t m = p[0]
+        cdef int32_t g
+        for g in range(1, self.n_outputs):
+            if p[g] > m:
+                m = p[g]
+        return m
+
+    cdef bint _normalizable(self) noexcept nogil:
+        return 0

--- a/causalml/inference/tree/_uplift/_tree.py
+++ b/causalml/inference/tree/_uplift/_tree.py
@@ -3,10 +3,10 @@
 Mirrors ``causal/_tree.py`` but wires the shared ``_tree`` kernel to the uplift
 criteria and the uplift builders (``_uplift/_builder.py``), which thread the
 Rzepakowski ``n_reg`` / ``min_samples_treatment`` parent-shrinkage regularization
-down the tree. This module is internal; it is not exported from
-``tree/__init__.py`` and the legacy ``UpliftTreeClassifier`` remains the public
-default. Normalization, honesty, and the forest are handled in later issues of the
-epic.
+down the tree. The criteria also support Rzepakowski ``normalization``. This
+module is internal; it is not exported from ``tree/__init__.py`` and the legacy
+``UpliftTreeClassifier`` remains the public default. Honesty and the forest are
+handled in later issues of the epic.
 """
 
 import numbers
@@ -25,12 +25,13 @@ from .._tree._classes import Tree, BaseDecisionTree
 from .._tree._splitter import Splitter
 
 from ._builder import DepthFirstUpliftTreeBuilder, BestFirstUpliftTreeBuilder
-from ._criterion import KLCriterion, EDCriterion, ChiCriterion
+from ._criterion import KLCriterion, EDCriterion, ChiCriterion, CTSCriterion
 
 UPLIFT_TREE_CRITERIA = {
     "KL": KLCriterion,
     "ED": EDCriterion,
     "Chi": ChiCriterion,
+    "CTS": CTSCriterion,
 }
 
 
@@ -187,6 +188,8 @@ class BaseUpliftDecisionTree(BaseDecisionTree):
             # Rzepakowski parent-shrinkage regularization (issue #947).
             criterion.n_reg = getattr(self, "n_reg", 0)
             criterion.min_samples_treatment = getattr(self, "min_samples_treatment", 0)
+            # Rzepakowski normalization (issue #948).
+            criterion.normalization = getattr(self, "normalization", False)
 
         SPLITTERS = SPARSE_SPLITTERS if issparse(X) else DENSE_SPLITTERS
 

--- a/causalml/inference/tree/_uplift/uplifttree.py
+++ b/causalml/inference/tree/_uplift/uplifttree.py
@@ -1,10 +1,11 @@
 """Experimental kernel-backed uplift tree classifier.
 
 Not part of the public API -- this exists to prove numerical parity of the
-kernel-backed KL / ED / Chi criteria against the legacy ``UpliftTreeClassifier``
-before the public classes are switched over. It supports the Rzepakowski
-``n_reg`` / ``min_samples_treatment`` regularization; normalization, honesty,
-pruning, and the forest are handled in later issues of the epic.
+kernel-backed KL / ED / Chi / CTS criteria against the legacy
+``UpliftTreeClassifier`` before the public classes are switched over. It supports
+the Rzepakowski ``n_reg`` / ``min_samples_treatment`` regularization and
+``normalization``; honesty, pruning, and the forest are handled in later issues of
+the epic.
 """
 
 from typing import Union
@@ -31,6 +32,7 @@ class _KernelUpliftTreeClassifier(BaseUpliftDecisionTree):
         min_samples_split: Union[int, float] = 2,
         min_samples_treatment: int = 10,
         n_reg: int = 100,
+        normalization: bool = True,
         max_features: Union[int, float, str, None] = None,
         min_weight_fraction_leaf: float = 0.0,
         random_state: int = None,
@@ -38,6 +40,7 @@ class _KernelUpliftTreeClassifier(BaseUpliftDecisionTree):
         self.control_name = control_name
         self.min_samples_treatment = min_samples_treatment
         self.n_reg = n_reg
+        self.normalization = normalization
         super().__init__(
             criterion=criterion,
             splitter="best",

--- a/tests/test_uplift_trees_kernel.py
+++ b/tests/test_uplift_trees_kernel.py
@@ -54,6 +54,29 @@ def _make_binary_feature_data(
     return X, treatment, y
 
 
+def _make_normalization_sensitive_data(n_samples=2000, n_features=6, seed=1):
+    """Binary-feature uplift data on which Rzepakowski normalization re-ranks splits.
+
+    Unlike :func:`_make_binary_feature_data` (balanced 50/50 assignment, so every
+    candidate split has a near-constant normalization factor and normalization is
+    effectively a no-op), here treatment assignment is *correlated with* ``X[:, 0]``.
+    The treatment/control balance -- and hence the per-split normalization factor
+    ``arr_normI`` -- then varies across candidate splits, so ``normalization=True``
+    genuinely changes the chosen splits. This is what exercises ``_norm_factor``
+    (and would catch it reading the wrong child).
+    """
+    rng = np.random.RandomState(seed)
+    X = rng.randint(0, 2, size=(n_samples, n_features)).astype(np.float32)
+    ptreat = np.where(X[:, 0] > 0, 0.75, 0.30)
+    treatment = np.where(rng.rand(n_samples) < ptreat, "treatment1", CONTROL_NAME)
+    is_t = treatment == "treatment1"
+    base = 0.35 + 0.08 * X[:, 1] - 0.04 * X[:, 2] + 0.05 * X[:, 3]
+    lift = 0.12 * X[:, 0] + 0.08 * X[:, 4] - 0.05 * X[:, 5]
+    p = np.where(is_t, base + lift, base)
+    y = (rng.rand(n_samples) < np.clip(p, 0.0, 1.0)).astype(int)
+    return X, treatment, y
+
+
 def _fit_pair(
     X,
     treatment,
@@ -63,12 +86,14 @@ def _fit_pair(
     min_samples_leaf=100,
     n_reg=0,
     min_samples_treatment=0,
+    normalization=False,
 ):
     """Fit the kernel-backed tree and the parity-configured legacy tree.
 
-    ``n_reg`` / ``min_samples_treatment`` are passed identically to both trees so
-    the Rzepakowski parent-shrinkage regularization (issue #947) can be exercised;
-    the defaults (0, 0) disable it for the no-regularization parity cases.
+    ``n_reg`` / ``min_samples_treatment`` (issue #947) and ``normalization``
+    (issue #948) are passed identically to both trees so the regularization and
+    normalization can be exercised; the defaults disable them for the plain parity
+    cases.
     """
     kern = _KernelUpliftTreeClassifier(
         criterion=criterion,
@@ -77,6 +102,7 @@ def _fit_pair(
         min_samples_leaf=min_samples_leaf,
         min_samples_treatment=min_samples_treatment,
         n_reg=n_reg,
+        normalization=normalization,
         random_state=RANDOM_SEED,
     )
     kern.fit(X, treatment, y)
@@ -88,7 +114,7 @@ def _fit_pair(
         min_samples_leaf=min_samples_leaf,
         min_samples_treatment=min_samples_treatment,
         n_reg=n_reg,
-        normalization=False,
+        normalization=normalization,
         honesty=False,
         random_state=RANDOM_SEED,
     )
@@ -258,3 +284,140 @@ def test_kernel_uplift_min_samples_treatment_gates_splits():
     )
     ungated.fit(X, treatment, y)
     assert ungated.tree_.node_count > 1
+
+
+# --- Normalization + CTS parity (issue #948) --------------------------------
+
+
+@pytest.mark.parametrize("criterion", KERNEL_UPLIFT_CRITERIA)
+@pytest.mark.parametrize("kernel_max_depth", [1, 2, 3])
+def test_kernel_uplift_parity_normalized(criterion, kernel_max_depth):
+    """Whole-tree parity with Rzepakowski normalization on (KL/ED/Chi)."""
+    X, treatment, y = _make_binary_feature_data()
+    kern, legacy = _fit_pair(
+        X,
+        treatment,
+        y,
+        criterion,
+        kernel_max_depth,
+        n_reg=LEGACY_N_REG,
+        min_samples_treatment=LEGACY_MIN_SAMPLES_TREATMENT,
+        normalization=True,
+    )
+
+    kernel_proba = kern.predict_proba_by_group(X)
+    legacy_proba = legacy.predict(X)
+
+    assert_array_almost_equal(kernel_proba, legacy_proba, decimal=8)
+
+
+@pytest.mark.parametrize("criterion", KERNEL_UPLIFT_CRITERIA)
+def test_kernel_uplift_parity_normalized_multi_treatment(criterion):
+    X, treatment, y = _make_binary_feature_data(
+        n_samples=4500,
+        n_features=6,
+        treatment_names=("treatment1", "treatment2"),
+        seed=7,
+    )
+    kern, legacy = _fit_pair(
+        X,
+        treatment,
+        y,
+        criterion,
+        kernel_max_depth=2,
+        n_reg=LEGACY_N_REG,
+        min_samples_treatment=LEGACY_MIN_SAMPLES_TREATMENT,
+        normalization=True,
+    )
+
+    kernel_proba = kern.predict_proba_by_group(X)
+    legacy_proba = legacy.predict(X)
+
+    assert kernel_proba.shape[1] == 3  # control + 2 treatments
+    assert_array_almost_equal(kernel_proba, legacy_proba, decimal=8)
+
+
+@pytest.mark.parametrize("criterion", KERNEL_UPLIFT_CRITERIA)
+def test_kernel_uplift_parity_normalization_effective(criterion):
+    """Normalized parity on data where normalization actually re-ranks splits.
+
+    The balanced-assignment parity tests above run on data where normalization
+    never changes the chosen split, so they cannot detect a wrong
+    ``_norm_factor`` (e.g. one built from the wrong child). Here treatment is
+    correlated with ``X[:, 0]`` so normalization flips the tree; the kernel must
+    (a) still match the legacy tree exactly *and* (b) differ from the
+    unnormalized tree -- otherwise the flag is a silent no-op.
+    """
+    X, treatment, y = _make_normalization_sensitive_data()
+    kern, legacy = _fit_pair(
+        X,
+        treatment,
+        y,
+        criterion,
+        kernel_max_depth=3,
+        n_reg=LEGACY_N_REG,
+        min_samples_treatment=LEGACY_MIN_SAMPLES_TREATMENT,
+        normalization=True,
+    )
+    plain, _ = _fit_pair(
+        X,
+        treatment,
+        y,
+        criterion,
+        kernel_max_depth=3,
+        n_reg=LEGACY_N_REG,
+        min_samples_treatment=LEGACY_MIN_SAMPLES_TREATMENT,
+        normalization=False,
+    )
+    kern_proba = kern.predict_proba_by_group(X)
+
+    # (a) exact parity with the legacy normalized tree.
+    assert_array_almost_equal(kern_proba, legacy.predict(X), decimal=8)
+    # (b) normalization is not silently ignored: it changes the fitted tree here.
+    assert not np.allclose(kern_proba, plain.predict_proba_by_group(X))
+
+
+@pytest.mark.parametrize("kernel_max_depth", [1, 2, 3])
+def test_kernel_uplift_parity_cts_single_treatment(kernel_max_depth):
+    """CTS parity with legacy defaults (n_reg=100, mst=10). CTS ignores normalization."""
+    X, treatment, y = _make_binary_feature_data()
+    kern, legacy = _fit_pair(
+        X,
+        treatment,
+        y,
+        "CTS",
+        kernel_max_depth,
+        n_reg=LEGACY_N_REG,
+        min_samples_treatment=LEGACY_MIN_SAMPLES_TREATMENT,
+        normalization=True,
+    )
+
+    kernel_proba = kern.predict_proba_by_group(X)
+    legacy_proba = legacy.predict(X)
+
+    assert_array_almost_equal(kernel_proba, legacy_proba, decimal=8)
+
+
+def test_kernel_uplift_parity_cts_multi_treatment():
+    X, treatment, y = _make_binary_feature_data(
+        n_samples=4500,
+        n_features=6,
+        treatment_names=("treatment1", "treatment2"),
+        seed=7,
+    )
+    kern, legacy = _fit_pair(
+        X,
+        treatment,
+        y,
+        "CTS",
+        kernel_max_depth=2,
+        n_reg=LEGACY_N_REG,
+        min_samples_treatment=LEGACY_MIN_SAMPLES_TREATMENT,
+        normalization=True,
+    )
+
+    kernel_proba = kern.predict_proba_by_group(X)
+    legacy_proba = legacy.predict(X)
+
+    assert kernel_proba.shape[1] == 3  # control + 2 treatments
+    assert_array_almost_equal(kernel_proba, legacy_proba, decimal=8)


### PR DESCRIPTION
**Stacked on #961 (issue #947) — review/merge #961 first.** Base is `feature/947-uplift-split-regularization`, so the diff below is only the #948 changes; GitHub retargets to `master` once #961 lands.

Part of the tree-unification epic #945 (child #948). Ports Rzepakowski split-gain **normalization** and the **CTS** criterion onto the kernel-backed uplift trees, keeping exact parity with the legacy `UpliftTreeClassifier`.

## What

- **`normalization`** (Rzepakowski et al. 2012, `arr_normI`, α=0.9): when enabled, the split gain is divided by `_norm_factor`, re-ranking splits by the treatment-vs-control distribution divergence. Refactors the per-node quantity behind a virtual `_node_metric` and adds a `_normalizable` hook so CTS can opt out (legacy never normalizes CTS).
- **`CTSCriterion`** (Contextual Treatment Selection, `evaluate_CTS`): node metric is the max over all groups of P(Y=1|T=g); the gain favors splits that raise the best achievable outcome. Wired in as the `"CTS"` criterion.

## Correctness note (the subtle bit)

`arr_normI` is **asymmetric** — it reads only *one* child's counts. Legacy's "left" branch is `col_vals >= value`, which is the sklearn splitter's **right** child, so `_norm_factor` reads `state.right`. Reading the left child passes every balanced-assignment parity test (where normalization never changes the chosen split) but selects the wrong split once treatment is correlated with a feature — which the new tests exercise.

## Tests

- Exact 8-decimal whole-tree parity with legacy for KL/ED/Chi with `normalization=True`, plus CTS single/multi-treatment, all at legacy defaults (`n_reg=100`, `min_samples_treatment=10`).
- A normalization-sensitive dataset + a parity test that *also* asserts normalization actually changes the fitted tree (guards a silent no-op or a wrong `_norm_factor`).
- Verified out-of-band over a 720-case sweep (40 seeds × KL/ED/Chi × depths 1–3 × norm on/off): 0 mismatches, 29 genuine norm-flips.
- 48 kernel + 47 legacy/causal tests pass locally.

Leaf predictions remain the raw `P(Y=1|T=g)` — normalization affects only the growth gain, matching legacy. Honesty, pruning, forest, and the public switchover follow in later epic children.
