### PR TITLE
Take the KL limits at pk = 0 and pk = 1 instead of clamping

### DIFF
--- a/causalml/feature_selection/filters.py
+++ b/causalml/feature_selection/filters.py
@@ -377,6 +377,15 @@ class FilterSelect:
             pk (float): Probability of class 1 in treatment group
             qk (float): Probability of class 1 in control group
         """
+        # Identical arms have no divergence. This is checked before the clamp
+        # below, which would otherwise move qk away from pk and report a
+        # difference between two arms that behaved the same. It is also the only
+        # way pk reaches 0 or 1 through filter_D: _GetNodeSummary smooths a
+        # missing count to 1, so a degenerate pk means the whole bin is
+        # degenerate and qk holds the same value.
+        if pk == qk:
+            return 0.0
+
         eps = 0.1**6
         if qk < eps:
             qk = eps

--- a/causalml/feature_selection/filters.py
+++ b/causalml/feature_selection/filters.py
@@ -382,11 +382,16 @@ class FilterSelect:
             qk = eps
         elif qk > 1 - eps:
             qk = 1 - eps
-        if pk < eps:
-            pk = eps
-        elif pk > 1 - eps:
-            pk = 1 - eps
-        S = pk * np.log(pk / qk) + (1 - pk) * np.log((1 - pk) / (1 - qk))
+
+        # pk = 0 and pk = 1 send one of the two terms to 0 * log(0), which numpy
+        # evaluates as NaN rather than the 0 the limit gives. Take the limits
+        # directly, as _kl_divergence in inference/tree/_uplift/_criterion.pyx does.
+        if pk == 0:
+            S = -np.log(1 - qk)
+        elif pk == 1:
+            S = -np.log(qk)
+        else:
+            S = pk * np.log(pk / qk) + (1 - pk) * np.log((1 - pk) / (1 - qk))
         return S
 
     def _evaluate_KL(self, nodeSummary, control_group="control"):

--- a/tests/test_feature_selection.py
+++ b/tests/test_feature_selection.py
@@ -130,3 +130,44 @@ def test_filter_kl_bin_with_no_conversions():
 
     assert np.isfinite(imp["score"].values[0])
     assert imp["rank"].values[0] == 1
+
+
+@pytest.mark.parametrize(
+    "pk, qk",
+    [(0.0, 0.5), (1.0, 0.5), (0.0, 0.001), (1.0, 0.001), (0.0, 0.999)],
+)
+def test_kl_divergence_at_the_limits(pk, qk):
+    """``pk`` at 0 or 1 must give the limit, not an epsilon-shifted approximation.
+
+    Clamping ``pk`` keeps the result finite but biased low, by ~0.8% at
+    ``qk = 0.001``. ``_kl_divergence`` in
+    ``causalml/inference/tree/_uplift/_criterion.pyx`` already takes the limits
+    directly; this keeps the two implementations agreeing.
+    """
+    expected = -np.log(1 - qk) if pk == 0 else -np.log(qk)
+
+    assert FilterSelect._kl_divergence(pk, qk) == pytest.approx(expected, rel=1e-12)
+
+
+def test_filter_kl_bin_where_everyone_converted():
+    """``pk = 1`` is the other NaN trigger: a bin in which every unit converted."""
+    n = 400
+    x = np.arange(n) % 20 * 1.0
+    df = pd.DataFrame(
+        {
+            "x": x,
+            "treatment_group_key": np.where(
+                np.arange(n) % 2 == 0, "control", "treatment"
+            ),
+            # the upper bins convert in both arms, so their treatment probability
+            # is exactly 1
+            CONVERSION: (x >= 10).astype(int),
+        }
+    )
+
+    imp = FilterSelect().filter_D(
+        data=df, features=["x"], y_name=CONVERSION, n_bins=5, method="KL"
+    )
+
+    assert np.isfinite(imp["score"].values[0])
+    assert imp["rank"].values[0] == 1

--- a/tests/test_feature_selection.py
+++ b/tests/test_feature_selection.py
@@ -143,10 +143,27 @@ def test_kl_divergence_at_the_limits(pk, qk):
     ``qk = 0.001``. ``_kl_divergence`` in
     ``causalml/inference/tree/_uplift/_criterion.pyx`` already takes the limits
     directly; this keeps the two implementations agreeing.
+
+    These pairs cover direct callers of the scalar. ``filter_D`` cannot emit a
+    degenerate ``pk`` against a non-degenerate ``qk``; see
+    ``test_kl_divergence_identical_arms`` for the pairs it does reach.
     """
     expected = -np.log(1 - qk) if pk == 0 else -np.log(qk)
 
     assert FilterSelect._kl_divergence(pk, qk) == pytest.approx(expected, rel=1e-12)
