### PR TITLE
Native missing-value (NaN) support for kernel uplift/causal trees (prereq for #955)

### DIFF
--- a/causalml/inference/tree/_uplift/_tree.py
+++ b/causalml/inference/tree/_uplift/_tree.py
@@ -65,7 +65,26 @@ class BaseUpliftDecisionTree(BaseDecisionTree):
     """
 
     def _support_missing_values(self, X) -> bool:
-        return False
+        """Whether native missing-value (NaN) splitting is available for ``X``.
+
+        Mirrors scikit-learn's ``BaseDecisionTree._support_missing_values``: the
+        kernel splitter carries the missing-value machinery for the dense
+        best-first splitter only (see ``__sklearn_tags__``), so NaNs are rejected
+        for sparse input or a non-default splitter.
+        """
+        return (
+            not issparse(X)
+            and self.__sklearn_tags__().input_tags.allow_nan
+            and self.monotonic_cst is None
+        )
+
+    def __sklearn_tags__(self):
+        tags = super().__sklearn_tags__()
+        # The uplift/causal criterion implements scikit-learn's per-feature
+        # missing-value accumulation, which the dense best splitter threads
+        # through; the random and sparse splitters do not.
+        tags.input_tags.allow_nan = self.splitter == "best"
+        return tags
 
     def fit(
         self,
@@ -79,11 +98,20 @@ class BaseUpliftDecisionTree(BaseDecisionTree):
         if self.ccp_alpha < 0.0:
             raise ValueError("ccp_alpha must be greater than or equal to 0")
 
+        missing_values_in_feature_mask = None
         if check_input:
-            check_X_params = dict(dtype=DTYPE, accept_sparse="csc")
+            check_X_params = dict(
+                dtype=DTYPE, accept_sparse="csc", ensure_all_finite=False
+            )
             check_y_params = get_check_y_params()
             X, y = validate_data(
                 self, X, y, validate_separately=(check_X_params, check_y_params)
+            )
+            # Native missing-value support (scikit-learn convention): rejects inf
+            # and, when NaNs are not supported, rejects them too; otherwise returns
+            # the per-feature missing mask threaded to the builder.
+            missing_values_in_feature_mask = (
+                self._compute_missing_values_in_feature_mask(X)
             )
             if issparse(X):
                 X.sort_indices()
@@ -260,7 +288,7 @@ class BaseUpliftDecisionTree(BaseDecisionTree):
                 self.min_impurity_decrease,
             )
         # First column of y is always the control group.
-        builder.build(self.tree_, X, y, sample_weight)
+        builder.build(self.tree_, X, y, sample_weight, missing_values_in_feature_mask)
 
         self._prune_tree()
 

--- a/causalml/inference/tree/_uplift/upliftforest.py
+++ b/causalml/inference/tree/_uplift/upliftforest.py
@@ -175,7 +175,11 @@ class _KernelUpliftRandomForestClassifier(SerializableLearner, ForestRegressor):
         Returns:
             self
         """
-        X = check_array(X, accept_sparse=False, dtype=DTYPE)
+        # NaNs are handled natively by the kernel trees (see
+        # ``_KernelUpliftTreeClassifier``); keep them through forest validation.
+        X = check_array(
+            X, accept_sparse=False, dtype=DTYPE, ensure_all_finite="allow-nan"
+        )
         treatment = np.asarray(treatment)
         y = np.asarray(y)
         self.n_features_in_ = X.shape[1]

--- a/causalml/inference/tree/_uplift/uplifttree.py
+++ b/causalml/inference/tree/_uplift/uplifttree.py
@@ -471,7 +471,12 @@ class _KernelUpliftTreeClassifier(SerializableLearner, BaseUpliftDecisionTree):
         }
         self.classes_ = [self.control_name] + self.unique_treatments
 
-        X = check_array(X, dtype=DTYPE, accept_sparse="csc")
+        # Missing (NaN) feature values are handled natively by the kernel
+        # splitter; finiteness is enforced (support-gated) by the base fit's
+        # ``_compute_missing_values_in_feature_mask``.
+        X = check_array(
+            X, dtype=DTYPE, accept_sparse="csc", ensure_all_finite="allow-nan"
+        )
         y = check_array(y, ensure_2d=False, dtype=None)
         y = (y > 0).astype(np.float64)
         self.n_samples, self.n_features = X.shape

