### PR TITLE
Fail the suite on causalml's own arg-order FutureWarning (#995)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,6 +76,18 @@ requires = [
 [project.urls]
 homepage = "https://github.com/uber/causalml"
 
+[tool.pytest.ini_options]
+filterwarnings = [
+    # CausalML's own #854 argument-order deprecation must never fire during the
+    # suite: it means the library called a shimmed method positionally, and a
+    # user calling the API correctly would see the warning with nothing to fix.
+    # Scoped to this one message rather than all FutureWarnings, so a warning
+    # from numpy, pandas or scikit-learn cannot fail the build on a dependency
+    # release. Tests that assert the warning use `pytest.warns`, which is
+    # unaffected.
+    'error:Passing .treatment. and/or .y. to \w+\(\) by position is deprecated:FutureWarning',
+]
+
 [tool.cibuildwheel]
 build = ["cp311-*", "cp312-*"]
 build-verbosity = 1

--- a/tests/test_fit_arg_order.py
+++ b/tests/test_fit_arg_order.py
@@ -535,3 +535,24 @@ def test_timeit_preserves_signature():
     assert CausalTreeRegressor.bootstrap_pool.__name__ == "bootstrap_pool"
     params = _positional_params(CausalTreeRegressor.bootstrap_pool.__wrapped__)
     assert params[:3] == ["X", "treatment", "y"]
+
+
+def test_arg_order_warning_is_an_error_under_the_repo_pytest_config():
+    """The suite must fail, not merely print, when the shim warns.
+
+    ``filterwarnings`` in ``pyproject.toml`` selects this warning by message, so
+    editing the text in ``_arg_order.py`` would stop it matching and the guard
+    would go quiet while CI stayed green. Both internal-positional-call
+    regressions (#988, #989) were found only by running the suite by hand with
+    ``-W error::FutureWarning``; this test fails if that lane is ever removed or
+    stops matching (#995).
+
+    The warning is raised before the wrapped method runs, so these arrays are
+    never actually fitted.
+    """
+    X = np.zeros((4, 2))
+    treatment = np.array([0, 1, 0, 1])
+    y = np.zeros(4)
+
+    with pytest.raises(FutureWarning, match="argument order"):
+        BaseSRegressor(learner=LinearRegression()).fit(X, treatment, y)


### PR DESCRIPTION
## Proposed changes

Closes #995.

The suite has no warnings-as-errors lane. There is no `filterwarnings` setting in `pyproject.toml`, `setup.cfg`, `tests/conftest.py` or any workflow, so a `FutureWarning` raised during a test run is printed and the run stays green.

That matters for the #854 shim specifically. It ships in 0.18.0 and stays live through 0.19.0 and 0.20.0 before the flip in v1.0 — about nine months. Both internal-positional-call defects so far (#988, #989) were found by running the suite by hand with `-W error::FutureWarning`, and each was then pinned by a bespoke "does not warn" test written after the fact. Coverage is therefore by enumeration: it protects the three paths someone thought to protect.

This adds a `[tool.pytest.ini_options]` section with one filter, so every test in the suite becomes a detector instead:

```toml
filterwarnings = [
    'error:Passing .treatment. and/or .y. to \w+\(\) by position is deprecated:FutureWarning',
]
```

**Scoped to this one message, not to `FutureWarning` generally.** A blanket `error::FutureWarning` would also promote warnings from numpy, pandas and scikit-learn, and the build would go red on a dependency release that has nothing to do with this repo.

No workflow change is needed — every lane runs plain `pytest` with no `-c` override, so the ini filter applies to the source builds and the optional TF/torch/JAX lanes alike. `pytest.warns` installs its own filter, so the tests that assert the warning are unaffected.

## Types of changes

What types of changes does your code introduce to **CausalML**?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

Test/CI only — no library code changes.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/uber/causalml/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/uber/causalml)
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate) — the filter carries a comment explaining the scoping
- [x] Any dependent changes have been merged and published in downstream modules — #988 and #989 are on master

## Further comments

### What this catches that the current tests do not

Injected a positional `self.get_prediction(X, p, treatment, y)` into `SensitivitySelectionBias.causalsens` — the same defect class as #989, on a path none of the three bespoke tests assert on — and ran `tests/test_sensitivity.py` both ways:

| config | result |
|---|---|
| master today (`-c /dev/null`) | **20 passed, exit 0** — warning printed, defect invisible |
| this PR | **7 failed, 13 passed, exit 1** — incl. `test_SensitivitySelectionBias` |

`test_SensitivitySelectionBias` and `test_SensitivitySelectionBias_summary_ate` already execute that line; they simply had no reason to assert on warnings. The filter turns them into regression tests for free.

### The test

`test_arg_order_warning_is_an_error_under_the_repo_pytest_config` asserts a positional call raises under the repo's own config. The filter matches by message, so editing the warning text in `_arg_order.py` would silently stop it matching while CI stayed green — the failure mode this issue exists to prevent. Mutation-checked: with the `filterwarnings` entry removed, the test fails with `DID NOT RAISE <class 'FutureWarning'>`.

### Verification

- Full suite: 445 passed, 10 skipped, exit 0 in 11:06, with zero arg-order warnings emitted (status read directly from `$?`, not through a pipe). 445 is the previous 444 plus the one test added here.
- `tests/test_fit_arg_order.py`: 58 → 59 tests, all passing.
- Reverting #988's fix at `causalforest.py:136` turns the suite red, which is the acceptance criterion on #995. Worth noting that `test_causal_forest_keyword_fit_does_not_warn` already catches that one on its own — the filter's contribution is the untested paths above, not the three already pinned.
- `black --check` clean.

### Not included

The issue also floated a separate CI job as an alternative. A single ini entry covers local runs and every CI lane at once, so a second job would add surface without adding coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
