### PR TITLE
Record the load_data return-type change in the changelog

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -24,6 +24,18 @@ Behavior Changes
   This matches ``CausalRandomForestRegressor`` and scikit-learn's forests, which use the same
   across-trees parallelism and default to serial.
 
+* **`causalml.features.load_data` now returns** ``numpy.ndarray`` **instead of**
+  ``numpy.matrix`` **(#978).** This was the only function in the package that returned a
+  ``numpy.matrix``. Code that relied on matrix semantics — ``*`` as matrix multiplication,
+  or an always-2-D result from indexing — needs ``np.asmatrix()`` around the call or,
+  preferably, the equivalent ``ndarray`` operation. ``numpy.matrix`` carries a
+  ``PendingDeprecationWarning`` upstream.
+
+  The same change fixes an ``AssertionError`` raised whenever the one-hot encoder produced
+  no columns: with an all-numeric feature list, a constant categorical column, or a
+  high-cardinality column whose levels all fall below ``min_obs``. All three now return a
+  feature matrix instead of raising (#978, #979).
+
 Deprecations
 ~~~~~~~~~~~~
 * **Positional** ``treatment`` **and** ``y`` **are deprecated (#854).** In v1.0 every


### PR DESCRIPTION
## Proposed changes

Adds a `Behavior Changes` entry under `Unreleased` in `docs/changelog.rst` for the `causalml.features.load_data` return-type change.

#978 changed the return from `numpy.matrix` to `numpy.ndarray`, and #979 completed the fix so a `None` encoder result is handled under `python -O`. Neither PR title names the return type, and release sections are written from the PR list at release time, so the change would not have appeared in the 0.18.0 notes.

The entry goes under `Behavior Changes` rather than `Bug Fixes` because `load_data` was the only function in the package that returned a `numpy.matrix`. A caller relying on matrix semantics — `*` as matrix multiplication, or an always-2-D result from indexing — gets different behavior with no error raised. `numpy.matrix` also carries a `PendingDeprecationWarning` upstream, so the entry points callers at the `ndarray` equivalent rather than at `np.asmatrix()`.

It also records the three inputs that previously raised `AssertionError` and now return a feature matrix: an all-numeric feature list, a constant categorical column, and a high-cardinality column whose levels all fall below `min_obs`.

Documentation for #978 and #979.

## Types of changes

What types of changes does your code introduce to **CausalML**?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/uber/causalml/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/uber/causalml)
- [x] Lint and unit tests pass locally with my changes — all 18 checks green on this branch (`lint`, `build` 3.11/3.12, the TF/torch/JAX lanes, Read the Docs)
- [ ] I have added tests that prove my fix is effective or that my feature works — n/a, no code path changes
- [x] I have added necessary documentation (if appropriate) — this change is the documentation
- [x] Any dependent changes have been merged and published in downstream modules — #978 (`b3bd7e0`) and #979 (`08a035b`) are on master

## Further comments

Verification of the claims in the entry:

- Return type confirmed against `causalml/features.py` on master and against the diff in `b3bd7e0`: `X (numpy.matrix)` → `X (numpy.ndarray)` in the docstring, with `.toarray()` added on the encoder result.
- `docs/changelog.rst` parses under docutils with no new messages. The only errors reported are the pre-existing Sphinx-only `:ref:` and `:cite:` roles, which bare docutils does not know.
- Inline markup follows the alternating bold/literal style of the neighbouring entries. RST does not allow nested inline markup, so a literal cannot sit inside a bold run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