--- a/causalml/inference/tree/causal/_criterion.pxd
+++ b/causalml/inference/tree/causal/_criterion.pxd
@@ -44,6 +44,7 @@ cdef class NodeState:
     cdef int32_t reset(self, intp_t n_outputs) except -1 nogil
     cdef int32_t update_counters(self) except -1 nogil
     cdef int32_t copy_from_state(self, NodeState state) except -1 nogil
+    cdef int32_t set_difference(self, NodeState a, NodeState b) except -1 nogil
     cdef int32_t increment_count(self, int32_t group_idx, float64_t value) except -1 nogil
     cdef int32_t increment_y_sum(self, int32_t group_idx, float64_t value) except -1 nogil
     cdef int32_t increment_y_sq_sum(self, int32_t group_idx, float64_t value) except -1 nogil
@@ -56,6 +57,7 @@ cdef class NodeSplitState:
     cdef public NodeState node
     cdef public NodeState right
     cdef public NodeState left
+    cdef public NodeState missing
 
     """
     NodeSplitState cython class tracks statistics for the current node and potential left and right splits.
@@ -63,6 +65,8 @@ cdef class NodeSplitState:
     node:    NodeState,    current node statistics
     right:   NodeState,    right split statistics
     left:    NodeState,    left split statistics
+    missing: NodeState,    statistics of samples with a missing value for the
+                           feature currently being split on
     """
 
     cdef int32_t reset_nodes(self, intp_t n_outputs) except -1 nogil

--- a/causalml/inference/tree/causal/_criterion.pyx
+++ b/causalml/inference/tree/causal/_criterion.pyx
@@ -57,6 +57,18 @@ cdef class NodeState:
         self.update_counters()
         return 0
 
+    cdef int32_t set_difference(self, NodeState a, NodeState b) except -1 nogil:
+        """Set this state to the per-group difference ``a - b``."""
+        if self.count_1d.size() == 0:
+            return -1
+
+        for k in range(self.count_1d.size()):
+            self.count_1d[k] = a.count_1d[k] - b.count_1d[k]
+            self.y_sum_1d[k] = a.y_sum_1d[k] - b.y_sum_1d[k]
+            self.y_sq_sum_1d[k] = a.y_sq_sum_1d[k] - b.y_sq_sum_1d[k]
+        self.update_counters()
+        return 0
+
     cdef int32_t increment_count(self, int32_t group_idx, float64_t value) except -1 nogil:
         self.count_1d[group_idx] += value
         self.update_counters()
@@ -93,12 +105,14 @@ cdef class NodeSplitState:
         self.node = NodeState(n_outputs)
         self.right = NodeState(n_outputs)
         self.left = NodeState(n_outputs)
+        self.missing = NodeState(n_outputs)
         self.reset_nodes(n_outputs)
 
     cdef int32_t reset_nodes(self, intp_t n_outputs) except -1 nogil:
         self.node.reset(n_outputs)
         self.right.reset(n_outputs)
         self.left.reset(n_outputs)
+        self.missing.reset(n_outputs)
         return 0
 
 
@@ -197,19 +211,75 @@ cdef class CausalRegressionCriterion(RegressionCriterion):
         self.reset()
         return 0
 
+    # ``init_sum_missing`` is inherited from ``RegressionCriterion`` (it only
+    # allocates the flat ``sum_missing`` buffer); the per-group ``state.missing``
+    # is created in ``NodeSplitState.__cinit__``.
+    cdef void init_missing(self, intp_t n_missing) noexcept nogil:
+        """Accumulate the missing samples' statistics for the current feature.
+
+        Mirrors ``RegressionCriterion.init_missing`` (scikit-learn): the splitter
+        places the ``n_missing`` samples that have a missing value for the current
+        feature at ``sample_indices[end - n_missing:end]``. Their contribution is
+        summed both into the flat ``sum_missing`` (used by ``StandardMSE``) and the
+        per-group ``state.missing`` (used by the per-group causal / uplift
+        criteria), still respecting the group-encoding NaN mask ``isnan(y[i, k])``
+        (``y[i, k]`` is NaN when sample ``i`` is not in group ``k``).
+        """
+        cdef intp_t i, p, k
+        cdef float64_t w = 1.0
+        cdef float64_t y_ik, w_y_ik
+
+        self.n_missing = n_missing
+        if n_missing == 0:
+            return
+
+        memset(&self.sum_missing[0], 0, self.n_outputs * sizeof(float64_t))
+        self.weighted_n_missing = 0.0
+        self.state.missing.reset(self.n_outputs)
+
+        # The missing samples are assumed to be in sample_indices[end - n_missing:end].
+        for p in range(self.end - n_missing, self.end):
+            i = self.sample_indices[p]
+
+            if self.sample_weight is not None:
+                w = self.sample_weight[i]
+
+            for k in range(self.n_outputs):
+                y_ik = self.y[i, k]
+                if not isnan(y_ik):
+                    w_y_ik = w * y_ik
+                    self.sum_missing[k] += w_y_ik
+                    self.state.missing.increment_count(k, 1.)
+                    self.state.missing.increment_y_sum(k, w_y_ik)
+                    self.state.missing.increment_y_sq_sum(k, w_y_ik * y_ik)
+                    self.weighted_n_missing += w
+
     cdef int reset(self) except -1 nogil:
         """Reset the criterion at pos=start."""
         cdef intp_t n_bytes = self.n_outputs * sizeof(float64_t)
