### PR TITLE
Add kernel-backed uplift random forest (#952)

### DIFF
--- a/causalml/inference/tree/_uplift/upliftforest.py
+++ b/causalml/inference/tree/_uplift/upliftforest.py
@@ -1,0 +1,232 @@
+"""Experimental kernel-backed uplift random forest classifier.
+
+Not part of the public API -- this bags the experimental
+``_KernelUpliftTreeClassifier`` on scikit-learn's ``ForestRegressor``
+scaffolding (mirroring ``CausalRandomForestRegressor``) to prove parity with
+the legacy joblib-bagging ``UpliftRandomForestClassifier`` before the public
+class is switched over.
+
+Like the legacy forest it bootstraps by resampling rows (so a tree can miss a
+treatment group entirely -- the #569 sparse-group case handled by
+``_align_tree_predict``), keeps the ``joblib_prefer`` knob, and predicts the
+per-treatment delta columns (``full_output`` returns the full frame). Early
+stopping on a validation set -- a legacy tree feature -- is not supported here
+because the kernel tree does not implement it.
+"""
+
+from typing import Union
+
+import numpy as np
+import pandas as pd
+from joblib import Parallel, delayed
+from numpy import float32 as DTYPE
+from sklearn.ensemble._forest import ForestRegressor, MAX_INT
+from sklearn.utils import check_array, check_random_state
+
+from .uplifttree import _KernelUpliftTreeClassifier
+
+
+def _align_tree_predict(tree, X, forest_classes, class_to_forest_idx):
+    """Predict per-group P(Y=1|T=g) with one tree, aligned to the forest classes.
+
+    A row-subsampled bootstrap can exclude whole treatment groups, so a tree's
+    ``classes_`` may be a strict subset of the forest's. This scatters the
+    tree's per-group columns into the forest-wide ordering (zero-filling absent
+    groups) before the forest averages -- the #569 sparse-group case. A leaf
+    with no samples of an otherwise-present group yields a NaN rate under
+    ``min_samples_treatment=0``; those are zeroed so they do not poison the
+    ensemble average (the legacy tree instead backed such leaves up to the
+    parent rate).
+    """
+    raw = np.nan_to_num(tree.predict_proba_by_group(X=X), nan=0.0)
+    if len(tree.classes_) == len(forest_classes):
+        return raw
+    aligned = np.zeros((raw.shape[0], len(forest_classes)), dtype=raw.dtype)
+    for tree_idx, cls in enumerate(tree.classes_):
+        forest_idx = class_to_forest_idx.get(cls)
+        if forest_idx is not None:
+            aligned[:, forest_idx] = raw[:, tree_idx]
+    return aligned
+
+
+def _parallel_build_tree(tree, X, treatment, y, control_name, sample_weight):
+    """Fit one tree on a row-resampled bootstrap of ``(X, treatment, y)``.
+
+    Mirrors the legacy forest's bootstrap: draw ``len(X)`` rows with replacement
+    from the tree's own ``random_state`` (so a bootstrap can miss treatment
+    groups), then fit the kernel tree on that subset. A bootstrap that lands on
+    the control group alone (or drops the control group) carries no
+    treatment-effect signal and cannot grow an uplift tree, so it is dropped by
+    returning ``None`` -- only possible under extreme group imbalance (the #569
+    case). The legacy forest instead kept such trees as no-ops.
+    """
+    rng = check_random_state(tree.random_state)
+    idx = rng.choice(len(X), len(X))
+    t_sub = treatment[idx]
+    groups = set(t_sub)
+    if control_name not in groups or len(groups) < 2:
+        return None
+    sw = None if sample_weight is None else sample_weight[idx]
+    tree.fit(X[idx], t_sub, y[idx], sample_weight=sw, check_input=True)
+    return tree
+
+
+class _KernelUpliftRandomForestClassifier(ForestRegressor):
+    """A random forest of kernel-backed uplift trees.
+
+    Bags ``_KernelUpliftTreeClassifier`` on sklearn's ``ForestRegressor``
+    scaffolding. ``predict`` returns the per-treatment uplift deltas
+    ``P(Y=1|T=t) - P(Y=1|control)``; ``predict(..., full_output=True)`` returns
+    the full frame (per-group probabilities, recommended treatment, deltas,
+    ``max_delta``).
+    """
+
+    def __init__(
+        self,
+        control_name: Union[int, str] = "control",
+        n_estimators: int = 10,
+        *,
+        criterion: str = "KL",
+        max_depth: int = 5,
+        min_samples_leaf: int = 100,
+        min_samples_split: Union[int, float] = 2,
+        min_samples_treatment: int = 10,
+        n_reg: int = 10,
+        normalization: bool = True,
+        honesty: bool = False,
+        estimation_sample_size: float = 0.5,
+        max_features: Union[int, float, str, None] = "sqrt",
+        min_weight_fraction_leaf: float = 0.0,
+        n_jobs: int = -1,
+        random_state: int = None,
+        joblib_prefer: str = "threads",
+    ):
+        estimator = _KernelUpliftTreeClassifier(
+            criterion=criterion,
+            control_name=control_name,
+            max_depth=max_depth,
+            min_samples_leaf=min_samples_leaf,
+            min_samples_split=min_samples_split,
+            min_samples_treatment=min_samples_treatment,
+            n_reg=n_reg,
+            normalization=normalization,
+            honesty=honesty,
+            estimation_sample_size=estimation_sample_size,
+            max_features=max_features,
+            min_weight_fraction_leaf=min_weight_fraction_leaf,
+        )
+        super().__init__(
+            estimator=estimator,
+            n_estimators=n_estimators,
+            estimator_params=(
+                "criterion",
+                "control_name",
+                "max_depth",
+                "min_samples_leaf",
+                "min_samples_split",
+                "min_samples_treatment",
+                "n_reg",
+                "normalization",
+                "honesty",
+                "estimation_sample_size",
+                "max_features",
+                "min_weight_fraction_leaf",
+                "random_state",
+            ),
+            bootstrap=True,
+            n_jobs=n_jobs,
+            random_state=random_state,
+        )
+        self.criterion = criterion
+        self.control_name = control_name
+        self.max_depth = max_depth
+        self.min_samples_leaf = min_samples_leaf
+        self.min_samples_split = min_samples_split
+        self.min_samples_treatment = min_samples_treatment
+        self.n_reg = n_reg
+        self.normalization = normalization
+        self.honesty = honesty
+        self.estimation_sample_size = estimation_sample_size
+        self.max_features = max_features
+        self.min_weight_fraction_leaf = min_weight_fraction_leaf
+        self.joblib_prefer = joblib_prefer
+
+    def fit(
+        self,
+        X: np.ndarray,
+        treatment: np.ndarray,
+        y: np.ndarray,
+        sample_weight: np.ndarray = None,
+    ):
+        """Fit the forest.
+
+        Args:
+            X (np.ndarray): feature matrix
+            treatment (np.ndarray): treatment vector, includes the control group
+            y (np.ndarray): binary outcome vector
+            sample_weight (np.ndarray): optional sample weights
+        Returns:
+            self
+        """
+        X = check_array(X, accept_sparse=False, dtype=DTYPE)
+        treatment = np.asarray(treatment)
+        y = np.asarray(y)
+        self.n_features_in_ = X.shape[1]
+
+        # Forest-wide class ordering; control is reserved for column 0.
+        treatment_groups = sorted(g for g in set(treatment) if g != self.control_name)
+        self.classes_ = [self.control_name] + treatment_groups
+        self.n_classes_ = len(self.classes_)
+        self.n_outputs_ = self.n_classes_
+
+        self._validate_estimator()
+        rng = check_random_state(self.random_state)
+
+        # Build the trees, seeding each from the parent RNG in the same order as
+        # the legacy forest so the per-tree bootstrap draws line up.
+        trees = [
+            self._make_estimator(append=False, random_state=None)
+            for _ in range(self.n_estimators)
+        ]
+        for tree in trees:
+            tree.random_state = rng.randint(MAX_INT)
+
+        trees = Parallel(n_jobs=self.n_jobs, prefer=self.joblib_prefer)(
+            delayed(_parallel_build_tree)(
+                tree, X, treatment, y, self.control_name, sample_weight
+            )
+            for tree in trees
+        )
+        self.estimators_ = [tree for tree in trees if tree is not None]
+        return self
+
+    def predict(self, X: np.ndarray, full_output: bool = False):
+        """Predict per-treatment uplift.
+
+        Args:
+            X (np.ndarray): feature matrix
+            full_output (bool): if True return the full frame (per-group
+                probabilities, recommended treatment, deltas, ``max_delta``);
+                otherwise return only the delta columns as an array.
+        Returns:
+            np.ndarray of shape (n_samples, n_treatments), or a pandas.DataFrame
+            when ``full_output`` is True.
+        """
+        class_to_forest_idx = {cls: idx for idx, cls in enumerate(self.classes_)}
+        preds = Parallel(n_jobs=self.n_jobs, prefer=self.joblib_prefer)(
+            delayed(_align_tree_predict)(tree, X, self.classes_, class_to_forest_idx)
+            for tree in self.estimators_
+        )
+        y_pred_ensemble = sum(preds) / len(self.estimators_)
+
+        df_res = pd.DataFrame(y_pred_ensemble, columns=self.classes_)
+        df_res["recommended_treatment"] = y_pred_ensemble.argmax(axis=1)
+
+        delta_cols = [f"delta_{group}" for group in self.classes_[1:]]
+        for group in self.classes_[1:]:
+            df_res[f"delta_{group}"] = df_res[group] - df_res[self.control_name]
+        df_res["max_delta"] = df_res[delta_cols].max(axis=1)
+
+        if full_output:
+            return df_res
+        return df_res[delta_cols].values

--- a/tests/test_uplift_trees_kernel.py
+++ b/tests/test_uplift_trees_kernel.py
@@ -5,7 +5,9 @@ uplift tree on the shared ``_tree`` Cython kernel via the new
 ``UpliftClassificationCriterion`` -- reproduces the legacy ``UpliftTreeClassifier``
 predictions exactly for the KL / ED / Chi / CTS / DDP / IT / CIT / IDDP criteria,
 with or without regularization, normalization, and the honest approach (pruning is
-handled in a later issue of the epic).
+handled in a later issue of the epic). A final section bags the kernel tree into
+``_KernelUpliftRandomForestClassifier`` (issue #952) and checks the same
+whole-forest parity against the legacy ``UpliftRandomForestClassifier``.
 
 Design notes
 ------------
@@ -22,13 +24,23 @@ Design notes
 """
 
 import numpy as np
+import pandas as pd
 import pytest
+from joblib import parallel_backend
 from numpy.testing import assert_array_almost_equal
+from sklearn.model_selection import train_test_split
 
-from causalml.inference.tree.uplift import UpliftTreeClassifier
+from causalml.inference.tree.uplift import (
+    UpliftTreeClassifier,
+    UpliftRandomForestClassifier,
+)
 from causalml.inference.tree._uplift.uplifttree import _KernelUpliftTreeClassifier
+from causalml.inference.tree._uplift.upliftforest import (
+    _KernelUpliftRandomForestClassifier,
+)
+from causalml.metrics import auuc_score
 
-from .const import RANDOM_SEED, CONTROL_NAME
+from .const import RANDOM_SEED, CONTROL_NAME, TREATMENT_NAMES, CONVERSION
 
 KERNEL_UPLIFT_CRITERIA = ["KL", "ED", "Chi"]
 
@@ -820,3 +832,252 @@ def test_kernel_uplift_prune_invalid_rule_raises():
     kern = _fit_prunable_tree(X, t, y)
     with pytest.raises(ValueError, match="maxAbsDiff"):
         kern.prune(X, t, y, rule="bogus")
+
+
+# ---------------------------------------------------------------------------
+# Forest (issue #952): _KernelUpliftRandomForestClassifier bags the kernel tree
+# on sklearn's ForestRegressor scaffolding, replacing the legacy joblib forest.
+# ---------------------------------------------------------------------------
+
+FOREST_CRITERIA = ["KL", "ED", "Chi"]
+
+
+def _fit_forest_pair(
+    X,
+    treatment,
+    y,
+    criterion,
+    kernel_max_depth,
+    n_estimators=5,
+    normalization=False,
+    honesty=False,
+    random_state=RANDOM_SEED,
+):
+    """Fit the kernel forest and a structurally-identical legacy forest.
+
+    Both forests draw per-tree seeds from the same parent RNG and bootstrap the
+    same rows, so with binary features (identical split candidates), all features
+    considered, and ``legacy_max_depth = kernel_max_depth + 1`` every tree -- and
+    therefore the averaged forest -- matches to full precision.
+    """
+    n_features = X.shape[1]
+    kern = _KernelUpliftRandomForestClassifier(
+        control_name=CONTROL_NAME,
+        n_estimators=n_estimators,
+        criterion=criterion,
+        max_depth=kernel_max_depth,
+        min_samples_leaf=100,
+        min_samples_treatment=0,
+        n_reg=0,
+        normalization=normalization,
+        honesty=honesty,
+        max_features=None,
+        random_state=random_state,
+    )
+    kern.fit(X, treatment, y)
+
+    legacy = UpliftRandomForestClassifier(
+        control_name=CONTROL_NAME,
+        n_estimators=n_estimators,
+        evaluationFunction=criterion,
+        max_depth=kernel_max_depth + LEGACY_DEPTH_OFFSET,
+        min_samples_leaf=100,
+        min_samples_treatment=0,
+        n_reg=0,
+        normalization=normalization,
+        honesty=honesty,
+        max_features=n_features,
+        random_state=random_state,
+    )
+    legacy.fit(X, treatment, y)
+    return kern, legacy
+
+
+@pytest.mark.parametrize("criterion", FOREST_CRITERIA)
+@pytest.mark.parametrize("normalization", [False, True])
+def test_kernel_uplift_forest_parity(criterion, normalization):
+    """The kernel forest reproduces the legacy forest's uplift deltas exactly."""
+    X, treatment, y = _make_binary_feature_data(
+        n_samples=3000,
+        n_features=6,
+        treatment_names=("treatment1", "treatment2"),
+        seed=RANDOM_SEED,
+    )
+    kern, legacy = _fit_forest_pair(
+        X, treatment, y, criterion, kernel_max_depth=3, normalization=normalization
+    )
+    assert kern.classes_ == legacy.classes_
+    assert_array_almost_equal(kern.predict(X), legacy.predict(X), decimal=8)
+
+
+def test_kernel_uplift_forest_honest_parity():
+    """Honest re-estimation carries through to whole-forest parity."""
+    X, treatment, y = _make_binary_feature_data(
+        n_samples=4000,
+        n_features=6,
+        treatment_names=("treatment1",),
+        seed=RANDOM_SEED,
+    )
+    kern, legacy = _fit_forest_pair(
+        X, treatment, y, "KL", kernel_max_depth=2, honesty=True
+    )
+    assert_array_almost_equal(kern.predict(X), legacy.predict(X), decimal=8)
+
+
+def test_kernel_uplift_forest_predict_shape_with_sparse_groups():
+    """#569: row-bootstrap can miss whole treatment groups; predict stays well-shaped.
+
+    Minority groups with a single sample are excluded from most bootstraps, so
+    some trees see a strict subset of the forest's classes (and some collapse to
+    control-only and are dropped). ``_align_tree_predict`` must still yield a
+    full-width, NaN-free prediction, identically in serial and parallel.
+    """
+    rng = np.random.RandomState(RANDOM_SEED)
+    n = 102
+    X = rng.randn(n, 3).astype(np.float32)
+    treatment = np.array(
+        [CONTROL_NAME] * 100 + [TREATMENT_NAMES[1]] + [TREATMENT_NAMES[2]]
+    )
+    y = rng.randint(0, 2, n)
+
+    model = _KernelUpliftRandomForestClassifier(
+        control_name=CONTROL_NAME,
+        n_estimators=10,
+        min_samples_leaf=1,
+        min_samples_treatment=0,
+        max_features=None,
+        random_state=RANDOM_SEED,
+        n_jobs=2,
+    )
+    model.fit(X, treatment, y)
+
+    # At least one surviving tree missed a group (the condition _align handles).
+    assert any(len(t.classes_) < len(model.classes_) for t in model.estimators_)
+
+    preds = model.predict(X)
+    assert preds.shape == (n, len(model.classes_) - 1)
+    assert not np.any(np.isnan(preds))
+
+    with parallel_backend("loky", n_jobs=2):
+        preds_par = model.predict(X)
+    assert np.allclose(preds, preds_par)
+
+
+@pytest.mark.parametrize("backend", ["loky", "threading", "multiprocessing"])
+@pytest.mark.parametrize("joblib_prefer", ["threads", "processes"])
+def test_kernel_uplift_forest_backend_determinism_and_auuc(
+    generate_classification_data, backend, joblib_prefer
+):
+    """Predictions are backend-invariant and beat random on AUUC.
+
+    Mirrors the legacy 12-case forest test (backends x joblib_prefer); the
+    early_stopping axis is dropped because the kernel tree has no validation-set
+    early stopping.
+    """
+    df, x_names = generate_classification_data()
+    df_train, df_test = train_test_split(df, test_size=0.2, random_state=RANDOM_SEED)
+
+    with parallel_backend(backend):
+        model = _KernelUpliftRandomForestClassifier(
+            control_name=CONTROL_NAME,
+            min_samples_leaf=50,
+            random_state=RANDOM_SEED,
+            joblib_prefer=joblib_prefer,
+        )
+        model.fit(
+            df_train[x_names].values,
+            df_train["treatment_group_key"].values,
+            df_train[CONVERSION].values,
+        )
+
+        predictions = {"single": model.predict(df_test[x_names].values)}
+        for name, be in [
+            ("loky", "loky"),
+            ("threading", "threading"),
+            ("mp", "multiprocessing"),
+        ]:
+            with parallel_backend(be, n_jobs=2):
+                predictions[name] = model.predict(df_test[x_names].values)
+
+    values = list(predictions.values())
+    assert all(np.array_equal(values[0], rest) for rest in values[1:])
+
+    result = pd.DataFrame(values[0], columns=model.classes_[1:])
+    best_treatment = np.where(
+        (result < 0).all(axis=1), CONTROL_NAME, result.idxmax(axis=1)
+    )
+    actual_is_best = np.where(df_test["treatment_group_key"] == best_treatment, 1, 0)
+    actual_is_control = np.where(df_test["treatment_group_key"] == CONTROL_NAME, 1, 0)
+    synthetic = (actual_is_best == 1) | (actual_is_control == 1)
+    synth = result[synthetic]
+    auuc_metrics = synth.assign(
+        is_treated=1 - actual_is_control[synthetic],
+        conversion=df_test.loc[synthetic, CONVERSION].values,
+        treatment_effect=df_test.loc[synthetic, "treatment_effect"].values,
+        uplift_tree=synth.max(axis=1),
+    ).drop(columns=list(model.classes_[1:]))
+    auuc = auuc_score(
+        auuc_metrics,
+        outcome_col=CONVERSION,
+        treatment_col="is_treated",
+        treatment_effect_col="treatment_effect",
+        normalize=True,
+    )
+    assert auuc["uplift_tree"] > 0.5
+
+
+def test_kernel_uplift_forest_full_output():
+    """full_output returns the per-group / recommendation / delta frame."""
+    X, treatment, y = _make_binary_feature_data(
+        n_samples=2000,
+        n_features=6,
+        treatment_names=("treatment1", "treatment2"),
+        seed=RANDOM_SEED,
+    )
+    model = _KernelUpliftRandomForestClassifier(
+        control_name=CONTROL_NAME,
+        n_estimators=5,
+        max_depth=3,
+        min_samples_leaf=100,
+        random_state=RANDOM_SEED,
+    )
+    model.fit(X, treatment, y)
+
+    delta = model.predict(X)
+    full = model.predict(X, full_output=True)
+    expected_cols = (
+        list(model.classes_)
+        + ["recommended_treatment"]
+        + [f"delta_{g}" for g in model.classes_[1:]]
+        + ["max_delta"]
+    )
+    assert list(full.columns) == expected_cols
+    assert full.shape[0] == X.shape[0]
+    # The bare-array predict is exactly the delta columns of the full frame.
+    assert_array_almost_equal(
+        delta, full[[f"delta_{g}" for g in model.classes_[1:]]].values
+    )
+
+
+def test_kernel_uplift_forest_feature_importances():
+    """feature_importances_ averages the trees and is a normalized distribution."""
+    X, treatment, y = _make_binary_feature_data(
+        n_samples=2000,
+        n_features=6,
+        treatment_names=("treatment1",),
+        seed=RANDOM_SEED,
+    )
+    model = _KernelUpliftRandomForestClassifier(
+        control_name=CONTROL_NAME,
+        n_estimators=5,
+        max_depth=3,
+        min_samples_leaf=100,
+        random_state=RANDOM_SEED,
+    )
+    model.fit(X, treatment, y)
+    fi = model.feature_importances_
+    assert fi.shape == (X.shape[1],)
+    assert np.isclose(fi.sum(), 1.0)
+    # Uplift split gains are not a monotone impurity decrease, so per-feature
+    # importances can be signed; they just have to be finite and averaged.
+    assert np.isfinite(fi).all()


### PR DESCRIPTION
## What

Reimplements `UpliftRandomForestClassifier` on scikit-learn's `ForestRegressor`
scaffolding as the experimental `_KernelUpliftRandomForestClassifier`, bagging
the kernel `_KernelUpliftTreeClassifier` (mirrors `CausalRandomForestRegressor`).
Part of the tree-unification epic #945 (issue #952, "6/9").

Not wired into the public API — it stays experimental alongside the kernel tree
until the epic switchover (#955).

## How

- **Bootstrap.** Legacy-style row resampling (so a bootstrap can miss whole
  treatment groups) via a vendored `_parallel_build_tree`, seeded from the same
  parent-RNG flow as the legacy forest.
- **`_align_tree_predict`.** Scatters each tree's per-group probabilities into
  the forest-wide class ordering (zero-filling absent groups) before averaging —
  the #569 sparse-group case. Degenerate control-only bootstraps carry no
  treatment signal and are dropped (only reachable under extreme imbalance; the
  legacy forest kept them as no-ops).
- **`predict`.** Returns per-treatment uplift deltas; `full_output=True` returns
  the per-group / recommended-treatment / delta frame. `joblib_prefer` preserved;
  `feature_importances_` inherited from `ForestRegressor` (per-tree averaging).
- No validation-set early stopping — the kernel tree does not implement it.

## Verify

New tests in `tests/test_uplift_trees_kernel.py`:

- **Whole-forest parity** vs the legacy `UpliftRandomForestClassifier`, bit-exact
  (`decimal=8`) on binary-feature data — KL/ED/Chi × normalization, plus a honest
  case. (Exact parity needs binary features + `legacy_max_depth = kernel + 1`;
  same conventions as the single-tree parity tests.)
- **#569** sparse-group predict-shape regression (1 sample per minority group):
  some tree misses a group, prediction is full-width and NaN-free, serial ==
  parallel.
- **Backend × `joblib_prefer`** determinism + AUUC > random (mirrors the legacy
  12-case test minus the early-stopping axis).
- `full_output` columns and `feature_importances_`.

Full kernel suite: 104 passed.

Part of #945.