### PR TITLE
Document DragonNet and CEVAE in the Methodology section (#417)

### DIFF
--- a/docs/methodology.rst
+++ b/docs/methodology.rst
@@ -28,8 +28,8 @@ CausalML currently supports the following methods:
     - :ref:`2-Stage Least Squares (2SLS)`
     - :ref:`Doubly Robust Instrumental Variable (DRIV) learner`
 - Neural network based algorithms
-    - CEVAE
-    - DragonNet
+    - :ref:`CEVAE`
+    - :ref:`DragonNet`
 - Treatment optimization algorithms
     - :ref:`Counterfactual Unit Selection`
     - :ref:`Counterfactual Value Estimator`
@@ -370,6 +370,102 @@ The final Uplift Tree algorithm that is implemented is the Contextual Treatment 
 
 where :math:`\phi_l` and :math:`\phi_r` refer to the feature subspaces in the left leaf and the right leaves respectively, :math:`\hat{p}(\phi_j \mid \phi)` denotes the estimated conditional probability of a subject's being in :math:`\phi_j` given :math:`\phi`, and :math:`\hat{y}_t(\phi_j)` is the conditional expected response under treatment :math:`t`.
 
+
+Neural Network Algorithms
+-------------------------
+
+Both methods below are optional backends. Install them with the ``tf``, ``torch``
+or ``jax`` extras, e.g. ``pip install causalml[tf]``.
+
+CEVAE
+~~~~~
+
+The Causal Effect Variational Autoencoder (CEVAE) :cite:`louizos2017causal`
+targets the case where the confounders are never observed directly. Instead of
+assuming that the covariates :math:`X` satisfy unconfoundedness, it assumes
+:math:`X` are noisy **proxies** for a latent confounder :math:`Z` — for example,
+a zip code standing in for socio-economic status — and recovers the treatment
+effect by inferring :math:`Z`.
+
+The generative model is
+
+.. math::
+   Z \sim p(Z), \quad
+   X \sim p(X \mid Z), \quad
+   W \sim p(W \mid Z), \quad
+   Y \sim p(Y \mid W, Z)
+
+where each distribution is parameterised by a neural network. The outcome model
+uses a disjoint pair of networks for :math:`p(Y \mid W=0, Z)` and
+:math:`p(Y \mid W=1, Z)`, so a treatment arm with few observations does not have
+its outcome head diluted by the other arm.
+
+Because :math:`Z` is latent, the posterior :math:`p(Z \mid X, W, Y)` is
+intractable. CEVAE approximates it with an inference network
+:math:`q(Z \mid X, W, Y)` trained jointly with the generative model by
+maximising the evidence lower bound (ELBO). Two auxiliary networks,
+:math:`q(W \mid X)` and :math:`q(Y \mid X, W)`, are trained alongside it, because
+at prediction time only :math:`X` is available: the treatment and outcome that
+the inference network expects have to be supplied by the auxiliary heads before
+:math:`Z` can be inferred for a new unit.
+
+The CATE estimate marginalises the outcome heads over the inferred latent:
+
+.. math::
+   \hat\tau(x) = \mathbb{E}_{Z \sim q(Z \mid X=x)}
+       \big[\mathbb{E}[Y \mid W=1, Z] - \mathbb{E}[Y \mid W=0, Z]\big]
+
+CausalML wraps Pyro's implementation in ``causalml.inference.torch.CEVAE`` and
+also ships a JAX/``flax.nnx`` backend.
+
+DragonNet
+~~~~~~~~~
+
+DragonNet :cite:`shi2019adapting` starts from the sufficiency of the propensity
+score: if adjusting for :math:`X` suffices to identify the treatment effect, then
+adjusting for :math:`e(X) = P(W=1 \mid X)` alone also suffices. A representation
+of :math:`X` therefore only has to retain what predicts treatment, and a
+representation trained purely to predict the outcome may discard exactly that.
+
+The architecture makes this explicit with three heads on a shared trunk
+:math:`Z(x)` of three fully-connected layers:
+
+- a **propensity head** :math:`\hat{e}(x)`, a single sigmoid unit on
+  :math:`Z(x)`;
+- two **outcome heads** :math:`\hat{Q}(0, x)` and :math:`\hat{Q}(1, x)`, each its
+  own stack of layers.
+
+Attaching the propensity head directly to :math:`Z(x)` — with no hidden layer of
+its own — is what forces the shared trunk to keep the propensity information
+rather than discarding it in favour of outcome prediction.
+
+The second contribution is **targeted regularization**, which adds a trainable
+scalar :math:`\epsilon` and an extra loss term. Writing
+:math:`\hat{y} = w\hat{Q}(1,x) + (1-w)\hat{Q}(0,x)` and
+
+.. math::
+   h(w, x) = \frac{w}{\hat{e}(x)} - \frac{1-w}{1 - \hat{e}(x)}
+
+the perturbed prediction is :math:`\tilde{y} = \hat{y} + \epsilon \, h(w, x)`, and
+the training objective becomes
+
+.. math::
+   \mathcal{L} = \mathcal{L}_{\text{DragonNet}}
+       + \beta \sum_i \big(y_i - \tilde{y}_i\big)^2
+
+with :math:`\beta` the ``ratio`` argument. This is a one-step correction in the
+spirit of :ref:`TMLE <Targeted maximum likelihood estimation (TMLE) for ATE>`:
+at the optimum the fitted model satisfies the estimating equation for the ATE,
+which is what gives the resulting estimator its asymptotic guarantees. It is
+enabled by default via ``targeted_reg=True``.
+
+The CATE estimate is the difference of the two outcome heads:
+
+.. math::
+   \hat\tau(x) = \hat{Q}(1, x) - \hat{Q}(0, x)
+
+CausalML ships DragonNet as ``causalml.inference.tf.DragonNet`` (TensorFlow) and
+a JAX/``flax.nnx`` backend.
 
 Value optimization methods
 --------------------------

--- a/docs/refs.bib
+++ b/docs/refs.bib
@@ -501,3 +501,20 @@ publisher={Springer-Verlag New York},
 isbn = {978-1-4419-9781-4},
 doi = {10.1007/978-1-4419-9782-1}
 }
