### PR TITLE
#805: Add node p-value display to plot_causal_tree

### DIFF
--- a/causalml/inference/tree/causal/causaltree.py
+++ b/causalml/inference/tree/causal/causaltree.py
@@ -117,7 +117,10 @@ class CausalTreeRegressor(SerializableLearner, RegressorMixin, BaseCausalDecisio
                 See :term:`Glossary <random_state>` for details.
             groups_cnt: (bool), count treatment and control groups for each node/leaf
             groups_cnt_mode: (str, 'nodes', 'leaves'), mode for samples counting
-            node_pvalues: (bool), compute treatment effect p-values for each node
+            node_pvalues: (bool), compute treatment effect p-values for each node.
+                Note: These are naive in-sample t-tests and do not account for the tree
+                structure or multiple testing. They should be used for descriptive
+                purposes only and are not valid for post-selection inference.
         """
 
         self.criterion = criterion
@@ -464,6 +467,9 @@ class CausalTreeRegressor(SerializableLearner, RegressorMixin, BaseCausalDecisio
     ) -> dict:
         """
         Compute treatment effect p-values for each tree node using Welch's t-test.
+
+        Note: These p-values are descriptive and do not account for the search
+        process used to find the splits (no honesty or multiple-testing correction).
 
         Args:
             X: (np.ndarray), feature matrix

--- a/causalml/inference/tree/causal/causaltree.py
+++ b/causalml/inference/tree/causal/causaltree.py
@@ -6,7 +6,7 @@ import numpy as np
 from numpy import float32 as DTYPE
 
 from pathos.pools import ProcessPool as PPool
-from scipy.stats import norm
+from scipy.stats import norm, ttest_ind
 from sklearn.base import RegressorMixin
 from sklearn.utils import check_array
 from sklearn.utils.validation import check_is_fitted
@@ -46,6 +46,7 @@ class CausalTreeRegressor(SerializableLearner, RegressorMixin, BaseCausalDecisio
         random_state: int = None,
         groups_cnt: bool = False,
         groups_cnt_mode: str = "nodes",
+        node_pvalues: bool = False,
     ):
         """
         Initialize a Causal Tree
@@ -116,6 +117,7 @@ class CausalTreeRegressor(SerializableLearner, RegressorMixin, BaseCausalDecisio
                 See :term:`Glossary <random_state>` for details.
             groups_cnt: (bool), count treatment and control groups for each node/leaf
             groups_cnt_mode: (str, 'nodes', 'leaves'), mode for samples counting
+            node_pvalues: (bool), compute treatment effect p-values for each node
         """
 
         self.criterion = criterion
@@ -137,8 +139,10 @@ class CausalTreeRegressor(SerializableLearner, RegressorMixin, BaseCausalDecisio
         self._classes = {}
         self.groups_cnt = groups_cnt
         self.groups_cnt_mode = groups_cnt_mode
+        self.node_pvalues = node_pvalues
         self._with_outcomes = False
         self._groups_cnt = {}
+        self._node_pvalues = {}
 
         super().__init__(
             criterion=criterion,
@@ -184,6 +188,9 @@ class CausalTreeRegressor(SerializableLearner, RegressorMixin, BaseCausalDecisio
                 "min_impurity_decrease must be set to -inf for causal_mse criterion"
             )
 
+        # Keep original 1d outcomes for post-fit computations
+        y_orig = y.copy()
+
         if prepare_data:
             X, y = self._prepare_data(X=X, y=y, treatment=treatment)
 
@@ -191,6 +198,10 @@ class CausalTreeRegressor(SerializableLearner, RegressorMixin, BaseCausalDecisio
 
         if self.groups_cnt:
             self._groups_cnt = self._count_groups_distribution(X=X, treatment=treatment)
+        if self.node_pvalues:
+            self._node_pvalues = self._compute_node_pvalues(
+                X=X, treatment=treatment, y=y_orig
+            )
         return self
 
     def predict(
@@ -447,3 +458,58 @@ class CausalTreeRegressor(SerializableLearner, RegressorMixin, BaseCausalDecisio
                 for node_id in nodes_path:
                     groups_cnt[node_id][treatment[sample_id]] += 1
         return groups_cnt
+
+    def _compute_node_pvalues(
+        self, X: np.ndarray, treatment: np.ndarray, y: np.ndarray
+    ) -> dict:
+        """
+        Compute treatment effect p-values for each tree node using Welch's t-test.
+
+        Args:
+            X: (np.ndarray), feature matrix
+            treatment: (np.ndarray), treatment vector
+            y: (np.ndarray), outcome vector (1d, original outcomes)
+
+        Returns:
+            dict: {node_id: {treatment_group: p_value}} for each node
+        """
+        check_is_fitted(self)
+
+        groups = sorted(set(treatment))
+        control = self.control_name
+        treatments = [g for g in groups if g != control]
+
+        # Collect outcomes per group per node
+        node_outcomes = {
+            idx: {group: [] for group in groups} for idx in range(self.tree_.node_count)
+        }
+
+        node_indicators = self.tree_.decision_path(X.astype(np.float32))
+        for sample_id in range(X.shape[0]):
+            nodes_path = node_indicators.indices[
+                node_indicators.indptr[sample_id] : node_indicators.indptr[
+                    sample_id + 1
+                ]
+            ]
+            group = treatment[sample_id]
+            outcome = y[sample_id]
+            for node_id in nodes_path:
+                node_outcomes[node_id][group].append(outcome)
+
+        # Compute p-values via Welch's t-test (treatment vs control)
+        node_pvalues = {}
+        for node_id in range(self.tree_.node_count):
+            control_outcomes = node_outcomes[node_id][control]
+            pvals = {}
+            for t in treatments:
+                treatment_outcomes = node_outcomes[node_id][t]
+                if len(control_outcomes) >= 2 and len(treatment_outcomes) >= 2:
+                    _, p = ttest_ind(
+                        treatment_outcomes, control_outcomes, equal_var=False
+                    )
+                    pvals[t] = round(float(p), 4)
+                else:
+                    pvals[t] = None
+            node_pvalues[node_id] = pvals
+
+        return node_pvalues

--- a/causalml/inference/tree/plot.py
+++ b/causalml/inference/tree/plot.py
@@ -340,6 +340,7 @@ class _MPLCTreeExporter(_MPLTreeExporter):
         rounded: bool,
         precision: int,
         fontsize: int,
+        pvalue: bool = False,
     ):
         """
         Causal Tree exporter for matplotlib
@@ -368,6 +369,8 @@ class _MPLCTreeExporter(_MPLTreeExporter):
                 Add the number of treatment and control groups
             treatment_groups: tuple, default=(0, 1)
                     Treatment and control groups labels
+            pvalue: bool, default=False
+                When set to ``True``, show the treatment effect p-value at each node.
             node_ids: bool, default=False
                     When set to ``True``, show the ID number on each node.
             proportion: bool, default=False
@@ -398,6 +401,7 @@ class _MPLCTreeExporter(_MPLTreeExporter):
         self.causal_tree = causal_tree
         self.groups_count = groups_count
         self.treatment_groups = treatment_groups
+        self.pvalue = pvalue
 
     def node_to_str(
         self, tree: _tree.Tree, node_id: int, criterion: Union[str, object]
@@ -472,7 +476,18 @@ class _MPLCTreeExporter(_MPLTreeExporter):
                 node_string += (
                     f"Group {group} = {self.causal_tree._groups_cnt[node_id][group]} "
                 )
-        node_string += characters[4]
+            node_string += characters[4]
+
+        # Write treatment effect p-values
+        if self.pvalue and self.causal_tree._node_pvalues:
+            pvals = self.causal_tree._node_pvalues.get(node_id, {})
+            for group, p in pvals.items():
+                if p is not None:
+                    node_string += f"p_value({group}) = {p}" + characters[4]
+                else:
+                    node_string += f"p_value({group}) = N/A" + characters[4]
+        elif not self.groups_count:
+            node_string += characters[4]
 
         # Write node class distribution / regression value
         if self.proportion and tree.n_classes[0] != 1:
@@ -590,6 +605,7 @@ def plot_causal_tree(
     precision: int = 3,
     ax: plt.Axes = None,
     fontsize: int = None,
+    pvalue: bool = False,
 ):
     """
     Plot a Causal Tree.
@@ -618,6 +634,9 @@ def plot_causal_tree(
                 Add the number of treatment and control groups
         treatment_groups: tuple, default=(0, 1)
                 Treatment and control groups labels
+        pvalue: bool, default=False
+                When set to ``True``, show the treatment effect p-value at each node.
+                Requires the tree to be fitted with ``node_pvalues=True``.
         node_ids: bool, default=False
                 When set to ``True``, show the ID number on each node.
         proportion: bool, default=False
@@ -654,5 +673,6 @@ def plot_causal_tree(
         rounded=rounded,
         precision=precision,
         fontsize=fontsize,
+        pvalue=pvalue,
     )
     exporter.export(causal_tree, ax=ax)

--- a/causalml/inference/tree/plot.py
+++ b/causalml/inference/tree/plot.py
@@ -482,7 +482,7 @@ class _MPLCTreeExporter(_MPLTreeExporter):
         if self.pvalue and self.causal_tree._node_pvalues:
             pvals = self.causal_tree._node_pvalues.get(node_id, {})
             for group, p in pvals.items():
-                if p is not None:
+                if p is not None and not np.isnan(p):
                     node_string += f"p_value({group}) = {p}" + characters[4]
                 else:
                     node_string += f"p_value({group}) = N/A" + characters[4]
@@ -637,6 +637,7 @@ def plot_causal_tree(
         pvalue: bool, default=False
                 When set to ``True``, show the treatment effect p-value at each node.
                 Requires the tree to be fitted with ``node_pvalues=True``.
+                Note: These p-values are descriptive and not valid for inference.
         node_ids: bool, default=False
                 When set to ``True``, show the ID number on each node.
         proportion: bool, default=False

--- a/tests/test_causal_trees.py
+++ b/tests/test_causal_trees.py
@@ -623,3 +623,46 @@ def test_causal_tree_node_pvalues_small_group():
     # Actually with only 1 treated sample, root should also be None
     assert model._node_pvalues[0][1] is None
     assert has_none
+
+
+def test_plot_causal_tree_pvalue_nan_handling():
+    """Test that zero-variance nodes (p-value nan) are rendered as N/A."""
+    from causalml.inference.tree.plot import _MPLCTreeExporter
+
+    # Create data where one group has zero variance
+    X = np.array([[1], [2], [3], [4], [5], [6]])
+    treatment = np.array([0, 0, 0, 1, 1, 1])
+    # Control and Treatment both have zero variance and SAME mean
+    # This will result in nan p-value from ttest_ind
+    y = np.array([1.0, 1.0, 1.0, 1.0, 1.0, 1.0])
+
+    tree = CausalTreeRegressor(
+        control_name=0,
+        min_samples_leaf=2,
+        node_pvalues=True,
+        groups_cnt=True,
+        random_state=42,
+    )
+    tree.fit(X, treatment, y)
+
+    # In the root node, ttest_ind will return nan because variances are 0.
+    exporter = _MPLCTreeExporter(
+        causal_tree=tree,
+        max_depth=None,
+        feature_names=["X0"],
+        class_names=None,
+        label="all",
+        filled=False,
+        impurity=True,
+        groups_count=True,
+        treatment_groups=(0, 1),
+        node_ids=False,
+        proportion=False,
+        rounded=False,
+        precision=3,
+        fontsize=10,
+        pvalue=True,
+    )
+
+    node_str = exporter.node_to_str(tree.tree_, 0, "causal_mse")
+    assert "p_value(1) = N/A" in node_str

--- a/tests/test_causal_trees.py
+++ b/tests/test_causal_trees.py
@@ -435,3 +435,191 @@ def test_causal_tree_rejects_inf():
     model = CausalTreeRegressor(criterion="causal_mse", control_name=0)
     with pytest.raises(ValueError, match="infinity"):
         model.fit(X=X, treatment=treatment, y=y)
+
+
+def test_causal_tree_node_pvalues_computed():
+    """Node p-values are computed for each node when node_pvalues=True."""
+    rng = np.random.RandomState(RANDOM_SEED)
+    n = 500
+    X = rng.randn(n, 4)
+    treatment = rng.randint(0, 2, n)
+    # Strong treatment effect so p-values should be small
+    y = X[:, 0] + treatment * 2.0 + rng.randn(n) * 0.1
+
+    model = CausalTreeRegressor(
+        control_name=0,
+        groups_cnt=True,
+        node_pvalues=True,
+        max_depth=2,
+        min_samples_leaf=50,
+        random_state=RANDOM_SEED,
+    )
+    model.fit(X=X, treatment=treatment, y=y)
+
+    assert model._node_pvalues
+    # Root node should have a p-value for treatment group 1
+    assert 0 in model._node_pvalues
+    assert 1 in model._node_pvalues[0]
+    # With a strong effect, root p-value should be small
+    assert model._node_pvalues[0][1] < 0.05
+
+
+def test_causal_tree_node_pvalues_not_computed_by_default():
+    """Node p-values are not computed when node_pvalues=False (default)."""
+    rng = np.random.RandomState(RANDOM_SEED)
+    n = 200
+    X = rng.randn(n, 4)
+    treatment = rng.randint(0, 2, n)
+    y = rng.randn(n)
+
+    model = CausalTreeRegressor(
+        control_name=0, max_depth=2, min_samples_leaf=50, random_state=RANDOM_SEED
+    )
+    model.fit(X=X, treatment=treatment, y=y)
+
+    assert model._node_pvalues == {}
+
+
+def test_causal_tree_node_pvalues_multi_treatment():
+    """Node p-values are computed per treatment group with multiple treatments."""
+    rng = np.random.RandomState(RANDOM_SEED)
+    n = 600
+    X = rng.randn(n, 4)
+    treatment = rng.choice([0, 1, 2], size=n)
+    y = X[:, 0] + (treatment == 1) * 2.0 + (treatment == 2) * 0.01 + rng.randn(n) * 0.1
+
+    model = CausalTreeRegressor(
+        control_name=0,
+        node_pvalues=True,
+        max_depth=2,
+        min_samples_leaf=50,
+        random_state=RANDOM_SEED,
+    )
+    model.fit(X=X, treatment=treatment, y=y)
+
+    # Root node should have p-values for both treatment groups
+    root_pvals = model._node_pvalues[0]
+    assert 1 in root_pvals
+    assert 2 in root_pvals
+    # Treatment 1 has strong effect, treatment 2 does not
+    assert root_pvals[1] < 0.05
+    assert root_pvals[2] > 0.05
+
+
+def test_causal_tree_node_pvalues_no_effect():
+    """When there is no treatment effect, p-values should be large."""
+    rng = np.random.RandomState(RANDOM_SEED)
+    n = 400
+    X = rng.randn(n, 4)
+    treatment = rng.randint(0, 2, n)
+    # No treatment effect
+    y = X[:, 0] + rng.randn(n) * 0.5
+
+    model = CausalTreeRegressor(
+        control_name=0,
+        node_pvalues=True,
+        max_depth=2,
+        min_samples_leaf=50,
+        random_state=RANDOM_SEED,
+    )
+    model.fit(X=X, treatment=treatment, y=y)
+
+    # Root p-value should not be significant
+    assert model._node_pvalues[0][1] > 0.05
+
+
+def test_plot_causal_tree_with_pvalue():
+    """plot_causal_tree renders p-value text when pvalue=True."""
+    import matplotlib
+
+    matplotlib.use("Agg")
+    import matplotlib.pyplot as plt
+    from causalml.inference.tree.plot import plot_causal_tree
+
+    rng = np.random.RandomState(RANDOM_SEED)
+    n = 300
+    X = rng.randn(n, 4)
+    treatment = rng.randint(0, 2, n)
+    y = X[:, 0] + treatment * 2.0 + rng.randn(n) * 0.1
+
+    model = CausalTreeRegressor(
+        control_name=0,
+        groups_cnt=True,
+        node_pvalues=True,
+        max_depth=2,
+        min_samples_leaf=50,
+        random_state=RANDOM_SEED,
+    )
+    model.fit(X=X, treatment=treatment, y=y)
+
+    fig, ax = plt.subplots(figsize=(20, 10))
+    plot_causal_tree(model, ax=ax, pvalue=True)
+
+    # Check that at least one text artist contains "p_value"
+    texts = [t.get_text() for t in ax.texts]
+    all_text = " ".join(texts)
+    assert "p_value" in all_text
+    plt.close(fig)
+
+
+def test_plot_causal_tree_without_pvalue():
+    """plot_causal_tree does not render p-value text when pvalue=False."""
+    import matplotlib
+
+    matplotlib.use("Agg")
+    import matplotlib.pyplot as plt
+    from causalml.inference.tree.plot import plot_causal_tree
+
+    rng = np.random.RandomState(RANDOM_SEED)
+    n = 300
+    X = rng.randn(n, 4)
+    treatment = rng.randint(0, 2, n)
+    y = X[:, 0] + treatment * 2.0 + rng.randn(n) * 0.1
+
+    model = CausalTreeRegressor(
+        control_name=0,
+        groups_cnt=True,
+        node_pvalues=True,
+        max_depth=2,
+        min_samples_leaf=50,
+        random_state=RANDOM_SEED,
+    )
+    model.fit(X=X, treatment=treatment, y=y)
+
+    fig, ax = plt.subplots(figsize=(20, 10))
+    plot_causal_tree(model, ax=ax, pvalue=False)
+
+    texts = [t.get_text() for t in ax.texts]
+    all_text = " ".join(texts)
+    assert "p_value" not in all_text
+    plt.close(fig)
+
+
+def test_causal_tree_node_pvalues_small_group():
+    """Nodes with fewer than 2 samples in a group get p_value=None."""
+    rng = np.random.RandomState(RANDOM_SEED)
+    # Create data where one leaf will have very few treatment samples
+    n = 100
+    X = rng.randn(n, 2)
+    treatment = np.zeros(n, dtype=int)
+    # Only 1 treated sample
+    treatment[0] = 1
+    y = rng.randn(n)
+
+    model = CausalTreeRegressor(
+        control_name=0,
+        node_pvalues=True,
+        max_depth=1,
+        min_samples_leaf=1,
+        min_samples_split=2,
+        min_group_samples=1,
+        random_state=RANDOM_SEED,
+    )
+    model.fit(X=X, treatment=treatment, y=y)
+
+    # At least one leaf should have None p-value due to insufficient samples
+    has_none = any(pvals.get(1) is None for pvals in model._node_pvalues.values())
+    # Root has all samples so it should have a valid p-value (n_control >= 2, n_treatment = 1)
+    # Actually with only 1 treated sample, root should also be None
+    assert model._node_pvalues[0][1] is None
+    assert has_none


### PR DESCRIPTION
## Proposed changes

Add the ability to display treatment effect p-values at each node when plotting a causal tree via `plot_causal_tree`. This addresses #805.

When `node_pvalues=True` is passed to `CausalTreeRegressor` during fit, a Welch's t-test is computed at each node comparing treatment vs control outcomes. The resulting p-values can then be rendered in the plot by passing `pvalue=True` to `plot_causal_tree`.

Usage:
```python
model = CausalTreeRegressor(control_name=0, groups_cnt=True, node_pvalues=True)
model.fit(X=X, treatment=treatment, y=y)
plot_causal_tree(model, pvalue=True)
```

Each node will display `p_value(group) = X.XXXX` for each treatment group. Nodes with fewer than 2 samples in either group show `N/A`.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/uber/causalml/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/uber/causalml)
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments

Implementation follows the same pattern as the existing `groups_cnt` feature:
- `node_pvalues=True` in the constructor enables computation during `fit()`
- `_compute_node_pvalues()` traverses the tree via `decision_path` (same approach as `_count_groups_distribution`)
- Uses Welch's t-test (`scipy.stats.ttest_ind`, `equal_var=False`) which is standard for unequal group sizes
- Multi-treatment support: computes a separate p-value for each treatment group vs control
- Gracefully handles nodes with insufficient samples (returns None)

This PR was co-authored with AI assistance.