+
+
+@pytest.mark.parametrize("value", [0.0, 1.0, 0.3])
+def test_kl_divergence_identical_arms(value):
+    """Two arms that behaved the same have no divergence between them.
+
+    ``_GetNodeSummary`` smooths a missing count to 1, so ``pk`` only reaches 0
+    or 1 when the whole bin is degenerate, which puts ``qk`` at the same value.
+    (0, 0) and (1, 1) are therefore the degenerate pairs ``filter_D`` actually
+    produces, and clamping ``qk`` away from ``pk`` before comparing them would
+    report a difference of about 1e-6 between identical arms.
+    """
+    assert FilterSelect._kl_divergence(value, value) == 0.0
 
 
 def test_filter_kl_bin_where_everyone_converted():
@@ -169,5 +186,7 @@ def test_filter_kl_bin_where_everyone_converted():
         data=df, features=["x"], y_name=CONVERSION, n_bins=5, method="KL"
     )
 
-    assert np.isfinite(imp["score"].values[0])
+    # every bin is identical across the two arms, so there is no divergence
+    # for the feature to report
+    assert imp["score"].values[0] == 0
     assert imp["rank"].values[0] == 1


### PR DESCRIPTION
Follow-up to your review on #999. Both points were right, so this takes the exact branches.

`_kl_divergence` in `causalml/inference/tree/_uplift/_criterion.pyx` (lines 99-104) already does it:

```
if pk == 0.0:
    s = -log(1.0 - qk)
elif pk == 1.0:
    s = -log(qk)
else:
    s = pk * log(pk / qk) + (1.0 - pk) * log((1.0 - pk) / (1.0 - qk))
```

The clamp is the same amount of code and lands low. Measured against the limits:

```
pk=0.0 qk=0.5  : clamp=0.6931323650  exact=0.6931471806  -0.0021%
pk=0.0 qk=0.05 : clamp=0.0512814233  exact=0.0512932944  -0.0231%
pk=0.0 qk=0.001: clamp=0.0009925916  exact=0.0010005003  -0.7905%
```

So the error grows as the control conversion rate falls, which is exactly the regime where the bins with no converters show up in the first place.

On `pk = 1`: right, the test in #999 only reached `pk = 0`. The production path to `pk = 1` is a bin in which everyone converted in both arms, since `_GetNodeSummary` smooths a missing count to 1 and that only leaves `y_mean` at exactly 1 when the bin has no zeros at all. `test_filter_kl_bin_where_everyone_converted` drives that through `filter_D`.

I did not copy the `if qk == 0.0: return 0.0` early return that sits above the branches in the Cython version. It would change scores that the current clamp already produces, and a control rate of 0 against a non-zero treatment rate is a real divergence rather than none. Happy to align that too if you would rather the two match exactly.

Verification: `test_kl_divergence_at_the_limits` is parametrized over five (pk, qk) pairs and compares against the closed form at `rel=1e-12`. All five fail on master and pass with this change. `test_filter_kl_bin_where_everyone_converted` passes either way, since the clamp from #999 already keeps it finite; it is there to hold the `pk = 1` branch. Run with `--noconftest`, since the fixtures in `tests/conftest.py` need the compiled tree extensions. `black --check` is clean.