### PR TITLE
Add validation-based pruning to the kernel uplift tree (#951)

### DIFF
--- a/causalml/inference/tree/_tree/_tree.pyx
+++ b/causalml/inference/tree/_tree/_tree.pyx
@@ -1820,6 +1820,31 @@ def _build_pruned_tree_ccp(
                        pruning_controller.capacity)
 
 
+def build_pruned_tree_from_mask(
+    Tree tree,  # OUT
+    Tree orig_tree,
+    const unsigned char[:] leaves_in_subtree,
+):
+    """Build a pruned tree from an explicit leaf mask.
+
+    Like :func:`_build_pruned_tree_ccp`, but the nodes to collapse into leaves
+    are supplied directly via ``leaves_in_subtree`` instead of being derived by
+    cost-complexity pruning. Used by the uplift validation-based pruner (issue
+    #951).
+
+    Parameters
+    ----------
+    tree : Tree
+        Location to place the pruned tree.
+    orig_tree : Tree
+        Original tree.
+    leaves_in_subtree : unsigned char memoryview, shape=(node_count,)
+        1 for every node that must be a leaf in the pruned tree -- both the
+        collapsed internal nodes and the surviving original leaves.
+    """
+    _build_pruned_tree(tree, orig_tree, leaves_in_subtree, orig_tree.node_count)
+
+
 def ccp_pruning_path(Tree orig_tree):
     """Computes the cost complexity pruning path.
 

--- a/causalml/inference/tree/_uplift/uplifttree.py
+++ b/causalml/inference/tree/_uplift/uplifttree.py
@@ -4,10 +4,10 @@ Not part of the public API -- this exists to prove numerical parity of the
 kernel-backed KL / ED / Chi / CTS / DDP / IT / CIT / IDDP criteria against the
 legacy ``UpliftTreeClassifier`` before the public classes are switched over. It
 supports the Rzepakowski ``n_reg`` / ``min_samples_treatment`` regularization,
-``normalization``, and the honest approach (held-out leaf re-estimation, Athey &
-Imbens 2016); the two-class criteria (DDP/IT/CIT/IDDP) reject multi-treatment
-input and IDDP forces honesty on. Pruning and the forest are handled in later
-issues of the epic.
+``normalization``, the honest approach (held-out leaf re-estimation, Athey &
+Imbens 2016), and validation-based pruning; the two-class criteria
+(DDP/IT/CIT/IDDP) reject multi-treatment input and IDDP forces honesty on. The
+forest is handled in a later issue of the epic.
 """
 
 from typing import Union
@@ -20,6 +20,7 @@ from sklearn.utils import check_array
 from causalml.inference.meta.utils import check_treatment_vector
 
 from ._tree import BaseUpliftDecisionTree
+from .._tree._tree import Tree, build_pruned_tree_from_mask
 
 
 class _KernelUpliftTreeClassifier(BaseUpliftDecisionTree):
@@ -153,6 +154,139 @@ class _KernelUpliftTreeClassifier(BaseUpliftDecisionTree):
             n_pos = np.bincount(leaves, weights=col[valid], minlength=n_nodes)
             p = np.divide(n_pos, n, out=np.zeros_like(n), where=n > 0)
             value[is_leaf, g, 0] = p[is_leaf]
+
+    def prune(
+        self,
+        X: np.ndarray,
+        treatment: np.ndarray,
+        y: np.ndarray,
+        minGain: float = 0.0001,
+        rule: str = "maxAbsDiff",
+    ):
+        """Validation-based bottom-up merge pruning.
+
+        Collapses an internal node whose two children are leaves into a leaf
+        when the split does not improve the treatment-effect estimate on the
+        held-out validation set ``(X, treatment, y)``, cascading upward until no
+        further merge helps, then rebuilds a compact tree.
+
+        This reimplements the *intent* of the legacy
+        ``UpliftTreeClassifier.prune`` on the kernel tree. (The legacy recursion
+        never descended past the root -- its guard only recurses when a child is
+        missing -- so legacy pruning is a no-op; there is no legacy behavior to
+        match bit-for-bit here.)
+
+        Args:
+            X (np.ndarray): validation feature matrix.
+            treatment (np.ndarray): validation treatment vector (incl. control).
+            y (np.ndarray): validation binary outcome vector.
+            minGain (float): a split is kept only if it raises the summed child
+                uplift over the parent by more than this.
+            rule (str): ``"maxAbsDiff"`` (max-abs-diff treatment, signed,
+                child-size weighted) or ``"bestUplift"`` (best positive-uplift
+                treatment, total sample-fraction weighted).
+        Returns:
+            self
+        """
+        if rule not in ("maxAbsDiff", "bestUplift"):
+            raise ValueError(f"rule must be 'maxAbsDiff' or 'bestUplift'; got {rule!r}")
+
+        X = check_array(X, dtype=DTYPE, accept_sparse="csc")
+        treatment = np.asarray(treatment)
+        y = (np.asarray(y).ravel() > 0).astype(np.float64)
+        t_idx = np.fromiter(
+            (self._group2index[t] for t in treatment), dtype=int, count=len(treatment)
+        )
+
+        tree = self.tree_
+        n_nodes = tree.node_count
+        left = tree.children_left
+        right = tree.children_right
+        is_orig_leaf = left == -1
+        n_groups = self.n_outputs_
+
+        # Build-time (training) per-group P(Y=1|T=g) at every node -- the raw
+        # leaf estimate the kernel stores in ``value``; a collapsed node falls
+        # back to this, mirroring legacy ``backupResults``.
+        train_p = tree.value[:, :, 0]  # (n_nodes, n_groups)
+        diffs = train_p[:, 1:] - train_p[:, [0]]  # (n_nodes, n_treatments)
+        rows = np.arange(n_nodes)
+        max_diff_t = np.abs(diffs).argmax(axis=1) + 1  # group idx of max |uplift|
+        max_diff_sign = np.sign(diffs[rows, max_diff_t - 1])
+        best_t = diffs.argmax(axis=1) + 1  # group idx of best positive uplift
+        best_t = np.where(diffs[rows, best_t - 1] > 0, best_t, 0)  # 0 == control
+
+        # Validation per-node, per-group counts and positive-outcome rates.
+        dpath = tree.decision_path(X)  # sparse (n_val, n_nodes)
+        n_val = np.zeros((n_nodes, n_groups))
+        p_val = np.zeros((n_nodes, n_groups))
+        for g in range(n_groups):
+            in_g = t_idx == g
+            if not in_g.any():
+                continue
+            dp_g = dpath[in_g]
+            counts = np.asarray(dp_g.sum(axis=0)).ravel()
+            pos = np.asarray(dp_g[y[in_g] > 0].sum(axis=0)).ravel()
+            n_val[:, g] = counts
+            p_val[:, g] = np.divide(
+                pos, counts, out=np.zeros_like(counts, dtype=float), where=counts > 0
+            )
+
+        def uplift(node, treat_idx, sign):
+            """Signed validation uplift of ``treat_idx`` vs control at ``node``."""
+            return sign * (p_val[node, treat_idx] - p_val[node, 0])
+
+        def keep_split(node):
+            """True if the split at ``node`` should be kept (not pruned)."""
+            lft, rgt = left[node], right[node]
+            if rule == "maxAbsDiff":
+                cur = uplift(node, max_diff_t[node], max_diff_sign[node])
+                child = 0.0
+                for c in (lft, rgt):
+                    mt = max_diff_t[c]
+                    denom = n_val[node, mt] + n_val[node, 0]
+                    if denom <= 0:
+                        continue
+                    weight = (n_val[c, mt] + n_val[c, 0]) / denom
+                    child += uplift(c, mt, max_diff_sign[c]) * weight
+                gain = child - cur
+            else:  # bestUplift
+                cur = uplift(node, best_t[node], 1.0)
+                total = n_val[lft].sum() + n_val[rgt].sum()
+                if total <= 0:
+                    return False
+                child = n_val[lft].sum() / total * uplift(
+                    lft, best_t[lft], 1.0
+                ) + n_val[rgt].sum() / total * uplift(rgt, best_t[rgt], 1.0)
+                gain = child - cur
+            return gain > minGain and child >= 0.0
+
+        # Bottom-up merge: repeatedly collapse internal nodes whose children are
+        # both leaves-now and whose split is not worth keeping, until stable.
+        collapsed = np.zeros(n_nodes, dtype=bool)
+        changed = True
+        while changed:
+            changed = False
+            for node in range(n_nodes):
+                if is_orig_leaf[node] or collapsed[node]:
+                    continue
+                lft, rgt = left[node], right[node]
+                leaf_now_l = is_orig_leaf[lft] or collapsed[lft]
+                leaf_now_r = is_orig_leaf[rgt] or collapsed[rgt]
+                if leaf_now_l and leaf_now_r and not keep_split(node):
+                    collapsed[node] = True
+                    changed = True
+
+        if not collapsed.any():
+            return self
+
+        # Rebuild a compact tree: every surviving leaf (original leaves +
+        # collapsed internal nodes) is marked in the mask.
+        leaves_in_subtree = (is_orig_leaf | collapsed).astype(np.uint8)
+        pruned = Tree(self.n_features_, self.tree_.n_classes, self.n_outputs_)
+        build_pruned_tree_from_mask(pruned, self.tree_, leaves_in_subtree)
+        self.tree_ = pruned
+        return self
 
     def predict_proba_by_group(
         self, X: np.ndarray, check_input: bool = True

--- a/tests/test_uplift_trees_kernel.py
+++ b/tests/test_uplift_trees_kernel.py
@@ -686,3 +686,137 @@ def test_kernel_uplift_iddp_guard_rejects_multi_treatment():
     )
     with pytest.raises(ValueError, match="two-class"):
         kern.fit(X, treatment, y)
+
+
+# --- Validation-based pruning (issue #951) -----------------------------------
+# The kernel ``prune`` collapses an internal node whose two children are leaves
+# into a leaf when the split does not improve the treatment effect on a held-out
+# validation set, cascading upward, then rebuilds a compact tree. Legacy
+# ``UpliftTreeClassifier.prune`` is a no-op (its recursion never descends past
+# the root), so these are behavioral checks, not legacy bit-parity.
+PRUNE_RULES = ["maxAbsDiff", "bestUplift"]
+
+
+def _make_prune_signal_data(n_samples=4000, n_features=6, seed=RANDOM_SEED):
+    """Feature 0 drives a strong, generalizing uplift sign flip; the rest noise.
+
+    A deep tree over-splits on the noise features; only the feature-0 split
+    reproduces on an independent validation draw, so pruning should drop the
+    noise splits and keep the feature-0 split.
+    """
+    rng = np.random.RandomState(seed)
+    X = rng.randint(0, 2, size=(n_samples, n_features)).astype(np.float32)
+    treatment = np.where(rng.rand(n_samples) < 0.5, "treatment1", CONTROL_NAME)
+    lift = np.where(X[:, 0] > 0, 0.30, -0.30)
+    p = np.where(treatment == "treatment1", 0.4 + lift, 0.4)
+    y = (rng.rand(n_samples) < np.clip(p, 0.0, 1.0)).astype(int)
+    return X, treatment, y
+
+
+def _fit_prunable_tree(X, treatment, y, max_depth=4):
+    """A deep, unregularized tree that over-splits (so there is something to prune)."""
+    kern = _KernelUpliftTreeClassifier(
+        criterion="KL",
+        control_name=CONTROL_NAME,
+        max_depth=max_depth,
+        min_samples_leaf=50,
+        n_reg=0,
+        min_samples_treatment=0,
+        normalization=False,
+        random_state=RANDOM_SEED,
+    )
+    kern.fit(X, treatment, y)
+    return kern
+
+
+def _reachable_node_ids(tree):
+    """Node ids reachable from the root by following children_left/right."""
+    left, right = tree.children_left, tree.children_right
+    seen, stack = set(), [0]
+    while stack:
+        node = stack.pop()
+        if node == -1 or node in seen:
+            continue
+        seen.add(node)
+        stack.extend((left[node], right[node]))
+    return seen
+
+
+@pytest.mark.parametrize("rule", PRUNE_RULES)
+def test_kernel_uplift_prune_reduces_and_stays_compact(rule):
+    X, t, y = _make_prune_signal_data(seed=RANDOM_SEED)
+    Xv, tv, yv = _make_prune_signal_data(seed=RANDOM_SEED + 1)
+    kern = _fit_prunable_tree(X, t, y)
+    before = kern.tree_.node_count
+    kern.prune(Xv, tv, yv, minGain=0.005, rule=rule)
+    after = kern.tree_.node_count
+
+    assert after < before  # pruning removed nodes
+    # Compact rebuild: every id < node_count is reachable, no orphans.
+    assert _reachable_node_ids(kern.tree_) == set(range(after))
+    left, right = kern.tree_.children_left, kern.tree_.children_right
+    assert ((left == -1) == (right == -1)).all()  # leaf iff no children
+
+
+@pytest.mark.parametrize("rule", PRUNE_RULES)
+def test_kernel_uplift_prune_idempotent(rule):
+    X, t, y = _make_prune_signal_data(seed=RANDOM_SEED)
+    Xv, tv, yv = _make_prune_signal_data(seed=RANDOM_SEED + 1)
+    kern = _fit_prunable_tree(X, t, y)
+    kern.prune(Xv, tv, yv, minGain=0.005, rule=rule)
+    once = kern.tree_.node_count
+    proba_once = kern.predict_proba_by_group(X)
+
+    kern.prune(Xv, tv, yv, minGain=0.005, rule=rule)
+    assert kern.tree_.node_count == once
+    assert_array_almost_equal(kern.predict_proba_by_group(X), proba_once, decimal=12)
+
+
+@pytest.mark.parametrize("rule", PRUNE_RULES)
+def test_kernel_uplift_prune_mingain_monotonic(rule):
+    X, t, y = _make_prune_signal_data(seed=RANDOM_SEED)
+    Xv, tv, yv = _make_prune_signal_data(seed=RANDOM_SEED + 1)
+    counts = []
+    for min_gain in (0.0, 0.001, 0.01, 0.05, 0.2):
+        kern = _fit_prunable_tree(X, t, y)
+        kern.prune(Xv, tv, yv, minGain=min_gain, rule=rule)
+        counts.append(kern.tree_.node_count)
+    # Higher minGain prunes at least as aggressively.
+    assert all(a >= b for a, b in zip(counts, counts[1:]))
+
+
+@pytest.mark.parametrize("rule", PRUNE_RULES)
+def test_kernel_uplift_prune_keeps_generalizing_split(rule):
+    """The one generalizing split survives aggressive pruning; noise is dropped."""
+    X, t, y = _make_prune_signal_data(seed=RANDOM_SEED)
+    Xv, tv, yv = _make_prune_signal_data(seed=RANDOM_SEED + 1)
+    kern = _fit_prunable_tree(X, t, y)
+    kern.prune(Xv, tv, yv, minGain=0.05, rule=rule)
+
+    # Collapses to the single feature-0 split: root + two leaves.
+    assert kern.tree_.node_count == 3
+    assert kern.tree_.feature[0] == 0
+    # Predictions still recover the feature-0 uplift sign flip.
+    uplift = kern.predict(X)[:, 0]
+    assert uplift[X[:, 0] == 1].mean() > 0.1
+    assert uplift[X[:, 0] == 0].mean() < -0.1
+
+
+@pytest.mark.parametrize("rule", PRUNE_RULES)
+def test_kernel_uplift_prune_predictions_valid(rule):
+    X, t, y = _make_prune_signal_data(seed=RANDOM_SEED)
+    Xv, tv, yv = _make_prune_signal_data(seed=RANDOM_SEED + 1)
+    kern = _fit_prunable_tree(X, t, y)
+    kern.prune(Xv, tv, yv, minGain=0.01, rule=rule)
+
+    proba = kern.predict_proba_by_group(X)
+    assert proba.shape == (X.shape[0], kern.n_outputs_)
+    assert np.isfinite(proba).all()
+    assert (proba >= 0).all() and (proba <= 1).all()
+
+
+def test_kernel_uplift_prune_invalid_rule_raises():
+    X, t, y = _make_prune_signal_data(seed=RANDOM_SEED)
+    kern = _fit_prunable_tree(X, t, y)
+    with pytest.raises(ValueError, match="maxAbsDiff"):
+        kern.prune(X, t, y, rule="bogus")


### PR DESCRIPTION
Part of the tree-unification epic #945 (v1.0 M1). Issue #951. Targets `master` (builds on #950).

## What
Reimplements uplift-tree pruning on the shared `_tree` kernel as a post-build method `prune(X, treatment, y, minGain=0.0001, rule="maxAbsDiff")`:

- Route the held-out validation set through the grown tree (`decision_path`) to get per-node, per-group validation counts and outcome rates.
- Bottom-up: collapse an internal node whose two children are leaves into a leaf whenever the split does **not** improve the validation treatment-effect estimate, cascading upward until stable. Two rules, mirroring the legacy public API: `maxAbsDiff` (max-abs-diff treatment, signed, child-size weighted) and `bestUplift` (best positive-uplift treatment, total sample-fraction weighted). A collapsed node falls back to the raw training leaf estimate the kernel already stores in `value` (the analogue of legacy `backupResults`).
- Rebuild a **compact** tree from the surviving-leaf mask via a new Python-callable `build_pruned_tree_from_mask` wrapper over the vendored kernel's existing `_build_pruned_tree` (arbitrary leaf mask, mirroring the CCP entry point). No orphaned nodes, `node_count`/`max_depth` stay correct.

## Why not bit-parity with legacy
Legacy `UpliftTreeClassifier.prune` is **a no-op on normally-built trees**: its recursion guard (`if tree.trueBranch is None or tree.falseBranch is None:`) only descends when a child is *missing*, so it never visits internal nodes and never merges anything (verified: a fitted tree stays unchanged even with `minGain` set to prune everything; there's also a latent `control_name`-as-string-vs-index bug in the `maxAbsDiff` branch, and no tests). So there is no working legacy behavior to match, and per maintainer direction this PR implements correct pruning verified behaviorally. I'll file a short follow-up issue noting the legacy bug.

## Verification (behavioral)
`tests/test_uplift_trees_kernel.py`, both rules: pruning reduces the node count and leaves a **compact** tree (every id reachable, no orphans, leaf-consistency); is **idempotent**; is **monotonic in minGain**; **keeps a strong generalizing split** (a feature-0 uplift sign-flip collapses to exactly root + two leaves at high `minGain`, and predictions still recover the flip) while dropping noise splits; and leaves predictions finite and in `[0,1]`. Full suite **99 passed** (11 new); legacy uplift + causal suites **47 passed**.

Remaining epic children: #952 forest → #953 plot → #954 serialization/`BaseEstimator` → #955 switchover.