+
+@inproceedings{louizos2017causal,
+      title={Causal Effect Inference with Deep Latent-Variable Models},
+      author={Louizos, Christos and Shalit, Uri and Mooij, Joris and Sontag, David and Zemel, Richard and Welling, Max},
+      booktitle={Advances in Neural Information Processing Systems},
+      volume={30},
+      year={2017}
+}
+
+@misc{shi2019adapting,
+      title={Adapting Neural Networks for the Estimation of Treatment Effects},
+      author={Claudia Shi and David M. Blei and Victor Veitch},
+      year={2019},
+      eprint={1906.02120},
+      archivePrefix={arXiv},
+      primaryClass={stat.ML}
+}


### PR DESCRIPTION
## Proposed changes

Closes #417.

The Supported Algorithms list in `docs/methodology.rst` names CEVAE and DragonNet, but they are the only two entries in that list without a `:ref:` link — because Methodology had no section to link to. Every other family has one: meta-learners, tree-based, value optimization, probabilities of causation, traditional methods, TMLE. The math and intuition for these two lived only in docstrings and the example notebooks.

This adds a **Neural Network Algorithms** section covering both, and turns the two list entries into links.

- **CEVAE** — the proxy/latent-confounder setting, the generative model, why the outcome heads are a disjoint pair, and why the auxiliary `q(W|X)` and `q(Y|X,W)` networks are needed at all (at prediction time only `X` is available, so the inference network's inputs have to be supplied before `Z` can be inferred).
- **DragonNet** — propensity-score sufficiency as the motivation, the three-head architecture, why the propensity head is attached directly to the shared trunk with no hidden layer of its own, and targeted regularization with its loss term, cross-referenced to the existing TMLE section.

Content is taken from the implementations rather than from the papers alone: the architecture description matches `make_dragonnet` in `causalml/inference/tf/dragonnet.py`, and the targeted-regularization formula is transcribed from `make_tarreg_loss` in `causalml/inference/tf/utils.py`.

Also adds the two references to `docs/refs.bib`, which had entries for neither.

### One naming note

The section is titled **Neural Network Algorithms**, not "Neural network based algorithms" as the bullet in the list reads. `docs/quickstart.rst:151` already has a subsection by that exact name, and with `sphinx.ext.autosectionlabel` the two titles produce the same label. Using the list's wording verbatim built with:

```
docs/quickstart.rst:151: WARNING: duplicate label neural network based algorithms,
other instance in docs/methodology.rst [autosectionlabel.quickstart]
```

## Types of changes

What types of changes does your code introduce to **CausalML**?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/uber/causalml/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/uber/causalml)
- [x] Lint and unit tests pass locally with my changes — docs only; verified by building the docs, see below
- [ ] I have added tests that prove my fix is effective or that my feature works — n/a, no code paths changed
- [x] I have added necessary documentation (if appropriate) — this change is the documentation
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments

### Verification

Built the docs locally and diffed the warning set against master, both runs completing (exit 0, `methodology.html` written):

| | unique WARNING/ERROR lines |
|---|---|
| master | 93 |
| this branch | 93 |

Zero new, zero removed. In the rendered output:

- `id="neural-network-algorithms"`, `id="cevae"` and `id="dragonnet"` are present.
- The Supported Algorithms entries resolve to `href="#cevae"` and `href="#dragonnet"`.
- Both new citations appear in `references.html`; zero unresolved `[?]` markers on the page.
- The TMLE cross-reference resolves.

The local build needs `-D exclude_patterns=examples` because `nbsphinx` requires `pandoc` to render the example notebooks, which is not installed on this machine. That affects master identically and is unrelated to this change; Read the Docs builds the notebooks normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