+        cdef intp_t k
 
-        memset(&self.sum_left[0], 0, n_bytes)
-        memcpy(&self.sum_right[0], &self.sum_total[0], n_bytes)
+        if self.n_missing != 0 and self.missing_go_to_left:
+            # Missing samples seed the left child (scikit-learn missing_go_to_left).
+            memcpy(&self.sum_left[0], &self.sum_missing[0], n_bytes)
+            for k in range(self.n_outputs):
+                self.sum_right[k] = self.sum_total[k] - self.sum_missing[k]
 
-        self.state.left.reset(self.n_outputs)
-        self.state.right.copy_from_state(self.state.node)
+            self.state.left.copy_from_state(self.state.missing)
+            self.state.right.set_difference(self.state.node, self.state.missing)
 
-        # For compatibility with sklearn functions
-        self.weighted_n_left = 0.
-        self.weighted_n_right = self.weighted_n_node_samples
+            self.weighted_n_left = self.weighted_n_missing
+            self.weighted_n_right = self.weighted_n_node_samples - self.weighted_n_missing
+        else:
+            memset(&self.sum_left[0], 0, n_bytes)
+            memcpy(&self.sum_right[0], &self.sum_total[0], n_bytes)
+
+            self.state.left.reset(self.n_outputs)
+            self.state.right.copy_from_state(self.state.node)
+
+            # For compatibility with sklearn functions
+            self.weighted_n_left = 0.
+            self.weighted_n_right = self.weighted_n_node_samples
 
         self.pos = self.start
 
@@ -218,15 +288,29 @@ cdef class CausalRegressionCriterion(RegressionCriterion):
     cdef int reverse_reset(self) except -1 nogil:
         """Reset the criterion at pos=end."""
         cdef intp_t n_bytes = self.n_outputs * sizeof(float64_t)
-        memset(&self.sum_right[0], 0, n_bytes)
-        memcpy(&self.sum_left[0], &self.sum_total[0], n_bytes)
+        cdef intp_t k
 
-        self.state.right.reset(self.n_outputs)
-        self.state.left.copy_from_state(self.state.node)
+        if self.n_missing != 0 and not self.missing_go_to_left:
+            # Missing samples seed the right child.
+            memcpy(&self.sum_right[0], &self.sum_missing[0], n_bytes)
+            for k in range(self.n_outputs):
+                self.sum_left[k] = self.sum_total[k] - self.sum_missing[k]
 
-        # For compatibility with sklearn functions
-        self.weighted_n_right = 0.0
-        self.weighted_n_left = self.weighted_n_node_samples
+            self.state.right.copy_from_state(self.state.missing)
+            self.state.left.set_difference(self.state.node, self.state.missing)
+
+            self.weighted_n_right = self.weighted_n_missing
+            self.weighted_n_left = self.weighted_n_node_samples - self.weighted_n_missing
+        else:
+            memset(&self.sum_right[0], 0, n_bytes)
+            memcpy(&self.sum_left[0], &self.sum_total[0], n_bytes)
+
+            self.state.right.reset(self.n_outputs)
+            self.state.left.copy_from_state(self.state.node)
+
+            # For compatibility with sklearn functions
+            self.weighted_n_right = 0.0
+            self.weighted_n_left = self.weighted_n_node_samples
 
         self.pos = self.end
 
@@ -238,7 +322,10 @@ cdef class CausalRegressionCriterion(RegressionCriterion):
         cdef const intp_t[:] sample_indices = self.sample_indices
 
         cdef intp_t pos = self.pos
