### PR TITLE
Add the fit() argument-order migration guide and changelog entry (#984)

### DIFF
--- a/causalml/inference/_arg_order.py
+++ b/causalml/inference/_arg_order.py
@@ -35,6 +35,12 @@ import warnings
 #: Parameters whose positional slot changes in v1.0, in their v1.0 order.
 REORDERED_PARAMS = ("y", "treatment")
 
+#: Where the warning sends callers. This is the page that tells them what to
+#: type; #854 is a bug report and cannot serve that purpose.
+MIGRATION_GUIDE_URL = (
+    "https://causalml.readthedocs.io/en/latest/migration.html#fit-argument-order"
+)
+
 
 def _positional_params(method):
     """Return the names of ``method``'s positional parameters, minus ``self``."""
@@ -129,9 +135,9 @@ def deprecate_positional_treatment_y(method):
     message = (
         "Passing `treatment` and/or `y` to {name}() by position is deprecated "
         "and will change in causalml v1.0: the positional argument order "
-        "becomes ({new_order}) for scikit-learn Pipeline compatibility "
-        "(see https://github.com/uber/causalml/issues/854). To be safe across "
-        "the change, pass them as keyword arguments, e.g. {example}."
+        "becomes ({new_order}) for scikit-learn Pipeline compatibility. To be "
+        "safe across the change, pass them as keyword arguments, e.g. "
+        "{example}. Migration guide: {guide}"
     ).format(
         name=method.__name__,
         new_order=", ".join(target),
@@ -140,6 +146,7 @@ def deprecate_positional_treatment_y(method):
             params[0],
             ", ".join(f"{p}={p}" for p in REORDERED_PARAMS if p in params),
         ),
+        guide=MIGRATION_GUIDE_URL,
     )
 
     @functools.wraps(method)

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,6 +5,28 @@ Changelog
 
 You can find the latest changes in the `GitHub releases <https://github.com/uber/causalml/releases>`_
 
