### PR TITLE
Add two-class uplift criteria DDP/IT/CIT to the kernel tree (#949)

### DIFF
--- a/causalml/inference/tree/_uplift/_criterion.pxd
+++ b/causalml/inference/tree/_uplift/_criterion.pxd
@@ -30,8 +30,11 @@ cdef class UpliftClassificationCriterion(CausalRegressionCriterion):
     cdef vector[float64_t] parent_summary_p
 
     # Scratch buffers (size n_outputs) for the regularized node / child summaries.
+    # ``_buf_left`` and ``_buf_right`` coexist so criteria that need both children
+    # at once (IT / CIT) can read them together.
     cdef vector[float64_t] _buf_node
-    cdef vector[float64_t] _buf_child
+    cdef vector[float64_t] _buf_left
+    cdef vector[float64_t] _buf_right
 
     # Divergence contribution of a single treatment-vs-control pair. Overridden
     # by each concrete criterion (KL / ED / Chi).
@@ -41,7 +44,11 @@ cdef class UpliftClassificationCriterion(CausalRegressionCriterion):
     # Per-node split metric: gain = p*M(left) + (1-p)*M(right) - M(node). Defaults
     # to ``_divergence_of``; CTS overrides it with the max over groups.
     cdef float64_t _node_metric(self, float64_t* p) noexcept nogil
-    # Whether ``_norm_factor`` normalization applies (0 for CTS).
+    # Split gain from the regularized node / left / right summaries and the left
+    # fraction ``p``. Defaults to ``p*M(left)+(1-p)*M(right)-M(node)`` (KL/ED/Chi/
+    # CTS); DDP/IT/CIT override it with their own two-class gain forms.
+    cdef float64_t _split_gain(self, float64_t* s_node, float64_t* s_left, float64_t* s_right, float64_t p) noexcept nogil
+    # Whether ``_norm_factor`` normalization applies (0 for CTS/DDP/IT/CIT).
     cdef bint _normalizable(self) noexcept nogil
     # Rzepakowski normalization factor from the raw node / one-child group counts
     # (the child matching legacy ``arr_normI``'s asymmetric "left" = X >= value).

--- a/causalml/inference/tree/_uplift/_criterion.pyx
+++ b/causalml/inference/tree/_uplift/_criterion.pyx
@@ -45,7 +45,7 @@ rule), ``uplift_classification_results`` (~1942, the raw leaf estimate),
 the ``min_samples_treatment`` reject in ``growDecisionTreeFrom`` (~2270-2316).
 """
 
-from libc.math cimport log, INFINITY
+from libc.math cimport log, sqrt, fabs, INFINITY
 
 from .._tree._typedefs cimport int32_t, intp_t
 
@@ -119,7 +119,8 @@ cdef class UpliftClassificationCriterion(CausalRegressionCriterion):
         self.has_parent = 0
         self.parent_summary_p.resize(n_outputs, 0.0)
         self._buf_node.resize(n_outputs, 0.0)
-        self._buf_child.resize(n_outputs, 0.0)
+        self._buf_left.resize(n_outputs, 0.0)
+        self._buf_right.resize(n_outputs, 0.0)
 
     cdef float64_t _pair_divergence(self, float64_t p_t, float64_t p_c) noexcept nogil:
         # Overridden by each concrete criterion.
@@ -142,6 +143,25 @@ cdef class UpliftClassificationCriterion(CausalRegressionCriterion):
         overrides it with the max over groups.
         """
         return self._divergence_of(p)
+
+    cdef float64_t _split_gain(
+        self,
+        float64_t* s_node,
+        float64_t* s_left,
+        float64_t* s_right,
+        float64_t p,
+    ) noexcept nogil:
+        """Split gain from the regularized node / left / right summaries.
+
+        Defaults to ``p*M(left) + (1-p)*M(right) - M(node)`` (the divergence and
+        CTS criteria). DDP/IT/CIT override this with their own two-class gain
+        forms, reading the raw group counts from ``self.state`` as needed.
+        """
+        return (
+            p * self._node_metric(s_left)
+            + (1.0 - p) * self._node_metric(s_right)
+            - self._node_metric(s_node)
+        )
 
     cdef bint _normalizable(self) noexcept nogil:
         """Whether Rzepakowski normalization applies to this criterion."""
