### PR TITLE
Clamp the treatment probability in _kl_divergence

### DIFF
--- a/causalml/feature_selection/filters.py
+++ b/causalml/feature_selection/filters.py
@@ -377,10 +377,15 @@ class FilterSelect:
             pk (float): Probability of class 1 in treatment group
             qk (float): Probability of class 1 in control group
         """
-        if qk < 0.1**6:
-            qk = 0.1**6
-        elif qk > 1 - 0.1**6:
-            qk = 1 - 0.1**6
+        eps = 0.1**6
+        if qk < eps:
+            qk = eps
+        elif qk > 1 - eps:
+            qk = 1 - eps
+        if pk < eps:
+            pk = eps
+        elif pk > 1 - eps:
+            pk = 1 - eps
         S = pk * np.log(pk / qk) + (1 - pk) * np.log((1 - pk) / (1 - qk))
         return S
 

--- a/tests/test_feature_selection.py
+++ b/tests/test_feature_selection.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pandas as pd
 import pytest
 
 from causalml.feature_selection.filters import FilterSelect
@@ -100,3 +101,32 @@ def test_filter_f_accepts_continuous_outcome(generate_classification_data):
         df, X_names, CONVERSION, "F", treatment_group="treatment1"
     )
     assert f_imp.shape[0] == len(X_names)
+
+
+def test_filter_kl_bin_with_no_conversions():
+    """A bin where nobody converted must not turn the whole score into NaN.
+
+    ``_kl_divergence`` clamps the control probability away from 0 and 1 but not
+    the treatment one, so ``pk = 0`` gives ``0 * log(0 / qk)`` -> NaN, and the
+    NaN then propagates through the bin sum to the feature's score and rank.
+    """
+    n = 400
+    x = np.arange(n) % 20 * 1.0
+    df = pd.DataFrame(
+        {
+            "x": x,
+            "treatment_group_key": np.where(
+                np.arange(n) % 2 == 0, "control", "treatment"
+            ),
+            # conversions only happen in the upper half of x, so the lower bins
+            # have no converters in either arm
+            CONVERSION: ((x >= 10) & (np.arange(n) % 3 == 0)).astype(int),
+        }
+    )
+
+    imp = FilterSelect().filter_D(
+        data=df, features=["x"], y_name=CONVERSION, n_bins=5, method="KL"
+    )
+
+    assert np.isfinite(imp["score"].values[0])
+    assert imp["rank"].values[0] == 1


### PR DESCRIPTION
`FilterSelect._kl_divergence` guards the control probability against 0 and 1 but not the treatment one:

```python
if qk < 0.1**6:
    qk = 0.1**6
elif qk > 1 - 0.1**6:
    qk = 1 - 0.1**6
S = pk * np.log(pk / qk) + (1 - pk) * np.log((1 - pk) / (1 - qk))
```

When a bin contains no converters in the treatment arm, `pk` is 0 and the first term evaluates `0 * log(0 / qk)`, which numpy returns as NaN rather than the 0 the limit gives. `_evaluate_KL` adds that into the node total, `_filter_D_one_feature` adds the node totals together, and the feature's score and rank both come out NaN.

It is easy to hit on sparse conversion data. With a feature whose lower bins have no converters in either arm:

```
  feature method  score p_value               misc  rank
0       x     KL    NaN    None  number_of_bins: 5   NaN
```

plus `RuntimeWarning: divide by zero encountered in log` from line 384.

The change applies the same epsilon clamp to `pk`. With it, the same frame scores normally:

```
  feature method    score p_value               misc  rank
0       x     KL  0.00092    None  number_of_bins: 5   1.0
```

`ED` and `Chi` are unaffected since neither takes a log.

Verification: `tests/test_feature_selection.py::test_filter_kl_bin_with_no_conversions` is new and fails on master (`1 failed`), passes with the change. I ran it with `--noconftest` because the fixtures in `tests/conftest.py` pull in the compiled tree extensions, which are not built in my checkout. `black --check` is clean on both files.