-        cdef intp_t end = self.end
+        # Missing samples are held at sample_indices[end - n_missing:end] and are
+        # assigned to a fixed child by reset()/reverse_reset(); the scan only ever
+        # moves the non-missing samples (scikit-learn convention).
+        cdef intp_t end_non_missing = self.end - self.n_missing
         cdef intp_t i
         cdef intp_t p
         cdef intp_t k = 0
@@ -254,7 +341,7 @@ cdef class CausalRegressionCriterion(RegressionCriterion):
         we are going to update sum_left from the direction that require the least amount of computations,
         i.e. from pos to new_pos or from end to new_pos
         """
-        if (new_pos - pos) <= (end - new_pos):
+        if (new_pos - pos) <= (end_non_missing - new_pos):
             for p in range(pos, new_pos):
                 i = sample_indices[p]
 
@@ -274,7 +361,7 @@ cdef class CausalRegressionCriterion(RegressionCriterion):
         else:
             self.reverse_reset()
 
-            for p in range(end - 1, new_pos - 1, -1):
+            for p in range(end_non_missing - 1, new_pos - 1, -1):
                 i = sample_indices[p]
 
                 if sample_weight is not None:
@@ -419,6 +506,21 @@ cdef class StandardMSE(CausalRegressionCriterion):
                 y_ik = self.y[i, k]
                 if not isnan(y_ik):
                     sq_sum_left += w * y_ik * y_ik
+
+        # Missing samples (held at the tail) contribute their squared outcome to
+        # the left child when they were routed left (scikit-learn convention); the
+        # first-moment sums already carry them via reset()/update().
+        if self.n_missing != 0 and self.missing_go_to_left:
+            for p in range(self.end - self.n_missing, self.end):
+                i = sample_indices[p]
+
+                if sample_weight is not None:
+                    w = sample_weight[i]
+
+                for k in range(self.n_outputs):
+                    y_ik = self.y[i, k]
+                    if not isnan(y_ik):
+                        sq_sum_left += w * y_ik * y_ik
 
         sq_sum_right = self.sq_sum_total - sq_sum_left
 

--- a/causalml/inference/tree/causal/_tree.py
+++ b/causalml/inference/tree/causal/_tree.py
@@ -52,12 +52,24 @@ class BaseCausalDecisionTree(BaseDecisionTree):
         self.min_group_samples = min_group_samples
 
     def _support_missing_values(self, X) -> bool:
+        """Whether native missing-value (NaN) splitting is available for ``X``.
+
+        Mirrors scikit-learn's ``BaseDecisionTree._support_missing_values``. The
+        causal criterion implements scikit-learn's per-feature missing-value
+        accumulation, which the dense best splitter threads through (see
+        ``__sklearn_tags__``); NaNs are rejected for sparse input or a non-default
+        splitter.
         """
-        TODO: Add support for missing values
-        See sklearn PR: ENH Adds missing value support for trees (#23595)
-        https://github.com/scikit-learn/scikit-learn/commit/6392148d80e9f14a9524c137ac5cfa04f2274d48
-        """
-        return False
+        return (
+            not issparse(X)
+            and self.__sklearn_tags__().input_tags.allow_nan
+            and self.monotonic_cst is None
+        )
+
+    def __sklearn_tags__(self):
+        tags = super().__sklearn_tags__()
+        tags.input_tags.allow_nan = self.splitter == "best"
+        return tags
 
     def fit(
         self,
@@ -72,13 +84,22 @@ class BaseCausalDecisionTree(BaseDecisionTree):
         if self.ccp_alpha < 0.0:
             raise ValueError("ccp_alpha must be greater than or equal to 0")
 
+        missing_values_in_feature_mask = None
         if check_input:
             # Need to validate separately here.
             # We can't pass multi_ouput=True because that would allow y to be csr.
-            check_X_params = dict(dtype=DTYPE, accept_sparse="csc")
+            check_X_params = dict(
+                dtype=DTYPE, accept_sparse="csc", ensure_all_finite=False
+            )
             check_y_params = get_check_y_params()
             X, y = validate_data(
                 self, X, y, validate_separately=(check_X_params, check_y_params)
+            )
+            # Native missing-value support (scikit-learn convention): rejects inf
+            # and, when NaNs are not supported, rejects them too; otherwise returns
+            # the per-feature missing mask threaded to the builder.
+            missing_values_in_feature_mask = (
+                self._compute_missing_values_in_feature_mask(X)
             )
             if issparse(X):
                 X.sort_indices()
@@ -266,7 +287,7 @@ class BaseCausalDecisionTree(BaseDecisionTree):
                 self.min_group_samples,
             )
         # Treatment column is described via y cols. The first column is always a control group.
