### PR TITLE
Filter caught warnings by category in the serialization tests

### DIFF
--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -198,9 +198,15 @@ class TestSafetyChecks:
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")
             loaded = BaseTRegressor.load(tmp_path_file)
-            assert len(w) == 1
-            assert issubclass(w[0].category, CausalMLVersionMismatchWarning)
-            assert "0.0.1" in str(w[0].message)
+            # Filter rather than count: `load` goes through joblib, and a
+            # dependency warning raised on the way (NumPy 2.5 deprecates setting
+            # an array's shape, which joblib's unpickler still does) would
+            # otherwise fail a test that is about our own warning.
+            version_warnings = [
+                x for x in w if issubclass(x.category, CausalMLVersionMismatchWarning)
+            ]
+            assert len(version_warnings) == 1
+            assert "0.0.1" in str(version_warnings[0].message)
 
     def test_no_warning_when_versions_match(self, regression_data, tmp_path_file):
         """No warning should be raised when versions match."""
@@ -340,8 +346,16 @@ class TestEdgeCases:
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")
             loaded = load_learner(tmp_path_file)
-            assert len(w) == 1
-            assert "without causalml metadata" in str(w[0].message)
+            # See test_version_mismatch_warning: filter to our own warning so a
+            # dependency's deprecation raised during the joblib load cannot fail
+            # this.
+            metadata_warnings = [
+                x for x in w if "without causalml metadata" in str(x.message)
+            ]
+            assert len(metadata_warnings) == 1
+            assert issubclass(
+                metadata_warnings[0].category, CausalMLVersionMismatchWarning
+            )
 
         preds = loaded.predict(X=X)
         assert preds.shape[0] == X.shape[0]


### PR DESCRIPTION
## Proposed changes

`test_version_mismatch_warning` and `test_load_raw_joblib_fallback` assert `len(w) == 1` over every warning raised during a load. Both loads go through joblib, so any dependency warning raised on the way fails them.

NumPy 2.5.2 does exactly that. joblib 1.5.3's unpickler sets an array's shape, which NumPy 2.5 deprecates:

```
joblib/numpy_pickle.py:207: DeprecationWarning: Setting the shape on a NumPy array
has been deprecated in NumPy 2.5.
```

Both tests fail on the Python 3.12 CI lanes with `assert 2 == 1`. This is not specific to any one branch; every PR opened against master now hits it. The 3.11 lanes resolve an older NumPy and pass.

The fix filters to our own warning instead of counting all of them, which is the pattern `test_no_warning_when_versions_match` in the same class already uses.

Verified by patching `joblib.load` to emit the same `DeprecationWarning`: the tests fail with `assert 2 == 1` before this change and pass after. `tests/test_serialization.py` and `tests/test_serialization_extended.py` are green locally (44 passed).

Not done here: pinning `numpy<2.5`. The deprecation is joblib's to fix upstream, and the tests were fragile regardless of which dependency happened to warn.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/uber/causalml/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/uber/causalml)
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules