### PR TITLE
Preserve the decorated function's identity in `timeit`

### DIFF
--- a/causalml/inference/tree/utils.py
+++ b/causalml/inference/tree/utils.py
@@ -2,6 +2,7 @@
 Utility functions for uplift trees.
 """
 
+import functools
 import time
 from typing import Callable
 
@@ -342,6 +343,7 @@ def timeit(exclude_kwargs: tuple = ()) -> Callable:
     """
 
     def wrapper(f: Callable):
+        @functools.wraps(f)
         def wrapped(*args, **kw):
             ts = time.time()
             result = f(*args, **kw)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,5 +1,10 @@
+import inspect
+
 import numpy as np
+
 from causalml.inference.meta.utils import get_weighted_variance
+from causalml.inference.tree import CausalTreeRegressor
+from causalml.inference.tree.utils import timeit
 
 
 def test_weighted_variance():
@@ -18,3 +23,44 @@ def test_weighted_variance():
 
     # should get the same variance by duplicate the observation based on the sample weight
     assert var_x1 == var_x2
+
+
+def test_timeit_preserves_the_wrapped_signature():
+    """``timeit`` must not erase the identity of what it decorates.
+
+    Without ``functools.wraps`` the returned closure reports its own
+    ``(*args, **kw)`` signature and the name ``"wrapped"``, which breaks
+    anything that introspects the method — ``help()``, Sphinx autodoc, and
+    scikit-learn's parameter discovery among them.
+    """
+
+    @timeit()
+    def example(X, treatment, y, sample_weight=None):
+        """Docstring that must survive decoration."""
+        return X
+
+    assert example.__name__ == "example"
+    assert example.__doc__ == "Docstring that must survive decoration."
+    assert list(inspect.signature(example).parameters) == [
+        "X",
+        "treatment",
+        "y",
+        "sample_weight",
+    ]
+
+
+def test_timeit_preserves_bootstrap_pool_signature():
+    """``CausalTreeRegressor.bootstrap_pool`` is the decorator's only caller."""
+    assert CausalTreeRegressor.bootstrap_pool.__name__ == "bootstrap_pool"
+    params = list(inspect.signature(CausalTreeRegressor.bootstrap_pool).parameters)
+    assert params[:4] == ["self", "X", "treatment", "y"]
+
+
+def test_timeit_still_returns_the_wrapped_result():
+    """Guard the decorator's actual job while changing its metadata handling."""
+
+    @timeit(exclude_kwargs=("secret",))
+    def add(a, b, secret=None):
+        return a + b
+
+    assert add(2, 3, secret="hidden") == 5


### PR DESCRIPTION
## Proposed changes

`timeit` (`causalml/inference/tree/utils.py`) wraps the decorated function in a closure with no `functools.wraps`, so the decorated method loses its name, docstring and signature:

```python
>>> CausalTreeRegressor.bootstrap_pool.__name__
'wrapped'
>>> inspect.signature(CausalTreeRegressor.bootstrap_pool)
(*args, **kw)
```

`CausalTreeRegressor.bootstrap_pool` is the decorator's only user in the package, so that is the method affected today. Anything that introspects it sees the wrong thing — `help()`, Sphinx autodoc, and scikit-learn's parameter discovery among them.

One line of `functools.wraps` restores it.

I found this while adding a signature-driven deprecation shim for #854 (#975): the shim could not see `bootstrap_pool` because its signature read `(*args, **kw)`. The fix stands on its own and has nothing to do with argument order, so it's split out here rather than left buried in that PR. #975 also carries it; whichever lands first, the other merges cleanly.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Tests

Three cases added to `tests/test_utils.py`:

- signature, `__name__` and `__doc__` preservation on a synthetic decorated function
- `CausalTreeRegressor.bootstrap_pool` pinned specifically, so a regression is visible where it matters
- a guard that the decorator still returns the wrapped function's result, since this changes how it handles metadata

The first two fail on master (`assert 'wrapped' == 'bootstrap_pool'`) and pass with the fix. `pytest tests/test_causal_trees.py tests/test_utils.py` is 39 passed; `black --check` clean.