-        builder.build(self.tree_, X, y, sample_weight)
+        builder.build(self.tree_, X, y, sample_weight, missing_values_in_feature_mask)
 
         self._prune_tree()
 

--- a/causalml/inference/tree/causal/causalforest.py
+++ b/causalml/inference/tree/causal/causalforest.py
@@ -335,7 +335,12 @@ class CausalRandomForestRegressor(SerializableLearner, ForestRegressor):
         # Validate or convert input data
         if issparse(y):
             raise ValueError("sparse multilabel-indicator for y is not supported.")
-        check_X_params = dict(dtype=DTYPE, accept_sparse="csc")
+        # NaNs are handled natively by the kernel trees (each fit with
+        # ``check_input=True`` computes its own missing mask); keep them through
+        # the forest-level validation. Non-NaN non-finite values are still rejected.
+        check_X_params = dict(
+            dtype=DTYPE, accept_sparse="csc", ensure_all_finite="allow-nan"
+        )
         check_y_params = get_check_y_params()
         X, y = validate_data(
             self,

--- a/causalml/inference/tree/causal/causaltree.py
+++ b/causalml/inference/tree/causal/causaltree.py
@@ -400,7 +400,12 @@ class CausalTreeRegressor(SerializableLearner, RegressorMixin, BaseCausalDecisio
             **{treatment: i + 1 for i, treatment in enumerate(self.unique_treatments)},
         }
 
-        X = check_array(X, dtype=DTYPE, accept_sparse="csc")
+        # Missing (NaN) feature values are handled natively by the kernel
+        # splitter; finiteness is enforced (support-gated) by the base fit's
+        # ``_compute_missing_values_in_feature_mask``.
+        X = check_array(
+            X, dtype=DTYPE, accept_sparse="csc", ensure_all_finite="allow-nan"
+        )
         y = check_array(y, ensure_2d=False, dtype=None)
         self.n_samples, self.n_features = X.shape
 

--- a/tests/test_causal_trees.py
+++ b/tests/test_causal_trees.py
@@ -321,3 +321,117 @@ def test_CausalRandomForestRegressor_no_inf_predictions_ttest():
     preds = model.predict(X=X)
 
     assert np.all(np.isfinite(preds)), "Predictions contain inf or NaN values"
+
+
+# ---------------------------------------------------------------------------
+# Native missing-value (NaN) support (prerequisite for issue #955)
+#
+# The shared causal criterion implements scikit-learn's per-feature
+# missing-value accumulation, threaded through the dense best splitter, so the
+# causal tree and forest accept NaNs in X natively (inf is still rejected).
+# ---------------------------------------------------------------------------
+
+
+def _make_missing_effect_data(n=4000, seed=RANDOM_SEED):
+    """Regression uplift data whose treatment effect is carried by missingness.
+
+    The informative feature is NaN for half the rows and a varied value
+    otherwise; the treatment effect is 2.0 exactly on the missing rows and 0.0
+    on the observed rows. A missing-aware tree must route NaN accordingly.
+    """
+    rng = np.random.RandomState(seed)
+    treatment = rng.randint(0, 2, n)
+    missing = rng.rand(n) < 0.5
+    informative = np.where(missing, np.nan, rng.normal(size=n))
+    noise = rng.normal(size=n)
+    X = np.column_stack([informative, noise]).astype(np.float64)
+    tau = np.where(missing, 2.0, 0.0)
+    y = 0.3 * noise + treatment * tau + rng.normal(scale=0.1, size=n)
+    return X, treatment, y
+
+
+def test_causal_tree_reports_missing_value_support():
+    """The causal tree advertises native NaN support for the dense best splitter."""
+    from scipy.sparse import csr_matrix
+
+    est = CausalTreeRegressor(criterion="causal_mse", control_name=0)
+    X = np.random.RandomState(RANDOM_SEED).randn(100, 4)
+    assert est.__sklearn_tags__().input_tags.allow_nan is True
+    assert est._support_missing_values(X) is True
+    assert est._support_missing_values(csr_matrix(X)) is False
+
+
+@pytest.mark.parametrize("criterion", ["causal_mse", "standard_mse", "t_test"])
+def test_causal_tree_fit_predict_with_nan(criterion):
+    """The causal tree fits and predicts finite effects with NaNs in X."""
+    rng = np.random.RandomState(RANDOM_SEED)
+    n = 2000
+    X = rng.randn(n, 5)
+    treatment = rng.randint(0, 2, n)
+    y = X[:, 1] * 0.3 + treatment * (X[:, 0] > 0) * 0.5 + rng.normal(scale=0.1, size=n)
+    Xn = X.copy()
+    for c in (0, 2, 4):
+        idx = rng.choice(n, size=int(0.15 * n), replace=False)
+        Xn[idx, c] = np.nan
+
+    model = CausalTreeRegressor(
+        criterion=criterion,
+        control_name=0,
+        max_depth=4,
+        min_samples_leaf=50,
+        random_state=RANDOM_SEED,
+    )
+    model.fit(X=Xn, treatment=treatment, y=y)
+    te = np.ravel(model.predict(Xn))
+    assert te.shape == (n,)
+    assert np.isfinite(te).all()
+
+
+def test_causal_tree_learns_missing_routing():
+    """The tree routes NaN to isolate a treatment effect carried by missingness."""
+    X, treatment, y = _make_missing_effect_data(seed=RANDOM_SEED)
+    model = CausalTreeRegressor(
+        criterion="causal_mse",
+        control_name=0,
+        max_depth=3,
+        min_samples_leaf=100,
+        random_state=RANDOM_SEED,
+    )
+    model.fit(X=X, treatment=treatment, y=y)
+    te_missing = float(np.ravel(model.predict(np.array([[np.nan, 0.0]])))[0])
+    te_observed = float(np.ravel(model.predict(np.array([[0.0, 0.0]])))[0])
+    assert te_missing > 1.0
+    assert te_missing - te_observed > 0.8
+
+
+def test_causal_forest_fit_predict_with_nan():
+    """The causal forest fits and predicts finite effects with NaNs and reports the tag."""
+    X, treatment, y = _make_missing_effect_data(n=3000, seed=RANDOM_SEED)
+    model = CausalRandomForestRegressor(
+        criterion="causal_mse",
+        control_name=0,
+        n_estimators=10,
+        max_depth=4,
+        min_samples_leaf=50,
+        random_state=RANDOM_SEED,
+    )
+    assert model.__sklearn_tags__().input_tags.allow_nan is True
+    model.fit(X=X, treatment=treatment, y=y)
+    te = np.ravel(model.predict(X))
+    assert np.isfinite(te).all()
+    # The effect is concentrated on the missing rows, so their mean estimated
+    # effect must clearly exceed the observed rows'.
+    missing_rows = np.isnan(X[:, 0])
+    assert np.mean(te[missing_rows]) - np.mean(te[~missing_rows]) > 0.5
+
+
+def test_causal_tree_rejects_inf():
+    """Non-NaN, non-finite values (inf) are still rejected by the causal tree."""
+    rng = np.random.RandomState(RANDOM_SEED)
+    X = rng.randn(200, 4)
+    treatment = rng.randint(0, 2, 200)
+    y = rng.randn(200)
+    X[0, 0] = np.inf
+    model = CausalTreeRegressor(criterion="causal_mse", control_name=0)
+    with pytest.raises(ValueError, match="infinity"):
+        model.fit(X=X, treatment=treatment, y=y)

--- a/tests/test_uplift_trees_kernel.py
+++ b/tests/test_uplift_trees_kernel.py
@@ -1289,3 +1289,137 @@ def test_kernel_uplift_init_stores_args_verbatim():
     params = _KernelUpliftTreeClassifier(**args).get_params()
     for name, value in args.items():
         assert params[name] == value
+
+
+# ---------------------------------------------------------------------------
+# Native missing-value (NaN) support (prerequisite for issue #955)
+#
+# The uplift/causal criterion implements scikit-learn's per-feature missing-value
+# accumulation (``init_missing`` / ``sum_missing`` folded into the child chosen by
+# ``missing_go_to_left``), which the dense best splitter threads through. These
+# tests assert NaNs in X are accepted, routed, and learned -- and that non-NaN
+# non-finite values (inf) are still rejected.
+# ---------------------------------------------------------------------------
+
+
+def _inject_nan(X, cols, frac=0.15, seed=RANDOM_SEED):
+    """Return a float64 copy of ``X`` with ``frac`` of each of ``cols`` set to NaN."""
+    rng = np.random.RandomState(seed)
+    Xn = np.asarray(X, dtype=np.float64).copy()
+    for c in cols:
+        idx = rng.choice(len(Xn), size=int(frac * len(Xn)), replace=False)
+        Xn[idx, c] = np.nan
+    return Xn
+
+
+def test_kernel_uplift_reports_missing_value_support():
+    """The estimator advertises native NaN support for the dense best splitter."""
+    from scipy.sparse import csr_matrix
+
+    est = _KernelUpliftTreeClassifier(criterion="KL")
+    X, _, _ = _make_binary_feature_data(n_samples=200, seed=RANDOM_SEED)
+    assert est.__sklearn_tags__().input_tags.allow_nan is True
+    assert est._support_missing_values(X) is True
+    # Sparse input is not covered by the missing-value machinery.
+    assert est._support_missing_values(csr_matrix(X)) is False
+
+
+@pytest.mark.parametrize("criterion", KERNEL_UPLIFT_CRITERIA)
+def test_kernel_uplift_fit_predict_with_nan(criterion):
+    """Fitting and predicting with NaNs in X yields valid probabilities."""
+    X, treatment, y = _make_binary_feature_data(
+        n_samples=3000, n_features=6, seed=RANDOM_SEED
+    )
+    Xn = _inject_nan(X, cols=(0, 2, 4), frac=0.15)
+    est = _KernelUpliftTreeClassifier(
+        criterion=criterion, max_depth=4, min_samples_leaf=100, random_state=RANDOM_SEED
+    )
+    est.fit(Xn, treatment, y)
+    proba = est.predict_proba_by_group(Xn)
+    assert proba.shape == (len(Xn), 2)
+    assert np.isfinite(proba).all()
+    assert ((proba >= 0.0) & (proba <= 1.0)).all()
+    # The NaNs did not prevent the tree from growing.
+    assert est.tree_.max_depth >= 1
+
+
+def test_kernel_uplift_all_nan_column_and_row():
+    """An entirely-missing feature and an all-NaN prediction row are handled."""
+    X, treatment, y = _make_binary_feature_data(
+        n_samples=2000, n_features=5, seed=RANDOM_SEED
+    )
+    Xn = np.asarray(X, dtype=np.float64).copy()
+    Xn[:, 2] = np.nan  # a fully-missing feature must not break the fit
+    est = _KernelUpliftTreeClassifier(
+        criterion="KL", max_depth=3, min_samples_leaf=100, random_state=RANDOM_SEED
+    ).fit(Xn, treatment, y)
+    all_nan = np.full((1, X.shape[1]), np.nan)
+    proba = est.predict_proba_by_group(all_nan)
+    assert proba.shape == (1, 2)
+    assert np.isfinite(proba).all()
+
+
+def test_kernel_uplift_learns_missing_routing():
+    """The tree routes NaN to isolate a treatment effect carried by missingness.
+
+    The uplift is concentrated in the rows whose informative feature is missing;
+    a missing-aware tree must send those NaN rows to a high-uplift leaf and the
+    observed rows to a near-zero-uplift leaf.
+    """
+    rng = np.random.RandomState(RANDOM_SEED)
+    n = 4000
+    treatment = np.array([CONTROL_NAME, "treatment1"])[rng.randint(0, 2, n)]
+    missing = rng.rand(n) < 0.5
+    # Informative feature: missing for half the rows, otherwise a varied value so
+    # the splitter does not discard it as constant.
+    informative = np.where(missing, np.nan, rng.normal(size=n))
+    noise = rng.normal(size=n)
+    X = np.column_stack([informative, noise]).astype(np.float64)
+    is_t = treatment == "treatment1"
+    p = np.where(is_t & missing, 0.7, 0.2)  # uplift only where the feature is missing
+    y = (rng.rand(n) < p).astype(int)
+
+    est = _KernelUpliftTreeClassifier(
+        criterion="KL",
+        max_depth=3,
+        min_samples_leaf=100,
+        min_samples_treatment=10,
+        normalization=False,
+        n_reg=0,
+        random_state=RANDOM_SEED,
+    ).fit(X, treatment, y)
+
+    uplift_missing = est.predict(np.array([[np.nan, 0.0]]))[0, 0]
+    uplift_observed = est.predict(np.array([[0.0, 0.0]]))[0, 0]
+    assert uplift_missing > 0.3
+    assert uplift_missing - uplift_observed > 0.25
+
+
+def test_kernel_uplift_rejects_inf():
+    """Non-NaN, non-finite values (inf) are still rejected."""
+    X, treatment, y = _make_binary_feature_data(n_samples=500, seed=RANDOM_SEED)
+    Xinf = np.asarray(X, dtype=np.float64).copy()
+    Xinf[0, 0] = np.inf
+    est = _KernelUpliftTreeClassifier(criterion="KL", random_state=RANDOM_SEED)
+    with pytest.raises(ValueError, match="infinity"):
+        est.fit(Xinf, treatment, y)
+
+
+def test_kernel_uplift_forest_with_nan():
+    """The forest fits and predicts with NaNs and advertises NaN support."""
+    X, treatment, y = _make_binary_feature_data(
+        n_samples=3000, n_features=6, seed=RANDOM_SEED
+    )
+    Xn = _inject_nan(X, cols=(1, 3, 5), frac=0.12)
+    model = _KernelUpliftRandomForestClassifier(
+        control_name=CONTROL_NAME,
+        n_estimators=6,
+        max_depth=4,
+        min_samples_leaf=100,
+        random_state=RANDOM_SEED,
+    )
+    assert model.__sklearn_tags__().input_tags.allow_nan is True
+    model.fit(Xn, treatment, y)
+    delta = model.predict(Xn)
+    assert delta.shape == (len(Xn), 1)
+    assert np.isfinite(delta).all()


### PR DESCRIPTION
## What

Prerequisite for the #955 switchover (tree-unification epic #945). Adds **native missing-value (NaN) support** to the kernel-backed uplift and causal trees/forests, mirroring scikit-learn's tree implementation closely. Today these estimators reject `NaN` in `X`; the switched-over public `UpliftTreeClassifier` / `UpliftRandomForestClassifier` need to accept it, so this lands the criterion-level work first, isolated from the compat/switchover mechanics.

## How (follows scikit-learn's design)

The shared `CausalRegressionCriterion` (inherited by **every** uplift and causal criterion) now implements sklearn's per-feature missing-value machinery:

- `NodeSplitState` gains a per-group `missing` `NodeState`. `init_missing(n_missing)` accumulates the missing tail (`sample_indices[end - n_missing:end]`, the sklearn contract) into **both** the flat `sum_missing` (used by `StandardMSE`) and the per-group state — still respecting the group-encoding NaN mask (`isnan(y[i, k])` = "sample not in group k").
- `reset` / `reverse_reset` fold the missing block into the child chosen by `missing_go_to_left`; `update` scans only the non-missing range (`end - n_missing`); `StandardMSE.children_impurity` adds the missing squared-sum when routed left. All are **no-ops when `n_missing == 0`**, so clean-data behaviour is unchanged.
- The flat `sum_missing` allocation (`init_sum_missing`) is inherited from `RegressionCriterion` unchanged.

The Python tree layer follows sklearn 1.7:

- `_support_missing_values` + an `allow_nan` tag via `__sklearn_tags__` (dense **best** splitter only — random/sparse don't carry the machinery). The vendored base's `_get_tags()["allow_nan"]` is dead under sklearn 1.7; the causal/uplift layers now use `__sklearn_tags__().input_tags.allow_nan`.
- `fit` validates with `ensure_all_finite=False` and threads `_compute_missing_values_in_feature_mask(X)` into `builder.build(...)`.
- `_prepare_data` and both forests allow NaN through validation. **inf is still rejected.** The forest `allow_nan` tag is delegated automatically by sklearn's `BaseForest.__sklearn_tags__`.

## Scope

- Enabled for: `_KernelUpliftTreeClassifier`, `_KernelUpliftRandomForestClassifier`, `CausalTreeRegressor`, `CausalRandomForestRegressor` (the criterion is shared, so causal benefits for free — as discussed for the epic).
- Not covered (consistent with sklearn): the **random** splitter and **sparse** input; and a feature whose *non-missing* values are all constant is still treated as constant (its missing-only split is not separately proposed).

## Tests

New missing-value tests for both the uplift and causal trees/forests:

- acceptance (fit + predict with NaN, finite/valid outputs), the `allow_nan` tag + `_support_missing_values` (dense True / sparse False),
- all-NaN column and all-NaN prediction row,
- **learned NaN routing** — effect concentrated on the missing rows is recovered (NaN rows → high-effect leaf, observed rows → ~0),
- inf still rejected, forest fit/predict with NaN.

Full `tests/test_uplift_trees_kernel.py` + `tests/test_causal_trees.py` pass (**154**); `black` clean.

Part of #945. Prerequisite for #955.