+Unreleased
+----------
+
+Deprecations
+~~~~~~~~~~~~
+* **Positional** ``treatment`` **and** ``y`` **are deprecated (#854).** In v1.0 every
+  learner's positional argument order becomes ``fit(X, y, treatment, ...)``, matching
+  the scikit-learn convention so a CausalML learner can be a ``Pipeline`` step. Passing
+  ``treatment`` or ``y`` by position now emits a ``FutureWarning``; positional order is
+  unchanged in this release, so nothing breaks yet.
+
+  The fix is to pass them by keyword — ``learner.fit(X=X, treatment=treatment, y=y)`` —
+  which is order-independent and therefore correct both before and after the flip.
+
+  This one cannot be caught at runtime: ``y`` and ``treatment`` are both same-length
+  arrays, so a call left in the old positional form will silently train on swapped
+  arguments at v1.0 rather than raising ``TypeError``. See the
+  :ref:`migration guide <fit-argument-order>` for the per-family table and for the
+  signatures that are not a plain swap (``IVRegressor.fit`` and ``BaseDRIVLearner``).
+
+  By @jeongyoonlee in https://github.com/uber/causalml/pull/975
+
 0.17.0 (Jul 2026)
 -----------------
 * Adds **scikit-learn 1.9 support**, resolving an ``import causalml.dataset`` failure present on the 0.16.0 wheel (#926).

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -9,6 +9,7 @@ Contents:
     about
     installation
     quickstart
+    migration
     examples
     methodology
     interpretation

--- a/docs/migration.rst
+++ b/docs/migration.rst
@@ -1,0 +1,243 @@
+=================
+Migration Guide
+=================
+
+.. _fit-argument-order:
+
+``fit()`` argument order changes in v1.0
+========================================
+
+**If you only read one thing:** pass ``treatment`` and ``y`` as keyword
+arguments, starting now.
+
+.. code-block:: python
+
+    # Before — breaks silently at v1.0
+    learner.fit(X, treatment, y)
+
+    # After — works identically before and after v1.0
+    learner.fit(X=X, treatment=treatment, y=y)
+
+That single edit is the whole migration. Keyword arguments are
+order-independent, so a call written this way behaves the same in every version
+and needs no second edit when the flip lands.
+
+Why this is changing
+--------------------
+
+CausalML learners have always taken ``fit(X, treatment, y, ...)``, which puts
+``y`` third. ``sklearn.pipeline.Pipeline`` calls its final estimator's
+``fit(X, y)`` positionally, so a CausalML learner cannot be a pipeline step
+without an adapter — the problem reported in `#854
+<https://github.com/uber/causalml/issues/854>`_.
+
+In v1.0 the positional order becomes ``fit(X, y, treatment, ...)``, matching the
+scikit-learn convention.
+
+.. warning::
+
+    This change cannot be detected at runtime. ``y`` and ``treatment`` are both
+    same-length arrays, so a call left in the old positional form will **not**
+    raise ``TypeError`` after the flip — it will train on swapped arguments and
+    return plausible-looking, wrong numbers.
+
+    This is why the deprecation warns for a full release cycle before anything
+    moves, and why keyword arguments are the recommended fix rather than
+    "reorder your positional calls at v1.0".
+
+What happens when
+-----------------
+
+**Today (the release that ships this guide).** Positional order is *unchanged*.
+Passing ``treatment`` or ``y`` positionally emits a ``FutureWarning`` pointing
+here. Nothing breaks.
+
+**At v1.0.** The signatures are reordered and the warning is removed. Positional
+calls in the old order start silently mis-training; keyword calls are unaffected.
+
+The number of releases between the two is still being decided — see open
+question 2 in the `v1.0 roadmap discussion
+<https://github.com/uber/causalml/discussions/938>`_ if you need a longer
+window, or want to say so.
+
+The rule
+--------
+
+One rule, applied uniformly across the package:
+
+    **X, then** ``y``, **then** ``treatment``\ **, and every other parameter
+    keeps its relative position.**
+
+So the two arguments move to the front in scikit-learn order, and everything
+else — ``p``, ``sample_weight``, ``return_ci``, ``verbose`` — shifts right
+without being reshuffled among itself.
+
+The rule is implemented as ``v1_order()`` in ``causalml/inference/_arg_order.py``
+and derived per method from that method's own signature, so the target for every
+method is machine-checkable rather than hand-maintained.
+
+Finding the calls you need to change
+------------------------------------
+
+Run your test suite or a representative script with the warning made fatal, so
+each call site surfaces as a traceback:
+
+.. code-block:: bash
+
+    python -W error::FutureWarning your_script.py
+
+That also promotes unrelated ``FutureWarning``\ s from pandas, NumPy and
+scikit-learn, so on a large codebase it is usually easier to collect only this
+deprecation and keep going:
+
+.. code-block:: python
+
+    import warnings
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        ...  # your code
+    for w in caught:
+        if issubclass(w.category, FutureWarning) and "argument order" in str(w.message):
+            print(f"{w.filename}:{w.lineno}")
+
+The warning is raised with ``stacklevel=2``, so ``filename`` and ``lineno``
+point at *your* call site, not at CausalML internals.
+
+A grep is less reliable than it looks: ``fit(X, a, b)`` is also how you call a
+plain scikit-learn estimator, and those are unaffected. Prefer the warning.
+
+What changes, by family
+-----------------------
+
+Every public method whose positional order changes is listed below. ``predict``
+is included deliberately: its current order does not block ``Pipeline``, since
+``predict(X)`` already works, but flipping only ``fit`` would leave one class
+with the same two arguments in opposite positional orders on two methods.
+
+Meta-learners
+~~~~~~~~~~~~~
+
+``causalml.inference.meta`` — the S/T/X/R/DR learners and their classifier
+variants, ``XGBTRegressor``, ``XGBRRegressor``, ``XGBTClassifier``,
+``XGBRClassifier``, ``LRSRegressor``, ``TMLELearner``.
+
+Methods: ``fit``, ``predict``, ``fit_predict``, ``estimate_ate``, ``bootstrap``,
+``fit_bootstrap_ensemble``.
+
+.. code-block:: text
+
+    now:  (X, treatment, y, p, ...)
+    v1.0: (X, y, treatment, p, ...)
+
+Causal trees and forests
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+``CausalTreeRegressor``, ``CausalRandomForestRegressor``.
+
+Methods: ``fit``, ``fit_predict``, ``estimate_ate``, ``bootstrap``,
+``bootstrap_pool``.
+
+.. code-block:: text
+
+    now:  (X, treatment, y, sample_weight, ...)
+    v1.0: (X, y, treatment, sample_weight, ...)
+
+Uplift trees and forests
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+``UpliftTreeClassifier``, ``UpliftRandomForestClassifier``.
+
+Methods: ``fit``, ``fill``, ``prune``.
+
+``UpliftTreeClassifier.fit`` also takes a validation triple, which is reordered
+in place so it stays consistent with the main one:
+
+.. code-block:: text
+
+    now:  (X, treatment, y, X_val, treatment_val, y_val, sample_weight, check_input)
+    v1.0: (X, y, treatment, X_val, y_val, treatment_val, sample_weight, check_input)
+
+Instrumental variables
+~~~~~~~~~~~~~~~~~~~~~~
+
+Two signatures here are **not** a plain ``treatment``/``y`` swap.
+
+``IVRegressor.fit`` — the instrument ``w`` keeps its relative position and
+shifts right:
+
+.. code-block:: text
+
+    now:  (X, treatment, y, w)
+    v1.0: (X, y, treatment, w)
+
+``BaseDRIVLearner`` (``fit``, ``fit_predict``, ``estimate_ate``, ``bootstrap``)
+— ``assignment`` currently sits *second*, and lands fourth:
+
+.. code-block:: text
+
+    now:  (X, assignment, treatment, y, p, pZ, ...)
+    v1.0: (X, y, treatment, assignment, p, pZ, ...)
+
+``BaseDRIVLearner.predict`` takes no ``assignment`` and follows the ordinary
+rule: ``(X, treatment, y, ...)`` becomes ``(X, y, treatment, ...)``.
+
+Neural estimators
+~~~~~~~~~~~~~~~~~
+
+``DragonNet`` (TensorFlow and JAX backends) and ``CEVAE`` (PyTorch and JAX
+backends). Methods: ``fit``, ``predict``, ``fit_predict``.
+
+.. code-block:: text
+
+    now:  (X, treatment, y, p)
+    v1.0: (X, y, treatment, p)
+
+Optional backends are only importable with the matching extra installed, so
+these calls may not warn in an environment where the backend is missing. They
+change all the same.
+
+Policy learning
+~~~~~~~~~~~~~~~
+
+``PolicyLearner.fit``:
+
+.. code-block:: text
+
+    now:  (X, treatment, y, p, dhat)
+    v1.0: (X, y, treatment, p, dhat)
+
+Sensitivity analysis helpers
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+``causalml.metrics.sensitivity.Sensitivity`` — ``get_prediction``,
+``get_ate_ci``, ``get_potential_outcome_predictions``. These are a third shape,
+with ``p`` currently second; it shifts right:
+
+.. code-block:: text
+
+    now:  (X, p, treatment, y)
+    v1.0: (X, y, treatment, p)
+
+``Sensitivity.summary`` and ``sensitivity_analysis`` read ``treatment`` and
+``y`` from a DataFrame by column name and are unaffected.
+
+Deliberately unchanged
+----------------------
+
+A method is in scope only if **both** ``y`` and ``treatment`` appear after the
+first position. Anything else keeps its current signature at v1.0:
+
+* ``BaseRLearner.predict(X, p, return_components)`` — takes neither, so there is
+  nothing to reorder. After the flip, ``BaseRLearner.fit`` and ``.predict``
+  legitimately differ; that is not an oversight.
+* ``ElasticNetPropensityModel`` and the other ``PropensityModel`` classes —
+  ``fit(X, y)`` and ``fit_predict(X, y)`` take no ``treatment`` and already
+  follow the scikit-learn convention.
+* Dataset helpers that name their treatment vector something other than
+  ``treatment``, such as ``SemiSynthDataGenerator.fit(X, w, y)``.
+* Any plain scikit-learn estimator you pass *into* a CausalML learner. Only
+  CausalML's own signatures change.
+
+If a method takes only ``y`` and no ``treatment``, this deprecation does not
+apply to it.

--- a/tests/test_fit_arg_order.py
+++ b/tests/test_fit_arg_order.py
@@ -19,12 +19,17 @@ import importlib
 import inspect
 import pkgutil
 import warnings
+from pathlib import Path
 
 import numpy as np
 import pytest
 from sklearn.linear_model import LinearRegression
 
-from causalml.inference._arg_order import _positional_params, v1_order
+from causalml.inference._arg_order import (
+    MIGRATION_GUIDE_URL,
+    _positional_params,
+    v1_order,
+)
 from causalml.inference.iv import BaseDRIVRegressor, IVRegressor
 from causalml.inference.meta import (
     BaseSRegressor,
@@ -376,6 +381,53 @@ def test_uplift_tree_validation_triple_is_reordered():
         "sample_weight",
         "check_input",
     ]
+
+
+# --- the warning must point at a page that actually exists ------------------
+
+
+def test_warning_links_to_the_migration_guide(generate_regression_data):
+    """The link a user follows out of the warning has to reach instructions.
+
+    It originally pointed at #854, which is a bug report -- it tells a reader
+    what went wrong for someone else, not what to type.
+    """
+    y, X, treatment, _, _, _ = generate_regression_data()
+    learner = BaseTRegressor(learner=LinearRegression())
+
+    with warnings.catch_warnings(record=True) as record:
+        warnings.simplefilter("always")
+        learner.fit(X, treatment, y)
+
+    message = str(_order_warnings(record)[0].message)
+    assert MIGRATION_GUIDE_URL in message
+    # The actionable instruction must be in the warning itself, not only behind
+    # the link -- a user with no network still needs to know what to change.
+    assert "fit(X, y=y, treatment=treatment)" in message
+
+
+def test_migration_guide_url_matches_the_docs_source():
+    """Pin the URL to the file and label it points at.
+
+    Sphinx derives ``migration.html#fit-argument-order`` from the filename and
+    the ``.. _fit-argument-order:`` label. Renaming either would leave the
+    warning pointing at a 404 that nothing else would catch, because the
+    warning text is a plain string and the docs build would stay green.
+    """
+    page, _, anchor = MIGRATION_GUIDE_URL.rpartition("/")[2].partition("#")
+    guide = Path(__file__).resolve().parents[1] / "docs" / page.replace(".html", ".rst")
+
+    assert guide.is_file(), f"{guide.name} is missing; the warning links to it"
+    assert f".. _{anchor}:" in guide.read_text(), (
+        f"label `{anchor}` is missing from {guide.name}; "
+        "the warning's anchor would 404"
+    )
+
+
+def test_migration_guide_is_in_the_docs_toctree():
+    """An unlinked page is unreachable by browsing and warns at build time."""
+    docs = Path(__file__).resolve().parents[1] / "docs"
+    assert "\n    migration\n" in (docs / "index.rst").read_text()
 
 
 # --- the library's own internal calls must not warn the caller --------------


### PR DESCRIPTION
## Proposed changes

Closes #984. Part of #980; refs #854, #975.

#975 emits a `FutureWarning` telling callers to switch to keyword arguments, and points them at #854 — a user's bug report. It explains what went wrong for someone else; it does not tell a reader what to type. This adds the page that does, and points the warning at it.

### `docs/migration.rst` — the guide

Structured so the fix is the first thing on the page, before any of the reasoning:

```python
# Before — breaks silently at v1.0
learner.fit(X, treatment, y)

# After — works identically before and after v1.0
learner.fit(X=X, treatment=treatment, y=y)
```

Then: why it's changing, a `warning` block on why this particular deprecation can't be caught at runtime, what happens when, the one rule (`X`, then `y`, then `treatment`, everything else keeps its relative position), how to find affected calls in your own code, the per-family table, and what is deliberately **not** changing.

**The table is transcribed from the shim, not written by hand.** I enumerated every method carrying `_arg_order_shimmed` across the package and printed `_positional_params()` alongside `v1_order()` for each — 56 methods, plus 12 more on the optional TF/JAX/Torch backends that can't be imported without their extras. Every "now → v1.0" line in the guide comes from that dump.

It calls out the three shapes that aren't a plain `treatment`/`y` swap:

| | now | v1.0 |
|---|---|---|
| `IVRegressor.fit` | `(X, treatment, y, w)` | `(X, y, treatment, w)` |
| `BaseDRIVLearner.fit` | `(X, assignment, treatment, y, …)` | `(X, y, treatment, assignment, …)` |
| `Sensitivity.get_prediction` | `(X, p, treatment, y)` | `(X, y, treatment, p)` |

and documents the resolved answers to #980's open questions 1 and 2: `UpliftTreeClassifier`'s validation triple reorders in place to `(X_val, y_val, treatment_val)`, and the `Sensitivity` helpers are in scope with `p` shifting right.

The "deliberately unchanged" section covers what #981 settled — `BaseRLearner.predict(X, p, return_components)` takes neither argument, `PropensityModel.fit(X, y)` takes no `treatment`, and dataset helpers such as `SemiSynthDataGenerator.fit(X, w, y)` name their treatment vector something else. Each was verified against the live signature.

### `docs/changelog.rst` — an `Unreleased` section

#975 merged after v0.17.0 was cut, so there was no section for it to go in. The changelog had no `Unreleased` heading at all, which means any behaviour change whose significance isn't obvious from a PR title gets dropped at release time. This adds one, with the deprecation entry under `Deprecations` and a `:ref:` into the guide.

### The warning now links to the guide

```diff
-"(see https://github.com/uber/causalml/issues/854). To be safe across "
-"the change, pass them as keyword arguments, e.g. {example}."
+"...To be safe across the change, pass them as keyword arguments, e.g. "
+"{example}. Migration guide: {guide}"
```

The URL is a module constant, `MIGRATION_GUIDE_URL`, so the tests can pin it.

### Three tests, because a URL in a string rots silently

Sphinx derives `migration.html#fit-argument-order` from the filename and the `.. _fit-argument-order:` label. Rename either one and the docs build stays green while the warning starts pointing at a 404 — nothing else in the repo would catch it. So:

- `test_warning_links_to_the_migration_guide` — the warning contains the URL, **and** still contains the literal instruction `fit(X, y=y, treatment=treatment)`, since a user offline needs to know what to change without following a link.
- `test_migration_guide_url_matches_the_docs_source` — the page and anchor in the URL resolve to a real file and a real label.
- `test_migration_guide_is_in_the_docs_toctree` — an unlinked page is unreachable by browsing.

All three were confirmed to fail when the thing they guard is broken.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)

The only non-docs change is the warning's text.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/uber/causalml/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/uber/causalml)
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules

## Verification

Full suite on this branch: **438 passed, 10 skipped, exit 0** (435 on master plus the three new tests).

- `sphinx -b dummy` exits 0 with **zero warnings attributable to `migration.rst`, `changelog.rst` or `index.rst`**. (The full build needs `pandoc` for the notebook gallery, which isn't installed locally; this run excludes `examples/`. Read the Docs covers it on the PR.)
- Built the HTML and confirmed `id="fit-argument-order"` exists in `migration.html` and that the changelog's `:ref:` renders as `href="migration.html#fit-argument-order"` — so the URL in the warning resolves to a real anchor.
- Every signature claim in the guide was checked against the live object, including the four in the "deliberately unchanged" section.
- `black --check` clean.

One heading rename along the way: my `Sensitivity analysis` subsection collided with `quickstart.rst` under `autosectionlabel`, so it's `Sensitivity analysis helpers`. The build adds no new duplicate-label warnings.

## Further comments

**Not addressed here.** The guide states that the number of releases between the warning and the flip is still being decided, and links to open question 2 on [#938](https://github.com/uber/causalml/discussions/938). That's a call for you and the community to make, not something a docs PR should quietly fix — when it's settled, the "What happens when" section is the place to put the answer.

With this, all three window-closing issues on #980 are done: #982 and #983 in #989, #984 here. #985 (the flip) is then gated only on the release-window decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