@@ -245,14 +265,13 @@ cdef class UpliftClassificationCriterion(CausalRegressionCriterion):
     ) noexcept nogil:
         """Store the split gain in ``state.left.split_metric``.
 
-        gain = p * M_left + (1 - p) * M_right - M_node, where p is the fraction of
-        samples routed to the left child and each ``M`` (:meth:`_node_metric`) is
-        evaluated on the corresponding *regularized* summary: the node shrinks
-        toward its parent, the children shrink toward the node. When normalization
-        is enabled (and the criterion is normalizable) the gain is divided by
-        :meth:`_norm_factor`. A candidate split whose left or right child has any
-        group below ``min_samples_treatment`` is inadmissible and gets gain
-        ``-inf`` so the split search never selects it.
+        The gain (:meth:`_split_gain`, criterion-specific) is evaluated on the
+        *regularized* summaries: the node shrinks toward its parent, the children
+        shrink toward the node. When normalization is enabled (and the criterion
+        is normalizable) the gain is divided by :meth:`_norm_factor`. A candidate
+        split whose left or right child has any group below
+        ``min_samples_treatment`` is inadmissible and gets gain ``-inf`` so the
+        split search never selects it.
 
         ``impurity_left`` / ``impurity_right`` are set to the child metrics for
         interpretability only; the builder reads the gain via
@@ -263,8 +282,9 @@ cdef class UpliftClassificationCriterion(CausalRegressionCriterion):
         cdef float64_t min_left = self.state.left.count_1d[0]
         cdef float64_t min_right = self.state.right.count_1d[0]
         cdef float64_t* s_node = &self._buf_node[0]
-        cdef float64_t* s_child = &self._buf_child[0]
-        cdef float64_t m_node, m_left, m_right, p, gain
+        cdef float64_t* s_left = &self._buf_left[0]
+        cdef float64_t* s_right = &self._buf_right[0]
+        cdef float64_t p, gain
 
         for g in range(1, self.n_outputs):
             cnt = self.state.left.count_1d[g]
@@ -281,22 +301,17 @@ cdef class UpliftClassificationCriterion(CausalRegressionCriterion):
             return
 
         self._reg_summary(self.state.node, &self.parent_summary_p[0], self.has_parent, s_node)
-        m_node = self._node_metric(s_node)
-
         # Children always shrink toward the (regularized) current node.
-        self._reg_summary(self.state.left, s_node, 1, s_child)
-        m_left = self._node_metric(s_child)
-
-        self._reg_summary(self.state.right, s_node, 1, s_child)
-        m_right = self._node_metric(s_child)
+        self._reg_summary(self.state.left, s_node, 1, s_left)
+        self._reg_summary(self.state.right, s_node, 1, s_right)
 
         p = self.weighted_n_left / self.weighted_n_node_samples
-        gain = p * m_left + (1.0 - p) * m_right - m_node
+        gain = self._split_gain(s_node, s_left, s_right, p)
         if self.normalization and self._normalizable():
             gain = gain / self._norm_factor()
 
-        impurity_left[0] = m_left
-        impurity_right[0] = m_right
+        impurity_left[0] = self._node_metric(s_left)
+        impurity_right[0] = self._node_metric(s_right)
         self.state.left.split_metric = gain
 
     cdef float64_t impurity_improvement(
@@ -371,6 +386,136 @@ cdef class CTSCriterion(UpliftClassificationCriterion):
             if p[g] > m:
                 m = p[g]
         return m
+
+    cdef bint _normalizable(self) noexcept nogil:
+        return 0
+
+
+cdef class DDPCriterion(UpliftClassificationCriterion):
+    """Delta-Delta-P (legacy ``evaluate_DDP`` / ``arr_evaluate_DDP``).
+
+    Two-class only. The gain is the absolute difference between the children's
+    uplift ``DDP(s) = sum_t (P(Y=1|T=t) - P(Y=1|control))``:
+    ``|DDP(left) - DDP(right)|``. Legacy never normalizes DDP.
+    """
+
+    cdef float64_t _split_gain(
+        self,
+        float64_t* s_node,
+        float64_t* s_left,
+        float64_t* s_right,
+        float64_t p,
+    ) noexcept nogil:
+        cdef float64_t d_left = 0.0
+        cdef float64_t d_right = 0.0
+        cdef int32_t t
+        for t in range(1, self.n_outputs):
+            d_left += s_left[t] - s_left[0]
+            d_right += s_right[t] - s_right[0]
+        return fabs(d_left - d_right)
+
+    cdef bint _normalizable(self) noexcept nogil:
+        return 0
+
+
+cdef class ITCriterion(UpliftClassificationCriterion):
+    """Interaction-Tree squared t-statistic (legacy ``evaluate_IT`` / ``arr_evaluate_IT``).
+
+    Two-class only. The gain is the squared t-statistic of the difference in
+    treatment effect between the two children, using each regularized per-group
+    rate's Bernoulli variance ``p*(1-p)`` and the raw group counts. Legacy never
+    normalizes IT.
+    """
+
+    cdef float64_t _split_gain(
+        self,
+        float64_t* s_node,
+        float64_t* s_left,
+        float64_t* s_right,
+        float64_t p,
+    ) noexcept nogil:
+        # Control (group 0) and the single treatment (group 1); two-class only.
+        cdef float64_t y_l_0 = s_left[0]
+        cdef float64_t y_r_0 = s_right[0]
+        cdef float64_t y_l_1 = s_left[1]
+        cdef float64_t y_r_1 = s_right[1]
+        cdef float64_t n_3 = self.state.left.count_1d[0]
+        cdef float64_t n_4 = self.state.right.count_1d[0]
+        cdef float64_t n_1 = self.state.left.count_1d[1]
+        cdef float64_t n_2 = self.state.right.count_1d[1]
+        # Bernoulli sample variances.
+        cdef float64_t s_1 = y_l_1 * (1.0 - y_l_1)
+        cdef float64_t s_2 = y_r_1 * (1.0 - y_r_1)
+        cdef float64_t s_3 = y_l_0 * (1.0 - y_l_0)
+        cdef float64_t s_4 = y_r_0 * (1.0 - y_r_0)
+        cdef float64_t sum_n = (n_1 - 1.0) + (n_2 - 1.0) + (n_3 - 1.0) + (n_4 - 1.0)
+        cdef float64_t w_1 = (n_1 - 1.0) / sum_n
+        cdef float64_t w_2 = (n_2 - 1.0) / sum_n
+        cdef float64_t w_3 = (n_3 - 1.0) / sum_n
+        cdef float64_t w_4 = (n_4 - 1.0) / sum_n
+        # Pooled estimator of the constant variance.
+        cdef float64_t sigma = sqrt(w_1 * s_1 + w_2 * s_2 + w_3 * s_3 + w_4 * s_4)
+        cdef float64_t g_s = (
+            ((y_l_1 - y_l_0) - (y_r_1 - y_r_0))
+            / (sigma * sqrt(1.0 / n_1 + 1.0 / n_2 + 1.0 / n_3 + 1.0 / n_4))
+        )
+        return g_s * g_s
+
+    cdef bint _normalizable(self) noexcept nogil:
+        return 0
+
+
+cdef class CITCriterion(UpliftClassificationCriterion):
+    """Causal-Inference-Tree likelihood-ratio statistic (legacy ``evaluate_CIT`` / ``arr_evaluate_CIT``).
+
+    Two-class only. The gain is the likelihood-ratio test statistic comparing the
+    split model to the parent, using each regularized per-group rate's Bernoulli
+    SSE ``n*p*(1-p)`` and the raw group counts. Legacy never normalizes CIT.
+    """
+
+    cdef float64_t _split_gain(
+        self,
+        float64_t* s_node,
+        float64_t* s_left,
+        float64_t* s_right,
+        float64_t p,
+    ) noexcept nogil:
+        cdef float64_t n_l_t_0 = self.state.left.count_1d[0]
+        cdef float64_t n_r_t_0 = self.state.right.count_1d[0]
+        cdef float64_t n_l_t_1 = self.state.left.count_1d[1]
+        cdef float64_t n_r_t_1 = self.state.right.count_1d[1]
+        cdef float64_t n_l_t = n_l_t_1 + n_l_t_0
+        cdef float64_t n_r_t = n_r_t_1 + n_r_t_0
+        cdef float64_t n_t = n_l_t + n_r_t
+        cdef float64_t n_t_1 = n_l_t_1 + n_r_t_1
+        cdef float64_t n_t_0 = n_l_t_0 + n_r_t_0
+        # Bernoulli SSE = n * p * (1 - p) per group.
+        cdef float64_t sse_tau_l = (
+            n_l_t_0 * s_left[0] * (1.0 - s_left[0])
+            + n_l_t_1 * s_left[1] * (1.0 - s_left[1])
+        )
+        cdef float64_t sse_tau_r = (
+            n_r_t_0 * s_right[0] * (1.0 - s_right[0])
+            + n_r_t_1 * s_right[1] * (1.0 - s_right[1])
+        )
+        cdef float64_t sse_tau = (
+            n_t_0 * s_node[0] * (1.0 - s_node[0])
+            + n_t_1 * s_node[1] * (1.0 - s_node[1])
+        )
+        # Maximized log-likelihoods.
+        cdef float64_t i_tau_l = (
+            -(n_l_t / 2.0) * log(n_l_t * sse_tau_l)
+            + n_l_t_1 * log(n_l_t_1) + n_l_t_0 * log(n_l_t_0)
+        )
+        cdef float64_t i_tau_r = (
+            -(n_r_t / 2.0) * log(n_r_t * sse_tau_r)
+            + n_r_t_1 * log(n_r_t_1) + n_r_t_0 * log(n_r_t_0)
+        )
+        cdef float64_t i_tau = (
+            -(n_t / 2.0) * log(n_t * sse_tau)
+            + n_t_1 * log(n_t_1) + n_t_0 * log(n_t_0)
+        )
+        return 2.0 * (i_tau_l + i_tau_r - i_tau)
 
     cdef bint _normalizable(self) noexcept nogil:
         return 0

--- a/causalml/inference/tree/_uplift/_tree.py
+++ b/causalml/inference/tree/_uplift/_tree.py
@@ -25,14 +25,29 @@ from .._tree._classes import Tree, BaseDecisionTree
 from .._tree._splitter import Splitter
 
 from ._builder import DepthFirstUpliftTreeBuilder, BestFirstUpliftTreeBuilder
-from ._criterion import KLCriterion, EDCriterion, ChiCriterion, CTSCriterion
+from ._criterion import (
+    KLCriterion,
+    EDCriterion,
+    ChiCriterion,
+    CTSCriterion,
+    DDPCriterion,
+    ITCriterion,
+    CITCriterion,
+)
 
 UPLIFT_TREE_CRITERIA = {
     "KL": KLCriterion,
     "ED": EDCriterion,
     "Chi": ChiCriterion,
     "CTS": CTSCriterion,
+    "DDP": DDPCriterion,
+    "IT": ITCriterion,
+    "CIT": CITCriterion,
 }
+
+# Criteria that contrast a single treatment against control and cannot handle
+# more than one treatment group (legacy ``uplift.pyx`` ~533-536).
+TWO_CLASS_ONLY_CRITERIA = {"DDP", "IT", "CIT"}
 
 
 def get_check_y_params() -> dict:
@@ -87,6 +102,19 @@ class BaseUpliftDecisionTree(BaseDecisionTree):
 
         # n_outputs_ is the number of groups [control, treatment_1, ..., treatment_{n-1}]
         self.n_outputs_ = y.shape[1]
+
+        # DDP/IT/CIT contrast a single treatment against control; reject
+        # multi-treatment inputs, matching legacy uplift.pyx (~533-536).
+        if (
+            isinstance(self.criterion, str)
+            and self.criterion in TWO_CLASS_ONLY_CRITERIA
+            and self.n_outputs_ > 2
+        ):
+            raise ValueError(
+                f"The {self.criterion} criterion can only cope with two-class "
+                "problems (control vs. a single treatment); got "
+                f"{self.n_outputs_ - 1} treatment groups."
+            )
 
         if getattr(y, "dtype", None) != DOUBLE or not y.flags.contiguous:
             y = np.ascontiguousarray(y, dtype=DOUBLE)

--- a/causalml/inference/tree/_uplift/uplifttree.py
+++ b/causalml/inference/tree/_uplift/uplifttree.py
@@ -1,11 +1,12 @@
 """Experimental kernel-backed uplift tree classifier.
 
 Not part of the public API -- this exists to prove numerical parity of the
