### PR TITLE
Default UpliftRandomForestClassifier to n_jobs=None (#991)

### DIFF
--- a/causalml/inference/tree/_uplift/upliftforest.py
+++ b/causalml/inference/tree/_uplift/upliftforest.py
@@ -15,7 +15,7 @@ because the kernel tree does not implement it.
 """
 
 import warnings
-from typing import Union
+from typing import Optional, Union
 
 import numpy as np
 import pandas as pd
@@ -87,6 +87,15 @@ class _KernelUpliftRandomForestClassifier(SerializableLearner, ForestRegressor):
     ``save`` / ``load`` and is a scikit-learn ``BaseEstimator`` via
     ``ForestRegressor`` (``get_params`` / ``clone`` round-trip). Full
     ``check_estimator`` does not apply -- ``fit`` takes ``(X, treatment, y)``.
+
+    ``n_jobs`` trades memory for speed. Trees are fitted in parallel and each
+    concurrent fit holds its own working set, so peak memory grows roughly in
+    proportion to the number of workers -- on one benchmark (100k x 440
+    features) peak rose from 1.4x the input array at ``n_jobs=1`` to 8.8x at
+    ``n_jobs=-1`` on 10 cores, for a ~4.5x speedup. The default ``None`` means
+    one worker, as in scikit-learn's forests. Raise it when memory allows.
+    ``n_estimators`` does not affect peak memory once ``n_jobs`` is fixed.
+    Results do not depend on ``n_jobs``.
     """
 
     def __init__(
@@ -105,7 +114,7 @@ class _KernelUpliftRandomForestClassifier(SerializableLearner, ForestRegressor):
         estimation_sample_size: float = 0.5,
         max_features: Union[int, float, str, None] = "sqrt",
         min_weight_fraction_leaf: float = 0.0,
-        n_jobs: int = -1,
+        n_jobs: Optional[int] = None,
         random_state: int = None,
         joblib_prefer: str = "threads",
     ):
@@ -260,6 +269,12 @@ class UpliftRandomForestClassifier(_KernelUpliftRandomForestClassifier):
     ``early_stopping_eval_diff_scale`` and ``fit``'s ``X_val`` / ``treatment_val``
     / ``y_val`` are accepted for backward compatibility but ignored: validation-set
     early stopping is not implemented on the kernel trees.
+
+    ``n_jobs`` defaults to ``None`` (one worker). Peak memory during ``fit``
+    grows roughly in proportion to the number of workers, since each concurrent
+    tree fit holds its own working set; see
+    :class:`_KernelUpliftRandomForestClassifier` for measurements. Results are
+    unaffected by ``n_jobs``.
     """
 
     def __init__(
@@ -277,7 +292,7 @@ class UpliftRandomForestClassifier(_KernelUpliftRandomForestClassifier):
         normalization=True,
         honesty=False,
         estimation_sample_size=0.5,
-        n_jobs=-1,
+        n_jobs=None,
         joblib_prefer: str = "threads",
     ):
         # Retained verbatim for the sklearn get_params / clone contract on the

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -8,6 +8,22 @@ You can find the latest changes in the `GitHub releases <https://github.com/uber
 Unreleased
 ----------
 
+Behavior Changes
+~~~~~~~~~~~~~~~~
+* **`UpliftRandomForestClassifier` now defaults to** ``n_jobs=None`` **(one worker) instead of**
+  ``n_jobs=-1`` **(#991).** Trees are fitted in parallel and each concurrent fit holds its own
+  working set, so peak memory grew in proportion to the machine's core count — the same fit
+  needed more memory on a larger machine. On a 100k × 440 benchmark, peak memory was 8.8× the
+  input array at ``n_jobs=-1`` (10 cores) versus 1.4× at ``n_jobs=1``.
+
+  Fitted models and predictions are unchanged; only peak memory and wall time move. Existing
+  code gets slower and much lighter without any edit. Pass ``n_jobs=-1`` explicitly to restore
+  the previous behavior. Note that ``n_estimators`` does not affect peak memory once ``n_jobs``
+  is fixed.
+
+  This matches ``CausalRandomForestRegressor`` and scikit-learn's forests, which use the same
+  across-trees parallelism and default to serial.
+
 Deprecations
 ~~~~~~~~~~~~
 * **Positional** ``treatment`` **and** ``y`` **are deprecated (#854).** In v1.0 every

--- a/tests/test_fit_arg_order.py
+++ b/tests/test_fit_arg_order.py
@@ -479,6 +479,7 @@ def test_uplift_forest_keyword_fit_does_not_warn(generate_classification_data):
         min_samples_leaf=50,
         control_name=CONTROL_NAME,
         random_state=RANDOM_SEED,
+        n_jobs=-1,
     )
 
     with warnings.catch_warnings(record=True) as record:

--- a/tests/test_serialization_extended.py
+++ b/tests/test_serialization_extended.py
@@ -232,6 +232,7 @@ class TestUpliftForestRoundTrip:
             max_depth=3,
             min_samples_leaf=20,
             random_state=RANDOM_SEED,
+            n_jobs=-1,
         )
         forest.fit(X=X, treatment=treatment, y=y)
         preds_before = forest.predict(X)
@@ -243,7 +244,9 @@ class TestUpliftForestRoundTrip:
         np.testing.assert_array_almost_equal(preds_before, preds_after)
 
     def test_unfitted_save_raises(self, tmp_path_file):
-        forest = UpliftRandomForestClassifier(control_name="control", n_estimators=5)
+        forest = UpliftRandomForestClassifier(
+            control_name="control", n_estimators=5, n_jobs=-1
+        )
         with pytest.raises(ValueError, match="Cannot save an unfitted model"):
             forest.save(tmp_path_file)
 

--- a/tests/test_uplift_trees_kernel.py
+++ b/tests/test_uplift_trees_kernel.py
@@ -15,7 +15,7 @@ The data generators use binary features so split behavior is easy to reason abou
 import numpy as np
 import pandas as pd
 import pytest
-from joblib import parallel_backend
+from joblib import effective_n_jobs, parallel_backend
 from numpy.testing import assert_array_almost_equal
 from sklearn.base import clone
 from sklearn.model_selection import train_test_split
@@ -25,6 +25,7 @@ from causalml.inference.tree import uplift_tree_plot, uplift_tree_string
 from causalml.inference.tree._uplift.uplifttree import _KernelUpliftTreeClassifier
 from causalml.inference.tree._uplift.upliftforest import (
     _KernelUpliftRandomForestClassifier,
+    UpliftRandomForestClassifier,
 )
 from causalml.metrics import auuc_score
 
@@ -847,3 +848,42 @@ def test_kernel_uplift_forest_with_nan():
     delta = model.predict(Xn)
     assert delta.shape == (len(Xn), 1)
     assert np.isfinite(delta).all()
+
+
+def test_kernel_uplift_forest_n_jobs_defaults_to_serial():
+    """Both forests default to one worker (#991).
+
+    Trees are fitted in parallel and each concurrent fit holds its own working
+    set, so peak memory grows with the worker count -- which means the same fit
+    needs more memory on a machine with more cores. scikit-learn's forests use
+    the same across-trees parallelism and default to serial for this reason.
+    """
+    assert _KernelUpliftRandomForestClassifier(control_name=CONTROL_NAME).n_jobs is None
+    assert (
+        UpliftRandomForestClassifier(control_name=CONTROL_NAME).n_jobs is None
+    ), "the legacy-shaped subclass must not reintroduce n_jobs=-1"
+    assert effective_n_jobs(None) == 1
+
+
+@pytest.mark.parametrize("n_jobs", [None, 1, 2, -1])
+def test_kernel_uplift_forest_predictions_independent_of_n_jobs(n_jobs):
+    """n_jobs is a memory/speed knob only -- it must not move the numbers.
+
+    This is what makes the #991 default change safe: raising or lowering
+    n_jobs changes peak memory and wall time, never the fitted model.
+    """
+    X, treatment, y = _make_binary_feature_data(n_samples=2000, n_features=5)
+    common = dict(
+        control_name=CONTROL_NAME,
+        n_estimators=6,
+        max_depth=4,
+        min_samples_leaf=100,
+        random_state=RANDOM_SEED,
+    )
+    serial = _KernelUpliftRandomForestClassifier(**common, n_jobs=1)
+    serial.fit(X=X, treatment=treatment, y=y)
+
+    other = _KernelUpliftRandomForestClassifier(**common, n_jobs=n_jobs)
+    other.fit(X=X, treatment=treatment, y=y)
+
+    assert_array_almost_equal(serial.predict(X), other.predict(X), decimal=12)

--- a/tests/test_uplift_trees_kernel.py
+++ b/tests/test_uplift_trees_kernel.py
@@ -576,6 +576,7 @@ def test_kernel_uplift_forest_full_output():
         max_depth=3,
         min_samples_leaf=100,
         random_state=RANDOM_SEED,
+        n_jobs=-1,
     )
     model.fit(X=X, treatment=treatment, y=y)
 
@@ -609,6 +610,7 @@ def test_kernel_uplift_forest_feature_importances():
         max_depth=3,
         min_samples_leaf=100,
         random_state=RANDOM_SEED,
+        n_jobs=-1,
     )
     model.fit(X=X, treatment=treatment, y=y)
     fi = model.feature_importances_
@@ -649,7 +651,7 @@ def _make_serialization_estimator(kind, **overrides):
         random_state=RANDOM_SEED,
     )
     params.update(overrides)
-    return _KernelUpliftRandomForestClassifier(**params)
+    return _KernelUpliftRandomForestClassifier(**params, n_jobs=-1)
 
 
 @pytest.mark.parametrize("kind", ["tree", "forest"])
@@ -842,6 +844,7 @@ def test_kernel_uplift_forest_with_nan():
         max_depth=4,
         min_samples_leaf=100,
         random_state=RANDOM_SEED,
+        n_jobs=-1,
     )
     assert model.__sklearn_tags__().input_tags.allow_nan is True
     model.fit(X=Xn, treatment=treatment, y=y)


### PR DESCRIPTION
## Proposed changes

Closes #991.

`UpliftRandomForestClassifier` and `_KernelUpliftRandomForestClassifier` default to `n_jobs=None` (one worker) instead of `n_jobs=-1`.

Trees are fitted in parallel and each concurrent fit holds its own working set, so peak memory grows in proportion to the worker count — meaning the same fit needs more memory on a machine with more cores. `CausalRandomForestRegressor` and scikit-learn's forests use the same across-trees parallelism and default to serial.

## Measurements

Master `0ba283e`, macOS/arm64, 10 cores, float32 inputs. "fit peak" is peak RSS during `fit` minus RSS immediately before it.

| config | input | fit peak | × input | time |
|---|---|---|---|---|
| n=150k, p=220, `n_jobs=-1` | 137 MB | 1502 MB | 11.0× | 2.9 s |
| n=150k, p=220, `n_jobs=2` | 137 MB | 363 MB | 2.7× | 7.7 s |
| n=150k, p=220, `n_jobs=1` | 137 MB | 250 MB | 1.8× | 14.1 s |
| n=100k, p=440, `n_jobs=-1` | 179 MB | 1585 MB | 8.8× | 2.1 s |
| n=100k, p=440, `n_jobs=1` | 179 MB | 258 MB | 1.4× | 9.6 s |

`n_estimators` does not affect peak memory once `n_jobs` is fixed: at `n_jobs=1`, n=150k, p=220 — 5 trees → 220 MB, 10 → 257 MB, 20 → 254 MB. Only time scales.

## What this costs

Wall time, and the PR should be judged on that trade. For an isolated fit, `n_jobs=-1` is consistently faster and there is no crossover where serial wins:

| rows | features | serial | `n_jobs=-1` | speedup |
|---|---|---|---|---|
| 1,000 | 20 | 0.04 s | 0.03 s | 1.6× |
| 5,000 | 20 | 0.34 s | 0.09 s | 3.7× |
| 20,000 | 20 | 1.53 s | 0.36 s | 4.2× |
| 100,000 | 20 | 9.16 s | 1.99 s | 4.6× |
| 100,000 | 200 | 9.05 s | 2.04 s | 4.4× |

So existing code that does not set `n_jobs` gets roughly 2–5× slower and ~6× lighter. `n_jobs=-1` restores the old behaviour exactly.

The repo's own forest tests happen to get *faster* (4:09 → 2:35 on the same 13 tests), but that is an artifact rather than a general result: several of them parameterize over process-based joblib backends (`loky`, `multiprocessing`, `joblib_prefer="processes"`), where a high default worker count multiplies process-startup cost. The single-fit table above is the number to reason from.

## Why the default rather than documentation alone

The safe default depends on where the threads work:

| library | default | resolves to | parallelism |
|---|---|---|---|
| sklearn `RandomForest*` | `n_jobs=None` | 1 | joblib across trees |
| xgboost `XGBRegressor` | `n_jobs=None` | all threads | OpenMP within the build |
| lightgbm `LGBMRegressor` | `n_jobs=None` | physical cores | OpenMP within the build |
| `CausalRandomForestRegressor` | `n_jobs=None` | 1 | joblib across trees |

Where threads parallelise inside one build on shared data, an extra thread adds no copy of the working set. Where parallelism is across trees, each worker needs its own. (sklearn 1.6.1, xgboost 2.1.4, lightgbm 4.6.0.)

Both docstrings now state the memory/speed trade-off regardless of which way the default goes.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

Marked breaking because existing code changes behaviour without any edit — slower and much lighter. Fitted models and predictions are bit-identical; only memory and wall time move.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/uber/causalml/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/uber/causalml)
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules

## Verification

Full suite: **444 passed, 10 skipped, exit 0** (439 on master plus 5 new test instances). No new warning categories versus master, and zero arg-order `FutureWarning`s.

- `test_kernel_uplift_forest_predictions_independent_of_n_jobs` — predictions match a serial fit to 12 decimals at `n_jobs` of `None`, `1`, `2` and `-1`. This is what makes changing the default safe; without it the change would be altering users' numbers.
- `test_kernel_uplift_forest_n_jobs_defaults_to_serial` — pins the default on both classes, including the legacy-shaped subclass, which carried its own hardcoded `-1`.
- `docs/changelog.rst` entry under `Unreleased` → `Behavior Changes`, since this is invisible from the PR title.
- `black --check` clean.

## Further comments

**Release target is a decision for this PR.** #991 suggested the v1.0 line with #980 on the grounds that behaviour changes under an unchanged call signature are easier to justify at a major version. It is equally defensible in 0.18.0 given the changelog entry, since output is unchanged. Happy to hold it behind #985 if you prefer.

**Scope.** Only the uplift forest. `causalml/match.py`, `causalml/propensity.py` and `causalml/dataset/semiSynthetic.py` also default to `n_jobs=-1`, but those are different call sites with different parallelism models and memory profiles, and I did not measure them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
