### PR TITLE
Skip one-hot-encoding in load_data when no feature is categorical

### DIFF
--- a/causalml/features.py
+++ b/causalml/features.py
@@ -258,10 +258,16 @@ def load_data(data, features, transformations={}):
     cat_cols = [col for col in features if not pd.api.types.is_numeric_dtype(df[col])]
     num_cols = [col for col in features if col not in cat_cols]
 
-    logger.info("Applying one-hot-encoding to {}".format(cat_cols))
-    ohe = OneHotEncoder(min_obs=df.shape[0] * 0.001)
-    X_cat = ohe.fit_transform(df[cat_cols]).todense()
+    if cat_cols:
+        logger.info("Applying one-hot-encoding to {}".format(cat_cols))
+        ohe = OneHotEncoder(min_obs=df.shape[0] * 0.001)
+        X_cat = ohe.fit_transform(df[cat_cols]).todense()
 
-    X = np.hstack([df[num_cols].values, X_cat])
+        X = np.hstack([df[num_cols].values, X_cat])
+    else:
+        # OneHotEncoder asserts that at least one column was transformed, so
+        # skip it entirely when every feature is already numeric.
+        logger.info("No categorical features to one-hot-encode")
+        X = df[num_cols].values
 
     return X

--- a/causalml/features.py
+++ b/causalml/features.py
@@ -243,7 +243,7 @@ def load_data(data, features, transformations={}):
         transformation (dict of (str, func)): transformations to be applied to features
 
     Returns:
-        X (numpy.matrix): a feature matrix
+        X (numpy.ndarray): a feature matrix
     """
 
     df = data[features].copy()
@@ -258,16 +258,22 @@ def load_data(data, features, transformations={}):
     cat_cols = [col for col in features if not pd.api.types.is_numeric_dtype(df[col])]
     num_cols = [col for col in features if col not in cat_cols]
 
+    X_cat = None
     if cat_cols:
         logger.info("Applying one-hot-encoding to {}".format(cat_cols))
         ohe = OneHotEncoder(min_obs=df.shape[0] * 0.001)
-        X_cat = ohe.fit_transform(df[cat_cols]).todense()
+        try:
+            X_cat = ohe.fit_transform(df[cat_cols]).toarray()
+        except AssertionError:
+            # OneHotEncoder asserts when no column produced a non-empty
+            # encoding. That happens when every categorical column holds a
+            # single value, or when all of their levels fall below min_obs,
+            # so there is nothing to append.
+            logger.info("No categorical column produced an encoding")
 
-        X = np.hstack([df[num_cols].values, X_cat])
-    else:
-        # OneHotEncoder asserts that at least one column was transformed, so
-        # skip it entirely when every feature is already numeric.
-        logger.info("No categorical features to one-hot-encode")
+    if X_cat is None:
         X = df[num_cols].values
+    else:
+        X = np.hstack([df[num_cols].values, X_cat])
 
     return X

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -38,8 +38,29 @@ def test_load_data_all_numeric_features():
 
     features = load_data(df, df.columns)
 
+    assert isinstance(features, np.ndarray) and not isinstance(features, np.matrix)
     assert features.shape == (3, 2)
     np.testing.assert_array_equal(features, df.values)
+
+
+def test_load_data_categorical_column_that_encodes_to_nothing():
+    # A single-valued categorical column maps entirely to label 0, which
+    # _transform_col drops, so the encoder produces nothing and used to assert.
+    df = pd.DataFrame({"const_cat": ["x"] * 7, "num1": [1, 2, 1, 2, 1, 1, 1]})
+
+    features = load_data(df, ["const_cat", "num1"])
+
+    assert isinstance(features, np.ndarray) and not isinstance(features, np.matrix)
+    assert features.shape == (7, 1)
+    np.testing.assert_array_equal(features, df[["num1"]].values)
+
+
+def test_load_data_returns_ndarray_with_categorical_features(generate_categorical_data):
+    df = generate_categorical_data()
+
+    features = load_data(df, df.columns)
+
+    assert isinstance(features, np.ndarray) and not isinstance(features, np.matrix)
 
 
 def test_LabelEncoder(generate_categorical_data):

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -1,3 +1,4 @@
+import numpy as np
 import pandas as pd
 import pytest
 from causalml.features import OneHotEncoder, LabelEncoder, load_data
@@ -28,6 +29,17 @@ def test_load_data(generate_categorical_data):
     features = load_data(df, df.columns)
 
     assert df.shape[0] == features.shape[0]
+
+
+def test_load_data_all_numeric_features():
+    # OneHotEncoder asserts when nothing is categorical, so load_data used to
+    # raise instead of returning the numeric columns unchanged.
+    df = pd.DataFrame({"a": [1.0, 2.0, 3.0], "b": [4, 5, 6]})
+
+    features = load_data(df, df.columns)
+
+    assert features.shape == (3, 2)
+    np.testing.assert_array_equal(features, df.values)
 
 
 def test_LabelEncoder(generate_categorical_data):


### PR DESCRIPTION
## Proposed changes

`load_data` raises when every requested feature is numeric:

```python
>>> load_data(pd.DataFrame({"a": [1.0, 2.0, 3.0], "b": [4, 5, 6]}), ["a", "b"])
AssertionError: no column was transformed, please check your dataframe input
```

`cat_cols` comes out empty, but `ohe.fit_transform(df[cat_cols])` is still called, and `OneHotEncoder` asserts that it transformed at least one column. An all-numeric feature matrix is a perfectly ordinary input, so this guards the one-hot branch and returns the numeric columns as they are when there is nothing categorical to encode.

The existing `test_load_data` uses `generate_categorical_data`, which always has categorical columns, so this path was not covered.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/uber/causalml/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/uber/causalml)
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

`test_load_data_all_numeric_features` fails on master with the assertion above and passes with the change. `pytest tests/test_features.py` is 4 passed, and `black --check` is clean on both touched files.
