### PR TITLE
Handle a None encoding in load_data when assertions are disabled

### DIFF
--- a/causalml/features.py
+++ b/causalml/features.py
@@ -263,13 +263,19 @@ def load_data(data, features, transformations={}):
         logger.info("Applying one-hot-encoding to {}".format(cat_cols))
         ohe = OneHotEncoder(min_obs=df.shape[0] * 0.001)
         try:
-            X_cat = ohe.fit_transform(df[cat_cols]).toarray()
+            X_cat = ohe.fit_transform(df[cat_cols])
         except AssertionError:
             # OneHotEncoder asserts when no column produced a non-empty
-            # encoding. That happens when every categorical column holds a
-            # single value, or when all of their levels fall below min_obs,
-            # so there is nothing to append.
+            # encoding: every categorical column holds a single value, or all
+            # of their levels fall below min_obs. Under python -O that
+            # assertion is stripped and transform returns None instead of
+            # raising, so both outcomes end up here.
+            X_cat = None
+
+        if X_cat is None:
             logger.info("No categorical column produced an encoding")
+        else:
+            X_cat = X_cat.toarray()
 
     if X_cat is None:
         X = df[num_cols].values

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -55,6 +55,20 @@ def test_load_data_categorical_column_that_encodes_to_nothing():
     np.testing.assert_array_equal(features, df[["num1"]].values)
 
 
+def test_load_data_when_transform_returns_none(monkeypatch):
+    # Under python -O the assertion inside OneHotEncoder.transform is stripped
+    # and it returns None rather than raising, so load_data has to handle the
+    # value as well as the exception.
+    monkeypatch.setattr(OneHotEncoder, "fit_transform", lambda self, X, y=None: None)
+    df = pd.DataFrame({"const_cat": ["x"] * 7, "num1": [1, 2, 1, 2, 1, 1, 1]})
+
+    features = load_data(df, ["const_cat", "num1"])
+
+    assert isinstance(features, np.ndarray) and not isinstance(features, np.matrix)
+    assert features.shape == (7, 1)
+    np.testing.assert_array_equal(features, df[["num1"]].values)
+
+
 def test_load_data_returns_ndarray_with_categorical_features(generate_categorical_data):
     df = generate_categorical_data()
 


### PR DESCRIPTION
## Proposed changes

Follow-up to #978, taking @jeongyoonlee's note from that review.

`OneHotEncoder.transform` signals "no column produced a non-empty encoding" with an `assert`, and `load_data` catches it. Under `python -O` (or `PYTHONOPTIMIZE=1`) that assertion is compiled out, so `transform` returns `None` instead of raising, the `except` never runs, and `.toarray()` lands on `None`:

```
$ python -O -c "from causalml.features import load_data; ..."
AttributeError: 'NoneType' object has no attribute 'toarray'
```

That is the same constant-categorical input the assertion path already handles, so it works normally and fails only when assertions are off.

The fix keeps `fit_transform` in the `try` and moves `.toarray()` out behind a `None` check, so both signals converge on the same branch. No re-deriving of the encoder's own rule.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/uber/causalml/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/uber/causalml)
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

The test monkeypatches `OneHotEncoder.fit_transform` to return `None`, which reproduces the optimized-mode behavior deterministically without spawning a second interpreter. It fails on current master with the `AttributeError` above and passes with this change.

I also ran the real thing both ways. On master, `python -O` raises; with this patch it returns a `(7, 1)` array. `pytest tests/test_features.py` is 7 passed and `black --check` is clean.
