### PR TITLE
Let UpliftTreeClassifier prune inside fit (#1003)

### DIFF
--- a/causalml/inference/tree/_uplift/uplifttree.py
+++ b/causalml/inference/tree/_uplift/uplifttree.py
@@ -28,6 +28,36 @@ from ._tree import BaseUpliftDecisionTree
 from .._tree._tree import Tree, build_pruned_tree_from_mask
 
 
+def _check_fraction(name: str, value, allow_none: bool = False) -> None:
+    """Reject a held-out fraction that is not strictly inside (0, 1).
+
+    Both fractions reach ``train_test_split`` as ``test_size``, which rejects
+    out-of-range values but reports them against its own parameter name rather
+    than the one the caller passed. ``0.0`` needs catching here in particular:
+    it is a plausible way to write "hold nothing out", and nothing downstream
+    would have complained about it.
+
+    Args:
+        name (str): parameter name, for the message
+        value: the value to check
+        allow_none (bool): whether ``None`` is a valid value (off)
+
+    Raises:
+        ValueError: if the value is not a float strictly between 0 and 1
+    """
+    if allow_none and value is None:
+        return
+    try:
+        fraction = float(value)
+    except (TypeError, ValueError):
+        fraction = float("nan")
+    if not 0.0 < fraction < 1.0:
+        allowed = "a float strictly between 0 and 1"
+        if allow_none:
+            allowed += " or None"
+        raise ValueError(f"{name} must be {allowed}, got {value!r}")
+
+
 class _UpliftTreeNode:
     """A minimal ``DecisionTree``-shaped node for ``plot.py``.
 
@@ -131,7 +161,12 @@ class _KernelUpliftTreeClassifier(SerializableLearner, BaseUpliftDecisionTree):
         Returns:
             self
         """
-        if self.prune_fraction:
+        # Validated here rather than in __init__ so the constructor stores its
+        # arguments verbatim (sklearn get_params / clone round-trip).
+        _check_fraction("estimation_sample_size", self.estimation_sample_size)
+        _check_fraction("prune_fraction", self.prune_fraction, allow_none=True)
+
+        if self.prune_fraction is not None:
             return self._fit_with_pruning(
                 X=X,
                 treatment=treatment,
@@ -641,7 +676,9 @@ class UpliftTreeClassifier(_KernelUpliftTreeClassifier):
     ``min_gain`` / ``prune_rule``. The pruning rows are taken out before the honest
     split, so neither the split search nor the estimation half sees them, and
     ``n_nodes_before_pruning_`` records the size pruning started from. :meth:`prune`
-    is unchanged for callers managing their own holdout.
+    is unchanged for callers managing their own holdout. ``prune_fraction`` and
+    ``estimation_sample_size`` are held-out fractions, so ``fit`` rejects anything
+    outside ``(0, 1)`` — including ``0.0``, which would otherwise read as off.
 
     On ``make_uplift_classification`` (n=3000, 6 seeds, ``max_depth=None``,
     ``min_samples_leaf=20``), ``prune_fraction=0.3`` took held-out qini from -1.74 to

--- a/causalml/inference/tree/_uplift/uplifttree.py
+++ b/causalml/inference/tree/_uplift/uplifttree.py
@@ -150,10 +150,8 @@ class _KernelUpliftTreeClassifier(SerializableLearner, BaseUpliftDecisionTree):
             super().fit(
                 X=X_enc, y=y_2dim, sample_weight=sample_weight, check_input=check_input
             )
+            self._maybe_prune()
             self._node_group_counts = self._compute_node_group_counts(X_enc, y_2dim)
-            # Recorded for `_fit_with_pruning`, which has to redo both against the
-            # pruned tree. Structure rows only; there is no estimation half here.
-            self._fit_splits = (X_enc, y_2dim, None, None)
             return self
 
         # Honest approach (Athey & Imbens 2016): grow the tree on one split and
@@ -190,10 +188,12 @@ class _KernelUpliftTreeClassifier(SerializableLearner, BaseUpliftDecisionTree):
         sw_tr = split[4] if sample_weight is not None else None
 
         super().fit(X=X_tr, y=y_tr, sample_weight=sw_tr, check_input=check_input)
+        # Prune first: `_honest_reestimate` only writes leaves, so a node promoted
+        # to a leaf afterwards would keep the value it held as an internal node.
+        self._maybe_prune()
         self._honest_reestimate(X_est, y_est)
         # Per-group counts for plotting come from the structure (train) split.
         self._node_group_counts = self._compute_node_group_counts(X_tr, y_tr)
-        self._fit_splits = (X_tr, y_tr, X_est, y_est)
         return self
 
     def _fit_with_pruning(
@@ -204,18 +204,14 @@ class _KernelUpliftTreeClassifier(SerializableLearner, BaseUpliftDecisionTree):
         sample_weight: Union[np.ndarray, None],
         check_input: bool,
     ):
-        """Grow on part of the sample and prune on the rest (``prune_fraction``).
+        """Hold rows out for pruning, then fit normally (``prune_fraction``).
 
-        The pruning rows are taken out first, so neither the split search nor the
-        honest estimation half sees them -- a split kept because it helps on rows
-        that chose it is exactly what pruning is meant to catch.
-
-        Order matters. Pruning collapses leaves, so the honest re-estimation and
-        the per-node group counts are redone against the pruned tree: the former
-        because ``_honest_reestimate`` only writes leaves, so a node promoted to a
-        leaf would otherwise keep the structure-split estimate it was given as an
-        internal node; the latter because pruning renumbers nodes and
-        ``_node_group_counts`` is indexed by node id.
+        The pruning rows come out first, so neither the split search nor the honest
+        estimation half sees them -- a split kept because it helps on the rows that
+        chose it is what pruning is meant to catch. The holdout is parked on the
+        instance for :meth:`_maybe_prune`, which the ordinary fit path calls at the
+        point where the tree is grown but the leaves are not yet estimated, and is
+        dropped again on the way out so a fitted tree holds no training data.
         """
         treatment = np.asarray(treatment)
         y_arr = np.asarray(y).ravel()
@@ -243,8 +239,9 @@ class _KernelUpliftTreeClassifier(SerializableLearner, BaseUpliftDecisionTree):
         y_grow, y_prune = split[4], split[5]
         sw_grow = split[6] if sample_weight is not None else None
 
-        # Grow with pruning disabled, otherwise this recurses.
+        # prune_fraction is cleared so the recursive call takes the ordinary path.
         prune_fraction, self.prune_fraction = self.prune_fraction, None
+        self._prune_holdout = (X_prune, w_prune, y_prune)
         try:
             self.fit(
                 X=X_grow,
@@ -255,7 +252,15 @@ class _KernelUpliftTreeClassifier(SerializableLearner, BaseUpliftDecisionTree):
             )
         finally:
             self.prune_fraction = prune_fraction
+            del self._prune_holdout
+        return self
 
+    def _maybe_prune(self) -> None:
+        """Prune on the held-out rows, if ``fit`` set any aside."""
+        holdout = getattr(self, "_prune_holdout", None)
+        if holdout is None:
+            return
+        X_prune, w_prune, y_prune = holdout
         self.n_nodes_before_pruning_ = self.tree_.node_count
         self.prune(
             X=X_prune,
@@ -264,14 +269,6 @@ class _KernelUpliftTreeClassifier(SerializableLearner, BaseUpliftDecisionTree):
             minGain=self.min_gain,
             rule=self.prune_rule,
         )
-
-        X_structure, y_structure, X_est, y_est = self._fit_splits
-        if X_est is not None:
-            self._honest_reestimate(X_est, y_est)
-        self._node_group_counts = self._compute_node_group_counts(
-            X_structure, y_structure
-        )
-        return self
 
     def _honest_reestimate(self, X_est: np.ndarray, y_est: np.ndarray) -> None:
         """Overwrite each leaf's per-group P(Y=1|T=g) on the estimation split.
@@ -517,8 +514,45 @@ class _KernelUpliftTreeClassifier(SerializableLearner, BaseUpliftDecisionTree):
         leaves_in_subtree = (is_orig_leaf | collapsed).astype(np.uint8)
         pruned = Tree(self.n_features_, self.tree_.n_classes, self.n_outputs_)
         build_pruned_tree_from_mask(pruned, self.tree_, leaves_in_subtree)
+        self._remap_node_group_counts(leaves_in_subtree, pruned.node_count)
         self.tree_ = pruned
         return self
+
+    def _remap_node_group_counts(
+        self, leaves_in_subtree: np.ndarray, n_pruned_nodes: int
+    ) -> None:
+        """Carry ``_node_group_counts`` over to the pruned tree's node ids.
+
+        The counts are per-node totals of the rows reaching each node, and a node
+        that survives pruning is reached by exactly the same rows, so the values
+        transfer unchanged -- only the ids move. Collapsing a subtree does not
+        change its root's count either, since every row that reached a descendant
+        reached the root first.
+
+        Without this the array keeps the unpruned tree's length, and because it is
+        longer than the pruned tree nothing raises: ``_node_group_counts[node_id]``
+        just returns some other node's counts. The uplift-score p-value and the
+        plot's ``group_size`` read it that way.
+
+        The mapping replays ``_build_pruned_tree``'s traversal: a stack-based
+        preorder that pushes the right child before the left, so ids are assigned
+        in the order nodes are popped.
+        """
+        counts = getattr(self, "_node_group_counts", None)
+        if counts is None:
+            return
+
+        left, right = self.tree_.children_left, self.tree_.children_right
+        remapped = np.zeros((n_pruned_nodes, counts.shape[1]), dtype=counts.dtype)
+        stack, new_id = [0], 0
+        while stack:
+            old_id = stack.pop()
+            remapped[new_id] = counts[old_id]
+            new_id += 1
+            if not leaves_in_subtree[old_id]:
+                stack.append(right[old_id])
+                stack.append(left[old_id])
+        self._node_group_counts = remapped
 
     def predict_proba_by_group(
         self, X: np.ndarray, check_input: bool = True

--- a/causalml/inference/tree/_uplift/uplifttree.py
+++ b/causalml/inference/tree/_uplift/uplifttree.py
@@ -26,36 +26,7 @@ from causalml.inference.serialization import SerializableLearner
 
 from ._tree import BaseUpliftDecisionTree
 from .._tree._tree import Tree, build_pruned_tree_from_mask
-
-
-def _check_fraction(name: str, value, allow_none: bool = False) -> None:
-    """Reject a held-out fraction that is not strictly inside (0, 1).
-
-    Both fractions reach ``train_test_split`` as ``test_size``, which rejects
-    out-of-range values but reports them against its own parameter name rather
-    than the one the caller passed. ``0.0`` needs catching here in particular:
-    it is a plausible way to write "hold nothing out", and nothing downstream
-    would have complained about it.
-
-    Args:
-        name (str): parameter name, for the message
-        value: the value to check
-        allow_none (bool): whether ``None`` is a valid value (off)
-
-    Raises:
-        ValueError: if the value is not a float strictly between 0 and 1
-    """
-    if allow_none and value is None:
-        return
-    try:
-        fraction = float(value)
-    except (TypeError, ValueError):
-        fraction = float("nan")
-    if not 0.0 < fraction < 1.0:
-        allowed = "a float strictly between 0 and 1"
-        if allow_none:
-            allowed += " or None"
-        raise ValueError(f"{name} must be {allowed}, got {value!r}")
+from ..utils import _check_fraction
 
 
 class _UpliftTreeNode:

--- a/causalml/inference/tree/_uplift/uplifttree.py
+++ b/causalml/inference/tree/_uplift/uplifttree.py
@@ -82,6 +82,9 @@ class _KernelUpliftTreeClassifier(SerializableLearner, BaseUpliftDecisionTree):
         normalization: bool = True,
         honesty: bool = False,
         estimation_sample_size: float = 0.5,
+        prune_fraction: float = None,
+        min_gain: float = 0.0001,
+        prune_rule: str = "maxAbsDiff",
         max_features: Union[int, float, str, None] = None,
         min_weight_fraction_leaf: float = 0.0,
         random_state: int = None,
@@ -92,6 +95,9 @@ class _KernelUpliftTreeClassifier(SerializableLearner, BaseUpliftDecisionTree):
         self.normalization = normalization
         self.honesty = honesty
         self.estimation_sample_size = estimation_sample_size
+        self.prune_fraction = prune_fraction
+        self.min_gain = min_gain
+        self.prune_rule = prune_rule
         super().__init__(
             criterion=criterion,
             splitter="best",
@@ -125,6 +131,15 @@ class _KernelUpliftTreeClassifier(SerializableLearner, BaseUpliftDecisionTree):
         Returns:
             self
         """
+        if self.prune_fraction:
+            return self._fit_with_pruning(
+                X=X,
+                treatment=treatment,
+                y=y,
+                sample_weight=sample_weight,
+                check_input=check_input,
+            )
+
         X_enc, y_2dim = self._prepare_data(X=X, treatment=treatment, y=y)
 
         # IDDP requires the honest approach (legacy uplift.pyx ~468-469). Resolved
@@ -136,6 +151,9 @@ class _KernelUpliftTreeClassifier(SerializableLearner, BaseUpliftDecisionTree):
                 X=X_enc, y=y_2dim, sample_weight=sample_weight, check_input=check_input
             )
             self._node_group_counts = self._compute_node_group_counts(X_enc, y_2dim)
+            # Recorded for `_fit_with_pruning`, which has to redo both against the
+            # pruned tree. Structure rows only; there is no estimation half here.
+            self._fit_splits = (X_enc, y_2dim, None, None)
             return self
 
         # Honest approach (Athey & Imbens 2016): grow the tree on one split and
@@ -175,6 +193,84 @@ class _KernelUpliftTreeClassifier(SerializableLearner, BaseUpliftDecisionTree):
         self._honest_reestimate(X_est, y_est)
         # Per-group counts for plotting come from the structure (train) split.
         self._node_group_counts = self._compute_node_group_counts(X_tr, y_tr)
+        self._fit_splits = (X_tr, y_tr, X_est, y_est)
+        return self
+
+    def _fit_with_pruning(
+        self,
+        X: np.ndarray,
+        treatment: np.ndarray,
+        y: np.ndarray,
+        sample_weight: Union[np.ndarray, None],
+        check_input: bool,
+    ):
+        """Grow on part of the sample and prune on the rest (``prune_fraction``).
+
+        The pruning rows are taken out first, so neither the split search nor the
+        honest estimation half sees them -- a split kept because it helps on rows
+        that chose it is exactly what pruning is meant to catch.
+
+        Order matters. Pruning collapses leaves, so the honest re-estimation and
+        the per-node group counts are redone against the pruned tree: the former
+        because ``_honest_reestimate`` only writes leaves, so a node promoted to a
+        leaf would otherwise keep the structure-split estimate it was given as an
+        internal node; the latter because pruning renumbers nodes and
+        ``_node_group_counts`` is indexed by node id.
+        """
+        treatment = np.asarray(treatment)
+        y_arr = np.asarray(y).ravel()
+        stratify = np.stack(
+            [
+                np.asarray([self.control_name != t for t in treatment], dtype=int),
+                (y_arr > 0).astype(int),
+            ],
+            axis=1,
+        )
+
+        arrays = [X, treatment, y_arr]
+        if sample_weight is not None:
+            arrays.append(sample_weight)
+        split_kwargs = dict(
+            test_size=self.prune_fraction, shuffle=True, random_state=self.random_state
+        )
+        try:
+            split = train_test_split(*arrays, stratify=stratify, **split_kwargs)
+        except ValueError:
+            split = train_test_split(*arrays, **split_kwargs)
+
+        X_grow, X_prune = split[0], split[1]
+        w_grow, w_prune = split[2], split[3]
+        y_grow, y_prune = split[4], split[5]
+        sw_grow = split[6] if sample_weight is not None else None
+
+        # Grow with pruning disabled, otherwise this recurses.
+        prune_fraction, self.prune_fraction = self.prune_fraction, None
+        try:
+            self.fit(
+                X=X_grow,
+                treatment=w_grow,
+                y=y_grow,
+                sample_weight=sw_grow,
+                check_input=check_input,
+            )
+        finally:
+            self.prune_fraction = prune_fraction
+
+        self.n_nodes_before_pruning_ = self.tree_.node_count
+        self.prune(
+            X=X_prune,
+            treatment=w_prune,
+            y=y_prune,
+            minGain=self.min_gain,
+            rule=self.prune_rule,
+        )
+
+        X_structure, y_structure, X_est, y_est = self._fit_splits
+        if X_est is not None:
+            self._honest_reestimate(X_est, y_est)
+        self._node_group_counts = self._compute_node_group_counts(
+            X_structure, y_structure
+        )
         return self
 
     def _honest_reestimate(self, X_est: np.ndarray, y_est: np.ndarray) -> None:
@@ -504,6 +600,20 @@ class UpliftTreeClassifier(_KernelUpliftTreeClassifier):
     ``early_stopping_eval_diff_scale`` and ``fit``'s ``X_val`` / ``treatment_val``
     / ``y_val`` are accepted for backward compatibility but ignored: validation-set
     early stopping is not implemented on the kernel tree.
+
+    ``prune_fraction`` (default ``None``, off) makes ``fit`` do the split-and-prune
+    itself: that fraction of the rows is held out stratified on (treatment, outcome),
+    the tree is grown on the rest, and :meth:`prune` runs on the holdout with
+    ``min_gain`` / ``prune_rule``. The pruning rows are taken out before the honest
+    split, so neither the split search nor the estimation half sees them, and
+    ``n_nodes_before_pruning_`` records the size pruning started from. :meth:`prune`
+    is unchanged for callers managing their own holdout.
+
+    On ``make_uplift_classification`` (n=3000, 6 seeds, ``max_depth=None``,
+    ``min_samples_leaf=20``), ``prune_fraction=0.3`` took held-out qini from -1.74 to
+    -1.44, and to 0.83 combined with ``honesty=True``; an unpruned tree at that depth
+    is badly overfit. Measured on one simulated design, so treat the magnitudes as
+    indicative.
     """
 
     def __init__(
@@ -519,6 +629,9 @@ class UpliftTreeClassifier(_KernelUpliftTreeClassifier):
         normalization=True,
         honesty=False,
         estimation_sample_size=0.5,
+        prune_fraction=None,
+        min_gain=0.0001,
+        prune_rule="maxAbsDiff",
         random_state=None,
     ):
         # Retained verbatim for the sklearn get_params / clone contract on the
@@ -540,6 +653,9 @@ class UpliftTreeClassifier(_KernelUpliftTreeClassifier):
             normalization=normalization,
             honesty=honesty,
             estimation_sample_size=estimation_sample_size,
+            prune_fraction=prune_fraction,
+            min_gain=min_gain,
+            prune_rule=prune_rule,
             max_features=max_features,
             random_state=random_state,
         )

--- a/causalml/inference/tree/causal/causaltree.py
+++ b/causalml/inference/tree/causal/causaltree.py
@@ -17,7 +17,7 @@ from causalml.inference.serialization import SerializableLearner
 
 from ._tree import BaseCausalDecisionTree
 from .._tree._tree import Tree, _build_pruned_tree_ccp, ccp_pruning_path
-from ..utils import get_tree_leaves_mask, timeit
+from ..utils import _check_fraction, get_tree_leaves_mask, timeit
 
 logger = logging.getLogger("causalml")
 
@@ -281,6 +281,8 @@ class CausalTreeRegressor(SerializableLearner, RegressorMixin, BaseCausalDecisio
             raise ValueError(
                 "min_impurity_decrease must be set to -inf for causal_mse criterion"
             )
+
+        _check_fraction("estimation_sample_size", self.estimation_sample_size)
 
         if isinstance(self.ccp_alpha, str):
             if self.ccp_alpha != CV_PENALTY:

--- a/causalml/inference/tree/utils.py
+++ b/causalml/inference/tree/utils.py
@@ -1,5 +1,5 @@
 """
-Utility functions for uplift trees.
+Utility functions for uplift and causal trees.
 """
 
 import functools
@@ -8,6 +8,40 @@ from typing import Callable
 
 import numpy as np
 import pandas as pd
+
+
+def _check_fraction(name: str, value, allow_none: bool = False) -> None:
+    """Reject a held-out fraction that is not strictly inside (0, 1).
+
+    Shared by the uplift and causal trees, whose ``estimation_sample_size`` and
+    ``prune_fraction`` reach ``train_test_split`` as ``test_size``. That call
+    rejects out-of-range values but reports them against its own parameter name
+    rather than the one the caller passed, and ``0.0`` never reaches it: it is a
+    plausible way to write "hold nothing out", and each caller reads it as off.
+
+    Called from ``fit`` rather than ``__init__`` so constructors keep storing
+    their arguments verbatim, which sklearn's ``get_params`` / ``clone``
+    round-trip on.
+
+    Args:
+        name (str): parameter name, for the message
+        value: the value to check
+        allow_none (bool): whether ``None`` is a valid value (off)
+
+    Raises:
+        ValueError: if the value is not a float strictly between 0 and 1
+    """
+    if allow_none and value is None:
+        return
+    try:
+        fraction = float(value)
+    except (TypeError, ValueError):
+        fraction = float("nan")
+    if not 0.0 < fraction < 1.0:
+        allowed = "a float strictly between 0 and 1"
+        if allow_none:
+            allowed += " or None"
+        raise ValueError(f"{name} must be {allowed}, got {value!r}")
 
 
 def cat_group(dfx, kpix, n_group=10):

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -65,6 +65,31 @@ New Features
 
   ``ccp_alpha="cv"`` requires ``honesty=True`` and raises otherwise, since the
   cross-validation scores candidate subtrees with the honest objective.
+* **`UpliftTreeClassifier` can prune inside** ``fit`` **(#1003).** ``prune_fraction``
+  (default ``None``, off) holds out that fraction of the rows stratified on
+  (treatment, outcome), grows the tree on the rest, and runs the existing ``prune()``
+  on the holdout with ``min_gain`` / ``prune_rule``. Reaching validation-based pruning
+  previously meant splitting the data, fitting, and calling ``prune()`` as a second
+  step. ``prune()`` is unchanged for callers who manage their own holdout, and
+  ``n_nodes_before_pruning_`` records the size pruning started from.
+
+  The pruning rows are removed before the honest split, so neither the split search nor
+  the estimation half sees them. Pruning renumbers nodes and promotes internal nodes to
+  leaves, so the honest re-estimation and the per-node group counts are redone against
+  the pruned tree.
+
+  On ``make_uplift_classification`` (n=3000, 6 seeds, ``max_depth=None``,
+  ``min_samples_leaf=20``), held-out qini went from -1.74 unpruned to -1.44 with
+  ``prune_fraction=0.3``, and to 0.83 combined with ``honesty=True``. One simulated
+  design, so the magnitudes are indicative.
+
+Bug Fixes
+~~~~~~~~~
+* **`UpliftTreeClassifier.prune` left `_node_group_counts` stale (#1003).** ``prune()``
+  replaces ``tree_`` without rebuilding the per-node group counts, which are indexed by
+  node id and read by the uplift-score p-value and the plot's ``group_size``. The stale
+  array is longer than the pruned tree, so it returned another node's counts instead of
+  raising. The counts are now rebuilt whenever ``fit`` prunes.
 
 Behavior Changes
 ~~~~~~~~~~~~~~~~

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -79,6 +79,11 @@ New Features
   leaves, so the honest re-estimation and the per-node group counts are redone against
   the pruned tree.
 
+  ``fit`` now rejects a held-out fraction outside ``(0, 1)`` — ``prune_fraction`` on the
+  uplift tree and ``estimation_sample_size`` on both the uplift and causal trees —
+  raising a ``ValueError`` that names the parameter instead of ``train_test_split``'s
+  ``test_size``. ``prune_fraction=0.0`` was read as off.
+
   On ``make_uplift_classification`` (n=3000, 6 seeds, ``max_depth=None``,
   ``min_samples_leaf=20``), held-out qini went from -1.74 unpruned to -1.44 with
   ``prune_fraction=0.3``, and to 0.83 combined with ``honesty=True``. One simulated

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -65,6 +65,7 @@ New Features
 
   ``ccp_alpha="cv"`` requires ``honesty=True`` and raises otherwise, since the
   cross-validation scores candidate subtrees with the honest objective.
+
 * **`UpliftTreeClassifier` can prune inside** ``fit`` **(#1003).** ``prune_fraction``
   (default ``None``, off) holds out that fraction of the rows stratified on
   (treatment, outcome), grows the tree on the rest, and runs the existing ``prune()``
@@ -86,10 +87,13 @@ New Features
 Bug Fixes
 ~~~~~~~~~
 * **`UpliftTreeClassifier.prune` left `_node_group_counts` stale (#1003).** ``prune()``
-  replaces ``tree_`` without rebuilding the per-node group counts, which are indexed by
+  replaced ``tree_`` without rebuilding the per-node group counts, which are indexed by
   node id and read by the uplift-score p-value and the plot's ``group_size``. The stale
   array is longer than the pruned tree, so it returned another node's counts instead of
-  raising. The counts are now rebuilt whenever ``fit`` prunes.
+  raising. ``prune()`` now carries the counts over to the pruned node ids, so a
+  standalone call is fixed too, not only the fit-time path. A surviving node is reached
+  by the same rows either way, so the values transfer unchanged; the remap replays the
+  pruner's traversal and matches a full recomputation exactly.
 
 Behavior Changes
 ~~~~~~~~~~~~~~~~

--- a/tests/test_causal_trees.py
+++ b/tests/test_causal_trees.py
@@ -4,6 +4,7 @@ from abc import abstractmethod
 import numpy as np
 import pandas as pd
 import pytest
+from sklearn.base import clone
 from sklearn.model_selection import train_test_split
 
 from causalml.inference.tree import CausalTreeRegressor, CausalRandomForestRegressor
@@ -1087,3 +1088,42 @@ def test_causal_tree_fold_trees_inherit_the_parent_objective():
     assert fold.honesty is False
     assert fold.ccp_alpha == 0.0
     assert fold._train_to_est_ratio_override == parent._train_to_est_ratio == 1.0
+
+
+@pytest.mark.parametrize("bad", [0.0, 1.0, 1.5, -0.5, "abc", np.nan])
+def test_causal_tree_fit_rejects_invalid_estimation_sample_size(bad):
+    """`fit` names the offending parameter instead of `train_test_split`'s.
+
+    The value reaches `train_test_split` as `test_size`, which rejects the
+    out-of-range ones but reports them against its own parameter name. `0.0`
+    would otherwise reach it as "hold nothing out".
+    """
+    X, treatment, y = _make_heterogeneous_effect_data(n=300)
+    model = CausalTreeRegressor(
+        honesty=True, estimation_sample_size=bad, **HONEST_TREE_PARAMS
+    )
+
+    with pytest.raises(ValueError, match="estimation_sample_size"):
+        model.fit(X=X, treatment=treatment, y=y)
+
+
+def test_causal_forest_surfaces_the_estimation_sample_size_error():
+    """The forest fits trees in parallel; the tree's message must survive that."""
+    X, treatment, y = _make_heterogeneous_effect_data(n=300)
+    forest = CausalRandomForestRegressor(
+        honesty=True,
+        estimation_sample_size=1.5,
+        n_estimators=3,
+        **HONEST_TREE_PARAMS,
+    )
+
+    with pytest.raises(ValueError, match="estimation_sample_size"):
+        forest.fit(X=X, treatment=treatment, y=y)
+
+
+def test_causal_tree_validation_does_not_raise_in_init():
+    """Validation belongs to `fit`: `__init__` stores its arguments verbatim."""
+    model = CausalTreeRegressor(honesty=True, estimation_sample_size=0.0)
+
+    assert model.get_params()["estimation_sample_size"] == 0.0
+    assert clone(model).get_params()["estimation_sample_size"] == 0.0

--- a/tests/test_uplift_trees_kernel.py
+++ b/tests/test_uplift_trees_kernel.py
@@ -22,7 +22,10 @@ from sklearn.model_selection import train_test_split
 
 from causalml.dataset import make_uplift_classification
 from causalml.inference.tree import uplift_tree_plot, uplift_tree_string
-from causalml.inference.tree._uplift.uplifttree import _KernelUpliftTreeClassifier
+from causalml.inference.tree._uplift.uplifttree import (
+    UpliftTreeClassifier,
+    _KernelUpliftTreeClassifier,
+)
 from causalml.inference.tree._uplift.upliftforest import (
     _KernelUpliftRandomForestClassifier,
     UpliftRandomForestClassifier,
@@ -890,3 +893,119 @@ def test_kernel_uplift_forest_predictions_independent_of_n_jobs(n_jobs):
     other.fit(X=X, treatment=treatment, y=y)
 
     assert_array_almost_equal(serial.predict(X), other.predict(X), decimal=12)
+
+
+# ---------------------------------------------------------------------------
+# Fit-time pruning (#1003). `prune_fraction` holds rows out of the fit, grows on
+# the rest, and prunes on the holdout with the existing `prune()`.
+# ---------------------------------------------------------------------------
+
+
+def _prune_data(n=3000, seed=RANDOM_SEED):
+    df, x_names = make_uplift_classification(
+        n_samples=n, treatment_name=["control", "t1"], random_seed=seed
+    )
+    return (
+        df[x_names].values,
+        df["treatment_group_key"].values,
+        df["conversion"].values,
+    )
+
+
+def test_uplift_tree_prune_fraction_off_by_default():
+    """`prune_fraction` defaults to None and leaves the fit untouched."""
+    X, treatment, y = _prune_data()
+    assert UpliftTreeClassifier(control_name="control").prune_fraction is None
+
+    common = dict(
+        control_name="control",
+        max_depth=None,
+        min_samples_leaf=20,
+        random_state=RANDOM_SEED,
+    )
+    default = UpliftTreeClassifier(**common).fit(X=X, treatment=treatment, y=y)
+    explicit = UpliftTreeClassifier(prune_fraction=None, **common).fit(
+        X=X, treatment=treatment, y=y
+    )
+    pruned = UpliftTreeClassifier(prune_fraction=0.3, **common).fit(
+        X=X, treatment=treatment, y=y
+    )
+
+    assert np.array_equal(default.tree_.value, explicit.tree_.value)
+    # Against the tree's own pre-prune size, not against `default`: `default` is
+    # grown on all the rows, so a smaller pruned tree could just be the effect of
+    # holding rows out rather than of any pruning.
+    assert pruned.tree_.node_count < pruned.n_nodes_before_pruning_
+    assert not hasattr(default, "n_nodes_before_pruning_")
+
+
+def test_uplift_tree_prune_fraction_keeps_node_counts_consistent():
+    """Pruning renumbers nodes, so `_node_group_counts` is rebuilt to match.
+
+    `_node_group_counts` is indexed by node id (the uplift-score p-value and the
+    plot's group_size read it), and `prune()` replaces `tree_` without touching
+    it. A stale array is longer than the pruned tree, so it silently returns
+    another node's counts rather than raising.
+    """
+    X, treatment, y = _prune_data()
+    model = UpliftTreeClassifier(
+        control_name="control",
+        max_depth=None,
+        min_samples_leaf=20,
+        prune_fraction=0.3,
+        random_state=RANDOM_SEED,
+    ).fit(X=X, treatment=treatment, y=y)
+
+    assert model._node_group_counts.shape[0] == model.tree_.node_count
+    assert model._node_group_counts.shape[1] == model.n_outputs_
+
+
+def test_uplift_tree_prune_fraction_reestimates_honest_leaves():
+    """With honesty on, every leaf of the pruned tree carries an estimation-half value.
+
+    `_honest_reestimate` only writes leaves, so a node that pruning turns into a
+    leaf would otherwise keep the structure-split value it held as an internal
+    node. Asserted by recomputing the estimation-half per-group rates against the
+    pruned tree and comparing to what the leaves actually hold -- comparing an
+    honest fit to a plain one does not test this, since the two differ anyway
+    from the structure/estimation split.
+    """
+    X, treatment, y = _prune_data()
+    model = UpliftTreeClassifier(
+        control_name="control",
+        max_depth=None,
+        min_samples_leaf=20,
+        prune_fraction=0.3,
+        honesty=True,
+        random_state=RANDOM_SEED,
+    ).fit(X=X, treatment=treatment, y=y)
+
+    _, _, X_est, y_est = model._fit_splits
+    leaf_ids = model.tree_.apply(np.ascontiguousarray(X_est, dtype=np.float32))
+    value = model.tree_.value
+    is_leaf = model.tree_.children_left == -1
+    n_nodes = model.tree_.node_count
+
+    for group in range(model.n_outputs_):
+        column = y_est[:, group]
+        observed = ~np.isnan(column)
+        at = leaf_ids[observed]
+        n = np.bincount(at, minlength=n_nodes).astype(float)
+        total = np.bincount(at, weights=column[observed], minlength=n_nodes)
+        expected = np.divide(total, n, out=np.zeros_like(n), where=n > 0)
+        assert_array_almost_equal(value[is_leaf, group, 0], expected[is_leaf])
+
+
+def test_uplift_tree_prune_fraction_survives_clone():
+    """The three pruning parameters round-trip through `get_params`."""
+    cloned = clone(
+        UpliftTreeClassifier(
+            control_name="control",
+            prune_fraction=0.3,
+            min_gain=0.01,
+            prune_rule="bestUplift",
+        )
+    )
+    assert cloned.get_params()["prune_fraction"] == 0.3
+    assert cloned.get_params()["min_gain"] == 0.01
+    assert cloned.get_params()["prune_rule"] == "bestUplift"

--- a/tests/test_uplift_trees_kernel.py
+++ b/tests/test_uplift_trees_kernel.py
@@ -1063,3 +1063,61 @@ def test_uplift_tree_prune_fraction_survives_clone():
     assert cloned.get_params()["prune_fraction"] == 0.3
     assert cloned.get_params()["min_gain"] == 0.01
     assert cloned.get_params()["prune_rule"] == "bestUplift"
+
+
+@pytest.mark.parametrize("bad", [0.0, 1.0, 1.5, -0.5, "abc", np.nan])
+def test_uplift_tree_fit_rejects_invalid_prune_fraction(bad):
+    """`fit` names the offending parameter instead of `train_test_split`'s.
+
+    `0.0` is the case worth catching: `fit` branched on truthiness before, so it
+    read as off and pruning was skipped without a word. The others already raised,
+    but from `train_test_split` and against `test_size`.
+    """
+    X, treatment, y = _prune_data(n=300)
+    model = UpliftTreeClassifier(
+        control_name="control", max_depth=3, min_samples_leaf=10, prune_fraction=bad
+    )
+
+    with pytest.raises(ValueError, match="prune_fraction"):
+        model.fit(X=X, treatment=treatment, y=y)
+
+
+@pytest.mark.parametrize("bad", [0.0, 1.0, 1.5, -0.5, "abc", np.nan])
+def test_uplift_tree_fit_rejects_invalid_estimation_sample_size(bad):
+    """The honest fraction gets the same check as the pruning one."""
+    X, treatment, y = _prune_data(n=300)
+    model = UpliftTreeClassifier(
+        control_name="control",
+        max_depth=3,
+        min_samples_leaf=10,
+        honesty=True,
+        estimation_sample_size=bad,
+    )
+
+    with pytest.raises(ValueError, match="estimation_sample_size"):
+        model.fit(X=X, treatment=treatment, y=y)
+
+
+def test_uplift_tree_validation_does_not_raise_in_init():
+    """Validation belongs to `fit`: `__init__` stores its arguments verbatim.
+
+    sklearn's contract is that a constructor only assigns parameters, which is what
+    `get_params` / `clone` round-trip on. Raising here would break both.
+    """
+    model = UpliftTreeClassifier(control_name="control", prune_fraction=0.0)
+
+    assert model.get_params()["prune_fraction"] == 0.0
+    assert clone(model).get_params()["prune_fraction"] == 0.0
+
+
+def test_uplift_tree_fit_accepts_the_valid_fractions():
+    """`None` (off) and an in-range fraction both fit."""
+    X, treatment, y = _prune_data(n=300)
+    common = dict(control_name="control", max_depth=3, min_samples_leaf=10)
+
+    UpliftTreeClassifier(**common, prune_fraction=None).fit(
+        X=X, treatment=treatment, y=y
+    )
+    UpliftTreeClassifier(**common, prune_fraction=0.3, honesty=True).fit(
+        X=X, treatment=treatment, y=y
+    )

--- a/tests/test_uplift_trees_kernel.py
+++ b/tests/test_uplift_trees_kernel.py
@@ -960,40 +960,94 @@ def test_uplift_tree_prune_fraction_keeps_node_counts_consistent():
     assert model._node_group_counts.shape[1] == model.n_outputs_
 
 
-def test_uplift_tree_prune_fraction_reestimates_honest_leaves():
-    """With honesty on, every leaf of the pruned tree carries an estimation-half value.
+def test_uplift_tree_prune_fraction_prunes_before_honest_reestimation():
+    """Pruning runs before the honest re-estimation, not after.
 
     `_honest_reestimate` only writes leaves, so a node that pruning turns into a
-    leaf would otherwise keep the structure-split value it held as an internal
-    node. Asserted by recomputing the estimation-half per-group rates against the
-    pruned tree and comparing to what the leaves actually hold -- comparing an
-    honest fit to a plain one does not test this, since the two differ anyway
-    from the structure/estimation split.
+    leaf afterwards would keep the value it held as an internal node. The order is
+    asserted directly because the fitted tree keeps no training rows to check the
+    leaf values against.
     """
     X, treatment, y = _prune_data()
+    calls = []
+    cls = UpliftTreeClassifier
+    real_prune, real_reestimate = cls.prune, cls._honest_reestimate
+
+    def spy_prune(self, *a, **k):
+        calls.append("prune")
+        return real_prune(self, *a, **k)
+
+    def spy_reestimate(self, *a, **k):
+        calls.append("reestimate")
+        return real_reestimate(self, *a, **k)
+
+    cls.prune, cls._honest_reestimate = spy_prune, spy_reestimate
+    try:
+        model = cls(
+            control_name="control",
+            max_depth=None,
+            min_samples_leaf=20,
+            prune_fraction=0.3,
+            honesty=True,
+            random_state=RANDOM_SEED,
+        ).fit(X=X, treatment=treatment, y=y)
+    finally:
+        cls.prune, cls._honest_reestimate = real_prune, real_reestimate
+
+    assert calls == ["prune", "reestimate"]
+    assert np.isfinite(model.predict(X)).all()
+
+
+def test_uplift_tree_fit_retains_no_training_rows():
+    """A fitted tree holds no copy of the data it was fitted on.
+
+    `UpliftRandomForestClassifier` fits each tree on its own full-size bootstrap
+    copy, so an array parked on the estimator is multiplied by `n_estimators`.
+    """
+    X, treatment, y = _prune_data(n=2000)
     model = UpliftTreeClassifier(
         control_name="control",
         max_depth=None,
         min_samples_leaf=20,
         prune_fraction=0.3,
-        honesty=True,
         random_state=RANDOM_SEED,
     ).fit(X=X, treatment=treatment, y=y)
 
-    _, _, X_est, y_est = model._fit_splits
-    leaf_ids = model.tree_.apply(np.ascontiguousarray(X_est, dtype=np.float32))
-    value = model.tree_.value
-    is_leaf = model.tree_.children_left == -1
-    n_nodes = model.tree_.node_count
+    big = [
+        name
+        for name, value in vars(model).items()
+        if isinstance(value, np.ndarray) and value.shape[:1] == (X.shape[0],)
+    ]
+    assert not big, f"fitted estimator retains row-length arrays: {big}"
+    assert not hasattr(model, "_prune_holdout")
 
-    for group in range(model.n_outputs_):
-        column = y_est[:, group]
-        observed = ~np.isnan(column)
-        at = leaf_ids[observed]
-        n = np.bincount(at, minlength=n_nodes).astype(float)
-        total = np.bincount(at, weights=column[observed], minlength=n_nodes)
-        expected = np.divide(total, n, out=np.zeros_like(n), where=n > 0)
-        assert_array_almost_equal(value[is_leaf, group, 0], expected[is_leaf])
+
+def test_uplift_tree_standalone_prune_remaps_node_group_counts():
+    """`prune()` carries the per-node counts over to the pruned node ids.
+
+    Pruning renumbers nodes, and `_node_group_counts` is indexed by node id. A
+    stale array is longer than the pruned tree, so it returns another node's
+    counts rather than raising. The remap is checked against a full recomputation
+    on the original training rows.
+    """
+    X, treatment, y = _prune_data()
+    train = np.random.RandomState(RANDOM_SEED).rand(len(y)) < 0.7
+    model = UpliftTreeClassifier(
+        control_name="control",
+        max_depth=None,
+        min_samples_leaf=20,
+        random_state=RANDOM_SEED,
+    ).fit(X=X[train], treatment=treatment[train], y=y[train])
+
+    model.prune(X=X[~train], treatment=treatment[~train], y=y[~train])
+    assert model._node_group_counts.shape[0] == model.tree_.node_count
+
+    X_enc, y_2dim = model._prepare_data(
+        X=X[train], treatment=treatment[train], y=y[train]
+    )
+    assert_array_almost_equal(
+        model._node_group_counts, model._compute_node_group_counts(X_enc, y_2dim)
+    )
 
 
 def test_uplift_tree_prune_fraction_survives_clone():


### PR DESCRIPTION
## Proposed changes

`prune_fraction` (default `None`, off) makes `UpliftTreeClassifier.fit` do the split-and-prune itself. Closes #1003.

## Why prune an uplift tree

An uplift tree models the change in response caused by a treatment, so it chooses splits by how much they separate the treated arm from the control arm: `KL`, `ED` and `Chi` by the gain in divergence between the two arms' outcome distributions, `DDP` by how much the treated-minus-control response rate differs between the children ([Rzepakowski & Jaroszewicz 2012](https://doi.org/10.1007/s10115-011-0434-0); [full list](https://causalml.readthedocs.io/en/latest/methodology.html#uplift-tree)).

Each is a difference of two estimated rates, whose variances add, so an uplift split is noisier than a classification split and a deep tree overfits readily. Validation pruning is the standard answer: grow the tree, then walk it bottom-up on rows it never saw and collapse any subtree that does not gain `min_gain` on those rows.

`prune()` already implemented this. What was missing was a way to reach it from `fit` — you had to split the data yourself, fit, then call `prune()`, with nothing in `fit` to suggest it existed.

`prune_fraction=0.3` holds out 30% of the rows stratified on (treatment, outcome), grows the tree on the rest, and runs `prune()` on the holdout with `min_gain` / `prune_rule`. `prune()` is unchanged for callers who manage their own holdout, and `n_nodes_before_pruning_` records the size pruning started from.

### Ordering, which matters twice

- **The pruning rows come out before the honest split**, so neither the split search nor the estimation half sees them. A split kept because it helps on the rows that chose it is what pruning exists to catch.
- **Pruning runs inside the ordinary fit path**, between growing the tree and estimating its leaves, so a node promoted to a leaf is re-estimated like any other rather than keeping its internal-node value.

Nothing is retained on the estimator to make that work: `UpliftRandomForestClassifier` fits each tree on its own full-size bootstrap copy of `X`, so an array parked on a fitted tree is multiplied by `n_estimators`. A test asserts a fitted tree holds no row-length arrays.

### Measured

`make_uplift_classification` (n=3000, 6 seeds, `max_depth=None`, `min_samples_leaf=20`), held-out qini — area between the cumulative-uplift curve and the random-targeting line, so negative is worse than random:

| | leaves | qini |
| --- | --- | --- |
| off (default) | 115.0 | -1.74 |
| `prune_fraction=0.3` | 53.8 | -1.44 |
| `prune_fraction=0.3, honesty=True` | 35.7 | 0.83 |

An unpruned tree at that depth is badly overfit. One simulated design, so treat the magnitudes as indicative; the direction is consistent across seeds.

## Bug fix included

`prune()` replaced `tree_` without rebuilding `_node_group_counts` — per-node treated/control row counts, indexed by node id, read by the uplift-score p-value and the plot's `group_size`.

Pruning renumbers nodes, so the ids no longer line up. Because the stale array is *longer* than the pruned tree, the lookup did not raise; it returned another node's counts. On a 283-node tree pruned to 183, the array stayed at 283 rows.

`prune()` now carries the counts over to the pruned ids, so a standalone call is fixed as well as the fit-time path. A surviving node is reached by the same rows and collapsing a subtree does not change its root's count, so the values transfer unchanged and only the ids move. The remap replays `_build_pruned_tree`'s traversal — stack-based preorder, right child pushed before left — and matches a full recomputation exactly across seeds.

## Not done here

`ccp_alpha="cv"`, which #1001 added to `CausalTreeRegressor`, does not port.

[Cost-complexity pruning](https://scikit-learn.org/stable/modules/tree.html#minimal-cost-complexity-pruning) ranks subtrees by `alpha = (R(t) - R(T_t)) / (|leaves(T_t)| - 1)`, the price per leaf of collapsing `T_t` into `t`. That ordering needs `R(t) >= R(T_t)`, which holds for squared error or Gini because a split cannot increase them.

The uplift criteria are gain-based instead — `node_impurity` is a positive constant by design, so the builder's `impurity <= EPSILON` early-leaf never fires — and the inequality does not hold. `ccp_pruning_path` on a fitted uplift tree returns 28 alphas of which 26 are negative, leaving `{0.0, 0.997}` after the non-negative filter: the whole tree, or the root.

CV-selected `min_gain` is the natural next step and is left for its own change. `UpliftRandomForestClassifier` still does not prune; the analogous option on `CausalRandomForestRegressor` measured worse than leaving it off (#1001), so that wants measuring before it is extended.

## Where the code lives

| | |
| --- | --- |
| `_uplift/uplifttree.py` | `_maybe_prune` (called from `fit`), `prune` (unchanged entry point), `_remap_node_group_counts` (the bug fix) |
| `tests/test_uplift_trees_kernel.py` | 6 new tests, including a call-order check that pruning precedes the honest re-estimation, and one asserting a fitted tree retains no training rows |

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/uber/causalml/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/uber/causalml)
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
