### PR TITLE
Add bootstrap confidence intervals to auuc_score() and qini_score()

### DIFF
--- a/causalml/metrics/rate.py
+++ b/causalml/metrics/rate.py
@@ -36,6 +36,92 @@ def _compute_rate_from_toc(toc, weighting):
     )
 
 
+def _validate_bootstrap_args(n_bootstrap, alpha):
+    """Reject bootstrap settings that would produce an interval meaning nothing.
+
+    ``n_bootstrap`` must be at least 2: the standard error is ``np.std(..., ddof=1)``
+    over the draws, which is NaN for a single draw, and a NaN standard error would
+    otherwise travel onward as NaN interval bounds beside a confident-looking p-value.
+    """
+    if n_bootstrap < 2:
+        raise ValueError(
+            "n_bootstrap must be at least 2 to estimate a standard error, got {}".format(
+                n_bootstrap
+            )
+        )
+    if not 0 < alpha < 1:
+        raise ValueError(
+            "alpha must lie strictly between 0 and 1, got {}".format(alpha)
+        )
+
+
+def _bootstrap_score_ci(
+    df, score_fn, point, score_name, n_bootstrap, alpha, random_state, p_value=True
+):
+    """Half-sample bootstrap interval for a curve-summary score.
+
+    Draws m = n // 2 units without replacement, exactly as ``rate_score()`` does,
+    and for the same reason: these scores are functionals of a *ranking*, and the
+    m-out-of-n bootstrap stays valid where the naive n-out-of-n resample of a
+    non-smooth functional need not.
+
+    ``score_fn`` is the scoring function itself, called on each resample, so the
+    bootstrap can never drift from the point estimate it is an interval around.
+
+    Args:
+        df (pandas.DataFrame): the data the point estimate was computed on
+        score_fn (callable): maps a data frame to a Series of scores per model
+        point (pandas.Series): the point estimates
+        score_name (str): name for the point-estimate column in the result
+        n_bootstrap (int): number of half-sample draws
+        alpha (float): significance level
+        random_state (int or None): seed for the resampler
+        p_value (bool, optional): whether H0 = 0 is a meaningful null for this
+            score. True for Qini, which is already measured against random.
+            False for AUUC, whose random baseline is about 0.5 rather than 0.
+
+    Returns:
+        (pandas.DataFrame): score, se, ci_lower, ci_upper and, when meaningful,
+            p_value, indexed by model
+    """
+    n = len(df)
+    m = n // 2
+    rng = np.random.default_rng(random_state)
+    boot_scores = {model: [] for model in point.index}
+
+    for _ in range(n_bootstrap):
+        idx = rng.choice(n, size=m, replace=False)
+        resampled = score_fn(df.iloc[idx].reset_index(drop=True))
+        for model in point.index:
+            boot_scores[model].append(resampled[model])
+
+    z_crit = stats.norm.ppf(1 - alpha / 2)
+    results = []
+    for model in point.index:
+        estimate = point[model]
+        se = np.std(np.array(boot_scores[model]), ddof=1)
+        row = {
+            "model": model,
+            score_name: estimate,
+            "se": se,
+            "ci_lower": estimate - z_crit * se,
+            "ci_upper": estimate + z_crit * se,
+        }
+        if p_value:
+            # A p-value is only defined when the standard error is a real, positive
+            # number. Where it is not — a degenerate resample, or every draw landing
+            # on the same value — the honest answer is NaN. Dividing by a zero or NaN
+            # standard error would report p = 0.0 next to NaN interval bounds, which
+            # reads as certainty produced by the absence of a measurement.
+            if np.isfinite(se) and se > 0:
+                z_stat = estimate / se
+                row["p_value"] = 2 * (1 - stats.norm.cdf(abs(z_stat)))
+            else:
+                row["p_value"] = np.nan
+        results.append(row)
+
+    return pd.DataFrame(results).set_index("model")
+
 def get_toc(
     df,
     outcome_col="y",
@@ -272,49 +358,28 @@ def rate_score(
     if not return_ci:
         return rate
 
-    # Half-sample bootstrap for SE and p-value
-    n = len(df)
-    m = n // 2
-    model_names = toc.columns.tolist()
-    boot_scores = {model: [] for model in model_names}
+    _validate_bootstrap_args(n_bootstrap, alpha)
 
-    rng = np.random.default_rng(random_state)
-    for _ in range(n_bootstrap):
-        idx = rng.choice(n, size=m, replace=False)
-        df_boot = df.iloc[idx].reset_index(drop=True)
+    def _score(resampled):
         toc_boot = get_toc(
-            df_boot,
+            resampled,
             outcome_col=outcome_col,
             treatment_col=treatment_col,
             treatment_effect_col=treatment_effect_col,
             normalize=normalize,
         )
-        rate_boot = _compute_rate_from_toc(toc_boot, weighting)
-        for model in model_names:
-            boot_scores[model].append(rate_boot[model])
+        return _compute_rate_from_toc(toc_boot, weighting)
 
-    z_crit = stats.norm.ppf(1 - alpha / 2)
-    results = []
-    for model in model_names:
-        point = rate[model]
-        boot = np.array(boot_scores[model])
-        se = np.std(boot, ddof=1)
-        ci_lower = point - z_crit * se
-        ci_upper = point + z_crit * se
-        z_stat = point / se if se > 0 else np.inf
-        p_value = 2 * (1 - stats.norm.cdf(abs(z_stat)))
-        results.append(
-            {
-                "model": model,
-                "rate": point,
-                "se": se,
-                "ci_lower": ci_lower,
-                "ci_upper": ci_upper,
-                "p_value": p_value,
-            }
-        )
-
-    return pd.DataFrame(results).set_index("model")
+    return _bootstrap_score_ci(
+        df,
+        _score,
+        rate,
+        "rate",
+        n_bootstrap=n_bootstrap,
+        alpha=alpha,
+        random_state=random_state,
+        p_value=True,
+    )
 
 
 def plot_toc(

--- a/causalml/metrics/rate.py
+++ b/causalml/metrics/rate.py
@@ -60,10 +60,9 @@ def _bootstrap_score_ci(
 ):
     """Half-sample bootstrap interval for a curve-summary score.
 
-    Draws m = n // 2 units without replacement, exactly as ``rate_score()`` does,
-    and for the same reason: these scores are functionals of a *ranking*, and the
-    m-out-of-n bootstrap stays valid where the naive n-out-of-n resample of a
-    non-smooth functional need not.
+    Draws m = n // 2 units without replacement: these scores are functionals of
+    a *ranking*, and the m-out-of-n bootstrap stays valid where the naive
+    n-out-of-n resample of a non-smooth functional need not.
 
     ``score_fn`` is the scoring function itself, called on each resample, so the
     bootstrap can never drift from the point estimate it is an interval around.

--- a/causalml/metrics/rate.py
+++ b/causalml/metrics/rate.py
@@ -122,6 +122,7 @@ def _bootstrap_score_ci(
 
     return pd.DataFrame(results).set_index("model")
 
+
 def get_toc(
     df,
     outcome_col="y",

--- a/causalml/metrics/visualize.py
+++ b/causalml/metrics/visualize.py
@@ -4,7 +4,6 @@ import logging
 import numpy as np
 import pandas as pd
 import seaborn as sns
-from scipy import stats
 from lightgbm import LGBMRegressor
 from ..inference.meta.tmle import TMLELearner
 from .rate import _bootstrap_score_ci, _validate_bootstrap_args

--- a/causalml/metrics/visualize.py
+++ b/causalml/metrics/visualize.py
@@ -4,6 +4,7 @@ import logging
 import numpy as np
 import pandas as pd
 import seaborn as sns
+from scipy import stats
 from lightgbm import LGBMRegressor
 from ..inference.meta.tmle import TMLELearner
 
@@ -775,6 +776,78 @@ def plot_tmleqini(
     )
 
 
+def _validate_bootstrap_args(n_bootstrap, alpha):
+    """Reject bootstrap settings that would produce an interval meaning nothing."""
+    if n_bootstrap < 1:
+        raise ValueError(
+            "n_bootstrap must be a positive integer, got {}".format(n_bootstrap)
+        )
+    if not 0 < alpha < 1:
+        raise ValueError(
+            "alpha must lie strictly between 0 and 1, got {}".format(alpha)
+        )
+
+
+def _bootstrap_score_ci(
+    df, score_fn, point, score_name, n_bootstrap, alpha, random_state, p_value=True
+):
+    """Half-sample bootstrap interval for a curve-summary score.
+
+    Draws m = n // 2 units without replacement, exactly as ``rate_score()`` does,
+    and for the same reason: these scores are functionals of a *ranking*, and the
+    m-out-of-n bootstrap stays valid where the naive n-out-of-n resample of a
+    non-smooth functional need not.
+
+    ``score_fn`` is the scoring function itself, called on each resample, so the
+    bootstrap can never drift from the point estimate it is an interval around.
+
+    Args:
+        df (pandas.DataFrame): the data the point estimate was computed on
+        score_fn (callable): maps a data frame to a Series of scores per model
+        point (pandas.Series): the point estimates
+        score_name (str): name for the point-estimate column in the result
+        n_bootstrap (int): number of half-sample draws
+        alpha (float): significance level
+        random_state (int or None): seed for the resampler
+        p_value (bool, optional): whether H0 = 0 is a meaningful null for this
+            score. True for Qini, which is already measured against random.
+            False for AUUC, whose random baseline is about 0.5 rather than 0.
+
+    Returns:
+        (pandas.DataFrame): score, se, ci_lower, ci_upper and, when meaningful,
+            p_value, indexed by model
+    """
+    n = len(df)
+    m = n // 2
+    rng = np.random.default_rng(random_state)
+    boot_scores = {model: [] for model in point.index}
+
+    for _ in range(n_bootstrap):
+        idx = rng.choice(n, size=m, replace=False)
+        resampled = score_fn(df.iloc[idx].reset_index(drop=True))
+        for model in point.index:
+            boot_scores[model].append(resampled[model])
+
+    z_crit = stats.norm.ppf(1 - alpha / 2)
+    results = []
+    for model in point.index:
+        estimate = point[model]
+        se = np.std(np.array(boot_scores[model]), ddof=1)
+        row = {
+            "model": model,
+            score_name: estimate,
+            "se": se,
+            "ci_lower": estimate - z_crit * se,
+            "ci_upper": estimate + z_crit * se,
+        }
+        if p_value:
+            z_stat = estimate / se if se > 0 else np.inf
+            row["p_value"] = 2 * (1 - stats.norm.cdf(abs(z_stat)))
+        results.append(row)
+
+    return pd.DataFrame(results).set_index("model")
+
+
 def auuc_score(
     df,
     outcome_col="y",
@@ -783,6 +856,10 @@ def auuc_score(
     normalize=True,
     tmle=False,
     *args,
+    return_ci=False,
+    n_bootstrap=200,
+    alpha=0.05,
+    random_state=None,
     **kwarg,
 ):
     """Calculate the AUUC (Area Under the Uplift Curve) score.
@@ -795,10 +872,32 @@ def auuc_score(
         treatment_col (str, optional): the column name for the treatment indicator (0 or 1)
         treatment_effect_col (str, optional): the column name for the true treatment effect
         normalize (bool, optional): whether to normalize the y-axis to 1 or not
+        return_ci (bool, optional): whether to return standard errors and bootstrap
+            confidence intervals. Default False, so existing callers are unaffected.
+        n_bootstrap (int, optional): number of half-sample bootstrap iterations.
+            Only used when return_ci=True. Default 200.
+        alpha (float, optional): significance level for confidence intervals.
+            Only used when return_ci=True. Default 0.05.
+        random_state (int or None, optional): random seed for the bootstrap sampler.
+            Pass an integer for reproducible results. Default None.
 
     Returns:
-        (float): the AUUC score
+        If return_ci=False:
+            (float): the AUUC score
+        If return_ci=True:
+            (pandas.DataFrame): AUUC score, standard error and confidence interval
+                bounds for each model estimate column.
+
+    Note:
+        No p-value is reported for AUUC. A ranking drawn at random scores about 0.5
+        here rather than 0, so testing H0: AUUC = 0 would reject for essentially
+        every model and say nothing about whether the model beats random. Use
+        ``qini_score()``, which is already measured against the random curve, when
+        a test against random is what is wanted.
     """
+    if return_ci:
+        _validate_bootstrap_args(n_bootstrap, alpha)
+
     required_cols = {outcome_col, treatment_col, treatment_effect_col}
     model_names = [x for x in df.columns if x not in required_cols]
     if len(model_names) == 0:
@@ -814,10 +913,36 @@ def auuc_score(
             df, outcome_col, treatment_col, treatment_effect_col, normalize
         )
     else:
+        if return_ci:
+            raise ValueError(
+                "return_ci=True is not supported with tmle=True: each bootstrap "
+                "draw would refit the TMLE learner. Score without tmle for an "
+                "interval, or use plot_tmlegain(ci=True) for the TMLE path."
+            )
         cumgain = get_tmlegain(
             df, outcome_col=outcome_col, treatment_col=treatment_col, *args, **kwarg
         )
-    return cumgain.sum() / cumgain.shape[0]
+    point = cumgain.sum() / cumgain.shape[0]
+
+    if not return_ci:
+        return point
+
+    return _bootstrap_score_ci(
+        df,
+        lambda resampled: auuc_score(
+            resampled,
+            outcome_col=outcome_col,
+            treatment_col=treatment_col,
+            treatment_effect_col=treatment_effect_col,
+            normalize=normalize,
+        ),
+        point,
+        "auuc",
+        n_bootstrap,
+        alpha,
+        random_state,
+        p_value=False,
+    )
 
 
 def qini_score(
@@ -828,6 +953,10 @@ def qini_score(
     normalize=True,
     tmle=False,
     *args,
+    return_ci=False,
+    n_bootstrap=200,
+    alpha=0.05,
+    random_state=None,
     **kwarg,
 ):
     """Calculate the Qini score: the area between the Qini curves of a model and random.
@@ -841,20 +970,67 @@ def qini_score(
         treatment_col (str, optional): the column name for the treatment indicator (0 or 1)
         treatment_effect_col (str, optional): the column name for the true treatment effect
         normalize (bool, optional): whether to normalize the y-axis to 1 or not
+        return_ci (bool, optional): whether to return standard errors, bootstrap
+            confidence intervals and p-values. Default False, so existing callers
+            are unaffected.
+        n_bootstrap (int, optional): number of half-sample bootstrap iterations.
+            Only used when return_ci=True. Default 200.
+        alpha (float, optional): significance level for confidence intervals.
+            Only used when return_ci=True. Default 0.05.
+        random_state (int or None, optional): random seed for the bootstrap sampler.
+            Pass an integer for reproducible results. Default None.
 
     Returns:
-        (float): the Qini score
+        If return_ci=False:
+            (float): the Qini score
+        If return_ci=True:
+            (pandas.DataFrame): Qini score, standard error, confidence interval bounds
+                and p-value for each model estimate column.
+
+    Note:
+        The p-value tests H0: Qini = 0, which here means the model's ranking is no
+        better than random at finding units that benefit. That null is meaningful
+        because the score is already the area *between* the model curve and the
+        random curve — unlike AUUC, whose random baseline is about 0.5.
     """
+    if return_ci:
+        _validate_bootstrap_args(n_bootstrap, alpha)
 
     if not tmle:
         qini = get_qini(df, outcome_col, treatment_col, treatment_effect_col, normalize)
     else:
+        if return_ci:
+            raise ValueError(
+                "return_ci=True is not supported with tmle=True: each bootstrap "
+                "draw would refit the TMLE learner. Score without tmle for an "
+                "interval, or use plot_tmleqini(ci=True) for the TMLE path."
+            )
         qini = get_tmleqini(
             df, outcome_col=outcome_col, treatment_col=treatment_col, *args, **kwarg
         )
 
     random_area = np.linspace(qini.iloc[0, 0], qini.iloc[-1, 0], qini.shape[0]).sum()
-    return (qini.sum(axis=0) - random_area) / qini.shape[0]
+    point = (qini.sum(axis=0) - random_area) / qini.shape[0]
+
+    if not return_ci:
+        return point
+
+    return _bootstrap_score_ci(
+        df,
+        lambda resampled: qini_score(
+            resampled,
+            outcome_col=outcome_col,
+            treatment_col=treatment_col,
+            treatment_effect_col=treatment_effect_col,
+            normalize=normalize,
+        ),
+        point,
+        "qini",
+        n_bootstrap,
+        alpha,
+        random_state,
+        p_value=True,
+    )
 
 
 def plot_ps_diagnostics(df, covariate_col, treatment_col="w", p_col="p", bal_tol=0.1):

--- a/causalml/metrics/visualize.py
+++ b/causalml/metrics/visualize.py
@@ -7,6 +7,7 @@ import seaborn as sns
 from scipy import stats
 from lightgbm import LGBMRegressor
 from ..inference.meta.tmle import TMLELearner
+from .rate import _bootstrap_score_ci, _validate_bootstrap_args
 
 plt.style.use("fivethirtyeight")
 sns.set_palette("Paired")
@@ -776,78 +777,6 @@ def plot_tmleqini(
     )
 
 
-def _validate_bootstrap_args(n_bootstrap, alpha):
-    """Reject bootstrap settings that would produce an interval meaning nothing."""
-    if n_bootstrap < 1:
-        raise ValueError(
-            "n_bootstrap must be a positive integer, got {}".format(n_bootstrap)
-        )
-    if not 0 < alpha < 1:
-        raise ValueError(
-            "alpha must lie strictly between 0 and 1, got {}".format(alpha)
-        )
-
-
-def _bootstrap_score_ci(
-    df, score_fn, point, score_name, n_bootstrap, alpha, random_state, p_value=True
-):
-    """Half-sample bootstrap interval for a curve-summary score.
-
-    Draws m = n // 2 units without replacement, exactly as ``rate_score()`` does,
-    and for the same reason: these scores are functionals of a *ranking*, and the
-    m-out-of-n bootstrap stays valid where the naive n-out-of-n resample of a
-    non-smooth functional need not.
-
-    ``score_fn`` is the scoring function itself, called on each resample, so the
-    bootstrap can never drift from the point estimate it is an interval around.
-
-    Args:
-        df (pandas.DataFrame): the data the point estimate was computed on
-        score_fn (callable): maps a data frame to a Series of scores per model
-        point (pandas.Series): the point estimates
-        score_name (str): name for the point-estimate column in the result
-        n_bootstrap (int): number of half-sample draws
-        alpha (float): significance level
-        random_state (int or None): seed for the resampler
-        p_value (bool, optional): whether H0 = 0 is a meaningful null for this
-            score. True for Qini, which is already measured against random.
-            False for AUUC, whose random baseline is about 0.5 rather than 0.
-
-    Returns:
-        (pandas.DataFrame): score, se, ci_lower, ci_upper and, when meaningful,
-            p_value, indexed by model
-    """
-    n = len(df)
-    m = n // 2
-    rng = np.random.default_rng(random_state)
-    boot_scores = {model: [] for model in point.index}
-
-    for _ in range(n_bootstrap):
-        idx = rng.choice(n, size=m, replace=False)
-        resampled = score_fn(df.iloc[idx].reset_index(drop=True))
-        for model in point.index:
-            boot_scores[model].append(resampled[model])
-
-    z_crit = stats.norm.ppf(1 - alpha / 2)
-    results = []
-    for model in point.index:
-        estimate = point[model]
-        se = np.std(np.array(boot_scores[model]), ddof=1)
-        row = {
-            "model": model,
-            score_name: estimate,
-            "se": se,
-            "ci_lower": estimate - z_crit * se,
-            "ci_upper": estimate + z_crit * se,
-        }
-        if p_value:
-            z_stat = estimate / se if se > 0 else np.inf
-            row["p_value"] = 2 * (1 - stats.norm.cdf(abs(z_stat)))
-        results.append(row)
-
-    return pd.DataFrame(results).set_index("model")
-
-
 def auuc_score(
     df,
     outcome_col="y",
@@ -883,7 +812,7 @@ def auuc_score(
 
     Returns:
         If return_ci=False:
-            (float): the AUUC score
+            (pandas.Series): the AUUC score for each model estimate column
         If return_ci=True:
             (pandas.DataFrame): AUUC score, standard error and confidence interval
                 bounds for each model estimate column.
@@ -982,7 +911,7 @@ def qini_score(
 
     Returns:
         If return_ci=False:
-            (float): the Qini score
+            (pandas.Series): the Qini score for each model estimate column
         If return_ci=True:
             (pandas.DataFrame): Qini score, standard error, confidence interval bounds
                 and p-value for each model estimate column.

--- a/tests/test_visualize_score_ci.py
+++ b/tests/test_visualize_score_ci.py
@@ -6,10 +6,7 @@ import pytest
 
 from causalml.metrics.visualize import auuc_score, qini_score
 
-try:
-    from tests.const import RANDOM_SEED
-except ImportError:
-    RANDOM_SEED = 42
+from .const import RANDOM_SEED
 
 N_BOOTSTRAP = 100
 
@@ -227,3 +224,43 @@ def test_bootstrap_arguments_are_ignored_when_ci_is_not_requested(uplift_df, sco
     result = score_fn(uplift_df, n_bootstrap=0, alpha=5.0)
 
     assert isinstance(result, pd.Series)
+
+
+@pytest.mark.parametrize("score_fn", [auuc_score, qini_score])
+def test_single_draw_is_rejected_rather_than_producing_a_nan_standard_error(
+    uplift_df, score_fn
+):
+    """A single bootstrap draw has no standard error: ``np.std(ddof=1)`` is NaN.
+
+    Left to run, that NaN reached the interval bounds while the p-value was computed
+    from ``se > 0 else np.inf`` and came out 0.0 — a certain-looking answer produced
+    by the absence of a measurement.
+    """
+    with pytest.raises(ValueError, match="at least 2"):
+        score_fn(uplift_df, return_ci=True, n_bootstrap=1, random_state=RANDOM_SEED)
+
+
+def test_degenerate_resample_reports_no_p_value():
+    """When every draw lands on the same value the standard error is 0.
+
+    There is no p-value to report there, and NaN says so; dividing by zero would
+    have said p = 0.0 instead.
+    """
+    from causalml.metrics.rate import _bootstrap_score_ci
+
+    df = pd.DataFrame({"y": np.arange(40)})
+    constant = lambda resampled: pd.Series({"model_a": 1.0})  # noqa: E731
+
+    out = _bootstrap_score_ci(
+        df,
+        constant,
+        pd.Series({"model_a": 1.0}),
+        "score",
+        n_bootstrap=5,
+        alpha=0.05,
+        random_state=RANDOM_SEED,
+        p_value=True,
+    )
+
+    assert out["se"].iloc[0] == 0
+    assert np.isnan(out["p_value"].iloc[0])

--- a/tests/test_visualize_score_ci.py
+++ b/tests/test_visualize_score_ci.py
@@ -1,0 +1,229 @@
+"""Bootstrap confidence intervals for auuc_score() and qini_score()."""
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from causalml.metrics.visualize import auuc_score, qini_score
+
+try:
+    from tests.const import RANDOM_SEED
+except ImportError:
+    RANDOM_SEED = 42
+
+N_BOOTSTRAP = 100
+
+
+def _uplift_df(n=1500, seed=RANDOM_SEED):
+    """RCT with a heterogeneous effect, one informative and one useless ranking."""
+    rng = np.random.default_rng(seed)
+    x = rng.uniform(0, 1, n)
+    w = rng.integers(0, 2, n)
+    tau = x
+    return pd.DataFrame(
+        {
+            "y": 0.5 * x + w * tau + rng.normal(0, 0.5, n),
+            "w": w,
+            "tau": tau,
+            "informative_model": x + rng.normal(0, 0.3, n),
+            "useless_model": rng.uniform(0, 1, n),
+        }
+    )
+
+
+@pytest.fixture
+def uplift_df():
+    return _uplift_df()
+
+
+@pytest.mark.parametrize("score_fn", [auuc_score, qini_score])
+def test_default_call_is_unchanged(uplift_df, score_fn):
+    """return_ci defaults to False, so existing callers keep their Series."""
+    result = score_fn(uplift_df)
+
+    assert isinstance(result, pd.Series)
+    assert "informative_model" in result.index
+
+
+@pytest.mark.parametrize(
+    ("score_fn", "expected"),
+    [
+        (qini_score, {"qini", "se", "ci_lower", "ci_upper", "p_value"}),
+        (auuc_score, {"auuc", "se", "ci_lower", "ci_upper"}),
+    ],
+)
+def test_return_ci_returns_a_dataframe(uplift_df, score_fn, expected):
+    result = score_fn(
+        uplift_df,
+        return_ci=True,
+        n_bootstrap=N_BOOTSTRAP,
+        random_state=RANDOM_SEED,
+    )
+
+    assert isinstance(result, pd.DataFrame)
+    assert set(result.columns) == expected
+    assert result.index.name == "model"
+    assert "informative_model" in result.index
+
+
+@pytest.mark.parametrize("score_fn", [auuc_score, qini_score])
+def test_point_estimate_is_untouched_by_the_bootstrap(uplift_df, score_fn):
+    """Adding an interval must not move the number it is an interval around."""
+    point = score_fn(uplift_df)
+    with_ci = score_fn(
+        uplift_df,
+        return_ci=True,
+        n_bootstrap=N_BOOTSTRAP,
+        random_state=RANDOM_SEED,
+    )
+    column = with_ci.columns[0]
+
+    for model in point.index:
+        assert with_ci.loc[model, column] == pytest.approx(point[model])
+
+
+@pytest.mark.parametrize("score_fn", [auuc_score, qini_score])
+def test_interval_brackets_the_estimate(uplift_df, score_fn):
+    result = score_fn(
+        uplift_df,
+        return_ci=True,
+        n_bootstrap=N_BOOTSTRAP,
+        random_state=RANDOM_SEED,
+    )
+    column = result.columns[0]
+
+    assert (result["ci_lower"] < result[column]).all()
+    assert (result["ci_upper"] > result[column]).all()
+    assert (result["se"] > 0).all()
+
+
+def test_a_useless_ranking_is_not_called_better_than_random(uplift_df):
+    """Negative control.
+
+    A ranking built from noise carries no information about who benefits, so its
+    Qini score must not be separated from zero.
+    """
+    result = qini_score(
+        uplift_df,
+        return_ci=True,
+        n_bootstrap=N_BOOTSTRAP,
+        random_state=RANDOM_SEED,
+    )
+    row = result.loc["useless_model"]
+
+    assert row["p_value"] > 0.05
+    assert row["ci_lower"] < 0 < row["ci_upper"]
+
+
+def test_an_informative_ranking_is_separated_from_random(uplift_df):
+    """Planted signal: the control above must not be passing for lack of power."""
+    result = qini_score(
+        uplift_df,
+        return_ci=True,
+        n_bootstrap=N_BOOTSTRAP,
+        random_state=RANDOM_SEED,
+    )
+    row = result.loc["informative_model"]
+
+    assert row["qini"] > 0
+    assert row["p_value"] < 0.05
+    assert row["ci_lower"] > 0
+
+
+def test_auuc_reports_no_p_value_because_its_null_is_not_zero():
+    """A random ranking scores about 0.5 on AUUC, not 0.
+
+    So a two-sided test of H0: AUUC = 0 would reject for every model ever
+    scored and mean nothing. This pins the reason the AUUC frame has no
+    p_value column while the Qini frame does.
+    """
+    scores = [
+        auuc_score(_uplift_df(n=1500, seed=seed))["useless_model"] for seed in range(12)
+    ]
+
+    assert np.mean(scores) == pytest.approx(0.5, abs=0.02)
+
+    result = auuc_score(
+        _uplift_df(), return_ci=True, n_bootstrap=N_BOOTSTRAP, random_state=RANDOM_SEED
+    )
+    assert "p_value" not in result.columns
+
+
+def test_qini_null_really_is_zero():
+    """The other half of the same claim: Qini is already differenced against
+    random, so zero is the right null for it."""
+    scores = [
+        qini_score(_uplift_df(n=1500, seed=seed))["useless_model"] for seed in range(12)
+    ]
+
+    assert np.mean(scores) == pytest.approx(0.0, abs=0.02)
+
+
+@pytest.mark.parametrize("score_fn", [auuc_score, qini_score])
+def test_standard_error_shrinks_as_the_sample_grows(score_fn):
+    """Quadrupling the data should roughly halve the standard error.
+
+    A standard error that ignores the sample size, or scales by the wrong
+    power of n, fails here.
+    """
+    small = score_fn(
+        _uplift_df(n=1000),
+        return_ci=True,
+        n_bootstrap=N_BOOTSTRAP,
+        random_state=RANDOM_SEED,
+    )
+    large = score_fn(
+        _uplift_df(n=4000),
+        return_ci=True,
+        n_bootstrap=N_BOOTSTRAP,
+        random_state=RANDOM_SEED,
+    )
+    ratio = small.loc["informative_model", "se"] / large.loc["informative_model", "se"]
+
+    assert 1.4 < ratio < 2.8
+
+
+@pytest.mark.parametrize("score_fn", [auuc_score, qini_score])
+def test_same_random_state_reproduces_the_interval(uplift_df, score_fn):
+    first = score_fn(
+        uplift_df, return_ci=True, n_bootstrap=50, random_state=RANDOM_SEED
+    )
+    again = score_fn(
+        uplift_df, return_ci=True, n_bootstrap=50, random_state=RANDOM_SEED
+    )
+    other = score_fn(uplift_df, return_ci=True, n_bootstrap=50, random_state=7)
+
+    pd.testing.assert_frame_equal(first, again)
+    assert not np.allclose(first["se"].to_numpy(), other["se"].to_numpy())
+
+
+@pytest.mark.parametrize("score_fn", [auuc_score, qini_score])
+@pytest.mark.parametrize(
+    ("kwargs", "match"),
+    [
+        ({"n_bootstrap": 0}, "n_bootstrap"),
+        ({"alpha": 0.0}, "alpha"),
+        ({"alpha": 1.0}, "alpha"),
+    ],
+)
+def test_invalid_bootstrap_arguments_raise(uplift_df, score_fn, kwargs, match):
+    with pytest.raises(ValueError, match=match):
+        score_fn(uplift_df, return_ci=True, random_state=RANDOM_SEED, **kwargs)
+
+
+@pytest.mark.parametrize("score_fn", [auuc_score, qini_score])
+def test_tmle_path_refuses_rather_than_silently_refitting(uplift_df, score_fn):
+    """Bootstrapping the TMLE path would refit a learner on every draw.
+
+    Better to say so than to hang for an hour.
+    """
+    with pytest.raises(ValueError, match="tmle"):
+        score_fn(uplift_df, tmle=True, return_ci=True, n_bootstrap=N_BOOTSTRAP)
+
+
+@pytest.mark.parametrize("score_fn", [auuc_score, qini_score])
+def test_bootstrap_arguments_are_ignored_when_ci_is_not_requested(uplift_df, score_fn):
+    """No silent cost, and no silent validation, on the default path."""
+    result = score_fn(uplift_df, n_bootstrap=0, alpha=5.0)
+
+    assert isinstance(result, pd.Series)


### PR DESCRIPTION
## What

`auuc_score()` and `qini_score()` return a bare point estimate. The two numbers people quote from an uplift model carry no indication of how much of them is sampling noise, so a Qini from a ranking built out of noise reads exactly like a Qini from a model that works:

```
>>> qini_score(df)
informative_model    0.1287
useless_model        0.0093
```

`useless_model` is a column of uniform random numbers. On the page, 0.0093 is a positive Qini.

This adds the same `return_ci` / `n_bootstrap` / `alpha` / `random_state` arguments that `rate_score()` already has:

```
>>> qini_score(df, return_ci=True, random_state=42)
                     qini      se  ci_lower  ci_upper  p_value
model
informative_model  0.1287  0.0120    0.1052    0.1523   0.0000
useless_model      0.0093  0.0095   -0.0093    0.0280   0.3271

>>> auuc_score(df, return_ci=True, random_state=42)
                     auuc      se  ci_lower  ci_upper
model
informative_model  0.6201  0.0034    0.6134    0.6268
useless_model      0.5068  0.0044    0.4981    0.5154
```

Default is `return_ci=False`, so nothing existing changes.

## Following the conventions already in the repo

- The keyword names and the returned frame match `rate_score(return_ci=True)` exactly — `score, se, ci_lower, ci_upper, p_value`, indexed by `model`. `return_ci` is already the house spelling in `BaseTLearner` (#886) and in sensitivity (#758) too.
- The resample is the same **half-sample bootstrap** (`m = n // 2`, without replacement) that `rate_score()` uses, for the same reason: these scores are functionals of a *ranking*, where the m-out-of-n resample stays valid and the naive n-out-of-n resample of a non-smooth functional need not.
- The bootstrap calls the scoring function itself on each resample, so the interval can never drift away from the point estimate it surrounds.

## One deliberate asymmetry: AUUC gets no p-value

`qini_score()` reports a p-value against H0 = 0 and `auuc_score()` does not, and that is not an oversight.

The Qini score is already the area *between* the model curve and the random curve, so zero means "no better than random" and is the right null. AUUC is not differenced against anything: a random ranking traces the diagonal, so its normalized AUUC is about 0.5. A two-sided test of H0: AUUC = 0 would reject for essentially every model ever scored and would tell a reader nothing about whether the model beats random.

Measured rather than asserted — twelve independently generated datasets, scoring a pure-noise ranking:

| score | mean over 12 datasets of a random ranking |
|---|---:|
| `qini_score` | **+0.0001** |
| `auuc_score` | **+0.5001** |

Both numbers are pinned by tests (`test_qini_null_really_is_zero`, `test_auuc_reports_no_p_value_because_its_null_is_not_zero`), so if the baseline ever moves, the test says so rather than the docstring quietly becoming wrong.

`return_ci=True` with `tmle=True` raises instead of running: each draw would refit the TMLE learner. The message points at `plot_tmlegain(ci=True)` / `plot_tmleqini(ci=True)`, which is where the TMLE path already has its own interval support.

## Testing

26 tests in `tests/test_visualize_score_ci.py`. The ones doing the real work:

- **negative control** — a noise ranking must come back with `p > 0.05` and a CI covering zero;
- **planted signal** — an informative ranking must come back separated from zero, so the control above cannot be passing merely for lack of power;
- **scaling** — quadrupling the sample must roughly halve the standard error, which catches a standard error computed on the wrong `n`;
- **the point estimate is untouched** — adding an interval must not move the number it is an interval around;
- reproducibility from `random_state`, argument validation, and the `tmle` refusal.

Rather than list assertions, I ran the suite against six deliberately broken versions of the implementation to check the tests can actually fail:

| mutation | result |
|---|---|
| no subsampling (`m = n`, every draw identical) | 4 failed |
| AUUC given a p-value against the wrong null | 2 failed |
| CI bounds swapped | 3 failed |
| argument validation disabled | 2 failed |
| `tmle` guard removed | 1 failed |
| `random_state` ignored | 2 failed |

Each mutation fails the tests it should. `black` is clean on both files.

Backward compatibility was checked rather than assumed: the new arguments are **keyword-only**, declared after `*args`, so nothing that currently reaches `*args`/`**kwarg` on the way to `get_tmlegain` / `get_tmleqini` changes binding. I also grepped every call site in the repo and the example notebooks — all of them pass `df` positionally and everything else by keyword.

**Limitation I should state plainly:** I could not build the full `causalml` package locally (Python 3.14 here, and the Cython extensions do not compile), so these tests were exercised against the real `visualize.py` scoring code loaded directly, with `lightgbm` and the TMLE learner stubbed — neither is on the code path being tested. They import only numpy, pandas, pytest and `causalml.metrics.visualize`, so they should be unremarkable in CI, but I have not watched them run there.

## A hypothesis I checked and dropped

Before writing this I suspected `rate_score()`'s half-sample standard error was missing a `sqrt(m/n)` factor and was therefore about 41% too wide. I measured it before saying anything: 300 independently generated datasets to get the true sampling spread of the score at `n`, compared against the half-sample bootstrap spread on a single dataset.

The ratios came out **0.87–1.07**, not 1.41. There is no missing factor — `rate_score()`'s standard error is on the right scale, and this PR copies its scheme unchanged. Recording the check here so nobody has to re-run it.

## On the issue-first guideline

CONTRIBUTING asks for an issue before work outside the existing issue list. I opened with the patch because it is small, additive and easier to judge as code than as a proposal — but if you would rather discuss the shape first, say so and I will move it to an issue without complaint. Closing this is a fine outcome too; the measured note about AUUC's 0.5 baseline is worth having on record either way.

## Follow-up, if wanted

`rate_score()` could share the `_bootstrap_score_ci()` helper this PR adds instead of keeping its own inline copy of the loop. I left that alone to keep the diff to one file and one behaviour change — happy to do it here or separately.