-kernel-backed KL / ED / Chi / CTS criteria against the legacy
+kernel-backed KL / ED / Chi / CTS / DDP / IT / CIT criteria against the legacy
 ``UpliftTreeClassifier`` before the public classes are switched over. It supports
 the Rzepakowski ``n_reg`` / ``min_samples_treatment`` regularization and
-``normalization``; honesty, pruning, and the forest are handled in later issues of
-the epic.
+``normalization``; the two-class criteria (DDP/IT/CIT) reject multi-treatment
+input. IDDP, honesty, pruning, and the forest are handled in later issues of the
+epic.
 """
 
 from typing import Union

--- a/tests/test_uplift_trees_kernel.py
+++ b/tests/test_uplift_trees_kernel.py
@@ -421,3 +421,52 @@ def test_kernel_uplift_parity_cts_multi_treatment():
 
     assert kernel_proba.shape[1] == 3  # control + 2 treatments
     assert_array_almost_equal(kernel_proba, legacy_proba, decimal=8)
+
+
+# --- Two-class / variance criteria: DDP, IT, CIT (issue #949) ----------------
+# These contrast a single treatment against control (two-class only) and are
+# never normalized. (IDDP is deferred to the honesty issue #950, since legacy
+# forces honesty=True for IDDP and the kernel has no honesty pass yet.)
+TWO_CLASS_CRITERIA = ["DDP", "IT", "CIT"]
+
+
+@pytest.mark.parametrize("criterion", TWO_CLASS_CRITERIA)
+@pytest.mark.parametrize("kernel_max_depth", [1, 2, 3])
+def test_kernel_uplift_parity_two_class(criterion, kernel_max_depth):
+    """DDP/IT/CIT parity with legacy defaults (n_reg=100, mst=10), single treatment."""
+    X, treatment, y = _make_binary_feature_data()
+    kern, legacy = _fit_pair(
+        X,
+        treatment,
+        y,
+        criterion,
+        kernel_max_depth,
+        n_reg=LEGACY_N_REG,
+        min_samples_treatment=LEGACY_MIN_SAMPLES_TREATMENT,
+        normalization=True,  # ignored by these criteria; matches legacy defaults
+    )
+
+    kernel_proba = kern.predict_proba_by_group(X)
+    legacy_proba = legacy.predict(X)
+
+    assert_array_almost_equal(kernel_proba, legacy_proba, decimal=8)
+
+
+@pytest.mark.parametrize("criterion", TWO_CLASS_CRITERIA)
+def test_kernel_uplift_two_class_guard_rejects_multi_treatment(criterion):
+    """DDP/IT/CIT must reject more than one treatment group (legacy uplift.pyx)."""
+    X, treatment, y = _make_binary_feature_data(
+        n_samples=3000,
+        n_features=6,
+        treatment_names=("treatment1", "treatment2"),
+        seed=7,
+    )
+    kern = _KernelUpliftTreeClassifier(
+        criterion=criterion,
+        control_name=CONTROL_NAME,
+        max_depth=2,
+        min_samples_leaf=100,
+        random_state=RANDOM_SEED,
+    )
+    with pytest.raises(ValueError, match="two-class"):
+        kern.fit(X, treatment, y)


### PR DESCRIPTION
**Stacked on #962 (issue #948) — review/merge #962 first.** Base is `feature/948-normalization`, so the diff below is only the #949 changes; GitHub retargets down the stack as the parents land.

Part of the tree-unification epic #945 (child #949). Ports the two-class / variance-based uplift split criteria onto the kernel-backed uplift trees, keeping exact parity with the legacy `UpliftTreeClassifier`.

## What

- **DDP** (delta-delta-P): gain = `|DDP(left) - DDP(right)|`, where `DDP(s) = Σ_t (P(Y=1|T=t) - P(Y=1|control))`.
- **IT** (interaction tree): squared t-statistic of the effect difference between the children, from each regularized rate's Bernoulli variance `p*(1-p)` and the raw group counts.
- **CIT** (causal inference tree): likelihood-ratio test statistic.

All three contrast a single treatment against control and are **never normalized**; a **two-class guard** raises on multi-treatment input (matching legacy `uplift.pyx` ~533-536).

## How

These gains aren't the `p·M_left + (1-p)·M_right - M_node` divergence form, so the gain is now computed by a virtual `_split_gain(s_node, s_left, s_right, p)` (the divergence/CTS criteria keep the default). IT/CIT need both regularized child summaries at once, so a second scratch buffer `_buf_right` was added. Leaf predictions remain the raw `P(Y=1|T=g)`.

## Tests

- Exact 8-decimal whole-tree parity vs legacy for DDP/IT/CIT at depths 1-3 (legacy defaults `n_reg=100`, `min_samples_treatment=10`), single treatment.
- A multi-treatment guard test (DDP/IT/CIT raise).
- Verified out-of-band over a 270-case sweep (30 seeds × 3 criteria × depths 1-3): 0 mismatches.
- 60 kernel + 47 legacy/causal tests pass locally.

## Deferred: IDDP → #950 (honesty)

Legacy **forces `honesty=True` for IDDP** (`uplift.pyx:468`), and the kernel has no honesty pass yet, so kernel-vs-legacy IDDP parity can't be verified until the honest leaf re-estimation lands. IDDP (its gain + second `arr_normI` normalization variant + the honesty coupling) will land in #950 where it's testable, rather than shipping unverifiable here.
