### PR TITLE
Stop the #854 shim warning on causalml's own internal fit calls

### DIFF
--- a/causalml/inference/tree/_uplift/upliftforest.py
+++ b/causalml/inference/tree/_uplift/upliftforest.py
@@ -70,7 +70,7 @@ def _parallel_build_tree(tree, X, treatment, y, control_name, sample_weight):
     if control_name not in groups or len(groups) < 2:
         return None
     sw = None if sample_weight is None else sample_weight[idx]
-    tree.fit(X[idx], t_sub, y[idx], sample_weight=sw, check_input=True)
+    tree.fit(X[idx], y=y[idx], treatment=t_sub, sample_weight=sw, check_input=True)
     return tree
 
 

--- a/causalml/inference/tree/causal/causalforest.py
+++ b/causalml/inference/tree/causal/causalforest.py
@@ -135,8 +135,8 @@ def _parallel_build_trees(
 
         tree.fit(
             X,
-            treatment,
-            y,
+            y=y,
+            treatment=treatment,
             sample_weight=curr_sample_weight,
             check_input=True,
             prepare_data=False,
@@ -144,8 +144,8 @@ def _parallel_build_trees(
     else:
         tree.fit(
             X,
-            treatment,
-            y,
+            y=y,
+            treatment=treatment,
             sample_weight=sample_weight,
             check_input=True,
             prepare_data=False,

--- a/tests/test_fit_arg_order.py
+++ b/tests/test_fit_arg_order.py
@@ -38,10 +38,15 @@ from causalml.inference.meta import (
     BaseXClassifier,
     BaseRClassifier,
 )
-from causalml.inference.tree import CausalTreeRegressor, UpliftTreeClassifier
+from causalml.inference.tree import (
+    CausalRandomForestRegressor,
+    CausalTreeRegressor,
+    UpliftRandomForestClassifier,
+    UpliftTreeClassifier,
+)
 from causalml.metrics.sensitivity import Sensitivity
 
-from .const import RANDOM_SEED
+from .const import RANDOM_SEED, CONTROL_NAME, CONVERSION, TREATMENT_NAMES
 
 # One representative regressor per meta-learner family; all default to
 # ``control_name=0`` which matches the 0/1 treatment from ``synthetic_data``.
@@ -371,6 +376,59 @@ def test_uplift_tree_validation_triple_is_reordered():
         "sample_weight",
         "check_input",
     ]
+
+
+# --- the library's own internal calls must not warn the caller --------------
+
+
+def _arg_order_warnings(record):
+    """The shim's warnings only — not unrelated FutureWarnings from deps."""
+    return [
+        w
+        for w in record
+        if issubclass(w.category, FutureWarning) and "argument order" in str(w.message)
+    ]
+
+
+def test_causal_forest_keyword_fit_does_not_warn(generate_regression_data):
+    """A forest fits each of its trees internally, and that must stay invisible.
+
+    The shim's re-entrancy guard (``_in_arg_order_call``) is stored on the
+    instance, so it does not span the forest -> tree hop: the flag is set on the
+    forest while the warning fires on each tree. Until the internal calls were
+    made keyword, an all-keyword ``fit`` emitted one FutureWarning per tree
+    (default ``n_estimators=100``) telling the caller to do what they had
+    already done, with no way to silence it.
+    """
+    y, X, treatment, _, _, _ = generate_regression_data()
+    forest = CausalRandomForestRegressor(n_estimators=3, random_state=RANDOM_SEED)
+
+    with warnings.catch_warnings(record=True) as record:
+        warnings.simplefilter("always")
+        forest.fit(X=X, y=y, treatment=treatment)
+
+    assert _arg_order_warnings(record) == []
+
+
+def test_uplift_forest_keyword_fit_does_not_warn(generate_classification_data):
+    """Same forest -> tree hop in the uplift ensemble (default n_estimators=10)."""
+    df, x_names = generate_classification_data()
+    forest = UpliftRandomForestClassifier(
+        n_estimators=3,
+        min_samples_leaf=50,
+        control_name=CONTROL_NAME,
+        random_state=RANDOM_SEED,
+    )
+
+    with warnings.catch_warnings(record=True) as record:
+        warnings.simplefilter("always")
+        forest.fit(
+            X=df[x_names].values,
+            y=df[CONVERSION].values,
+            treatment=df["treatment_group_key"].values,
+        )
+
+    assert _arg_order_warnings(record) == []
 
 
 def test_timeit_preserves_signature():


### PR DESCRIPTION
## Proposed changes

Follow-up to #975. The deprecation shim suppresses re-entrant warnings with a flag stored on the **instance**, so it covers `self.fit` → `self.predict` nesting but not the **forest → tree** hop: the flag is set on the forest while the warning fires on each tree it fits.

The result is a warning the caller cannot act on or silence:

```python
>>> CausalRandomForestRegressor(n_estimators=2).fit(X=X, y=y, treatment=treatment)
FutureWarning: Passing `treatment` and/or `y` to fit() by position is deprecated ...
FutureWarning: Passing `treatment` and/or `y` to fit() by position is deprecated ...
```

That call is all-keyword — written exactly the way the warning asks for — and it emits **one FutureWarning per tree**: 100 at the default `n_estimators`. `UpliftRandomForestClassifier` behaves the same way (default 10).

This makes the forests pass `y` and `treatment` to their trees by keyword. It is the same migration #982 applies to `tests/`, applied to the library's own call sites — the epic (#980) has no ticket covering those.

### Call sites changed

| File | |
|---|---|
| `causalml/inference/tree/causal/causalforest.py:136` | subsample / bootstrap branch |
| `causalml/inference/tree/causal/causalforest.py:145` | non-subsample branch |
| `causalml/inference/tree/_uplift/upliftforest.py:73` | bagged uplift tree fit |

### Verification

An empirical probe over eleven public entry points (both forests, both trees, the S/T/X/R/DR learners, `estimate_ate`, `fit_predict`), all called with keywords, attributes each warning to its originating library line via `stacklevel=2`: **2 offending sites before, 0 after**.

- `tests/test_fit_arg_order.py`: 54 passed.
- `tests/test_causal_trees.py tests/test_uplift_trees.py tests/test_uplift_trees_kernel.py tests/test_serialization_extended.py`: 135 passed.
- Both new regression tests fail with the library change reverted and pass with it, so they pin the fix rather than passing vacuously.
- `black --check` clean.

### Left alone, deliberately

The same-instance `super().fit(X, treatment, y, ...)` calls in `upliftforest.py:342`, `uplifttree.py:567` and `rlearner.py:913`. The guard already covers them and they warn nobody today. **They do need to change under #985** — once the signature order flips, `treatment` silently lands in `y`.

### Note on why this was not caught

The repo sets no `filterwarnings` anywhere, so `FutureWarning` is never an error and the affected tests pass on a normal run. A deprecation shim without a warnings-as-errors lane is untested by construction; worth pairing with the CI work in #977.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/uber/causalml/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/uber/causalml)
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

🤖 Generated with [Claude Code](https://claude.com/claude-code)