### PR TITLE
Fix unclear XGBoost OpenMP failure message on macOS

### DIFF
--- a/causalml/dataset/synthetic.py
+++ b/causalml/dataset/synthetic.py
@@ -10,16 +10,10 @@ try:
     from xgboost import XGBRegressor
 except ImportError:  # pragma: no cover
     XGBRegressor = None
-except ValueError as exc:  # pragma: no cover
-    if type(exc).__name__ != "XGBoostError":
-        raise
-    raise RuntimeError(
-        "xgboost is installed, but its native library could not be loaded. This "
-        "is commonly caused by a missing OpenMP runtime on macOS, which xgboost "
-        "and lightgbm require at runtime (it is not a CausalML dependency). "
-        "Install the runtime with `brew install libomp` (Homebrew) or "
-        "`conda install -c conda-forge llvm-openmp` (conda), then retry."
-    ) from exc
+except ValueError as exc:
+    from causalml.exceptions import handle_xgboost_error
+
+    handle_xgboost_error(exc)
 from scipy.stats import entropy
 import warnings
 

--- a/causalml/dataset/synthetic.py
+++ b/causalml/dataset/synthetic.py
@@ -10,6 +10,16 @@ try:
     from xgboost import XGBRegressor
 except ImportError:  # pragma: no cover
     XGBRegressor = None
+except ValueError as exc:  # pragma: no cover
+    if type(exc).__name__ != "XGBoostError":
+        raise
+    raise RuntimeError(
+        "xgboost is installed, but its native library could not be loaded. This "
+        "is commonly caused by a missing OpenMP runtime on macOS, which xgboost "
+        "and lightgbm require at runtime (it is not a CausalML dependency). "
+        "Install the runtime with `brew install libomp` (Homebrew) or "
+        "`conda install -c conda-forge llvm-openmp` (conda), then retry."
+    ) from exc
 from scipy.stats import entropy
 import warnings
 

--- a/causalml/exceptions.py
+++ b/causalml/exceptions.py
@@ -1,0 +1,10 @@
+def handle_xgboost_error(exc: Exception):
+    if type(exc).__name__ != "XGBoostError":
+        raise exc
+
+    raise RuntimeError(
+        "xgboost is installed, but its native library could not be loaded. "
+        "On macOS, this is commonly caused by a missing OpenMP runtime. "
+        "Install it with `brew install libomp` or "
+        "`conda install -c conda-forge llvm-openmp`, then retry."
+    ) from exc

--- a/causalml/inference/iv/drivlearner.py
+++ b/causalml/inference/iv/drivlearner.py
@@ -14,7 +14,13 @@ from causalml.propensity import compute_propensity_score
 from scipy.stats import norm
 from sklearn.model_selection import KFold
 from tqdm import tqdm
-from xgboost import XGBRegressor
+
+try:
+    from xgboost import XGBRegressor
+except ValueError as exc:
+    from causalml.exceptions import handle_xgboost_error
+
+    handle_xgboost_error(exc)
 
 from causalml.inference.serialization import SerializableLearner
 

--- a/causalml/inference/meta/drlearner.py
+++ b/causalml/inference/meta/drlearner.py
@@ -5,7 +5,13 @@ import pandas as pd
 from scipy.stats import norm
 from sklearn.model_selection import KFold
 from tqdm import tqdm
-from xgboost import XGBRegressor
+
+try:
+    from xgboost import XGBRegressor
+except ValueError as exc:
+    from causalml.exceptions import handle_xgboost_error
+
+    handle_xgboost_error(exc)
 
 from causalml.inference.meta.base import BaseLearner
 from causalml.inference.meta.utils import (

--- a/causalml/inference/meta/rlearner.py
+++ b/causalml/inference/meta/rlearner.py
@@ -4,7 +4,13 @@ import numpy as np
 from tqdm import tqdm
 from scipy.stats import norm
 from sklearn.model_selection import cross_val_predict, KFold, train_test_split
-from xgboost import XGBRegressor, XGBClassifier
+
+try:
+    from xgboost import XGBRegressor, XGBClassifier
+except ValueError as exc:
+    from causalml.exceptions import handle_xgboost_error
+
+    handle_xgboost_error(exc)
 
 from causalml.inference.meta.base import BaseLearner
 from causalml.inference.meta.utils import (

--- a/causalml/inference/meta/tlearner.py
+++ b/causalml/inference/meta/tlearner.py
@@ -12,7 +12,13 @@ if version.parse(sklearn.__version__) >= version.parse("0.22.0"):
 else:
     from sklearn.utils.testing import ignore_warnings
 from tqdm import tqdm
-from xgboost import XGBRegressor, XGBClassifier
+
+try:
+    from xgboost import XGBRegressor, XGBClassifier
+except ValueError as exc:
+    from causalml.exceptions import handle_xgboost_error
+
+    handle_xgboost_error(exc)
 
 from causalml.inference.meta.base import BaseLearner
 from causalml.inference.meta.utils import (

--- a/causalml/inference/meta/utils.py
+++ b/causalml/inference/meta/utils.py
@@ -2,7 +2,13 @@ import pandas as pd
 import numpy as np
 
 from packaging import version
-from xgboost import __version__ as xgboost_version
+
+try:
+    from xgboost import __version__ as xgboost_version
+except ValueError as exc:
+    from causalml.exceptions import handle_xgboost_error
+
+    handle_xgboost_error(exc)
 
 # ---------------------------------------------------------------------------
 # Optional Polars import

--- a/causalml/propensity.py
+++ b/causalml/propensity.py
@@ -6,7 +6,13 @@ from sklearn.metrics import roc_auc_score as auc
 from sklearn.linear_model import LogisticRegressionCV
 from sklearn.model_selection import StratifiedKFold, cross_val_predict, train_test_split
 from sklearn.isotonic import IsotonicRegression
-import xgboost as xgb
+
+try:
+    import xgboost as xgb
+except ValueError as exc:
+    from causalml.exceptions import handle_xgboost_error
+
+    handle_xgboost_error(exc)
 
 logger = logging.getLogger("causalml")
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -58,6 +58,12 @@ Deprecations
 
   By @jeongyoonlee in https://github.com/uber/causalml/pull/975
 
+Bug Fixes
+~~~~~~~~~
+* **macOS without the OpenMP runtime now reports an actionable error (#908).**
+  The installation guide now documents the required OpenMP runtime and
+  installation options.
+
 Release Schedule
 ~~~~~~~~~~~~~~~~
 Quarterly, targeting:

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -23,6 +23,22 @@ System Requirements
 
 **macOS and Windows:** All recent versions are supported.
 
+.. note::
+   On macOS, ``xgboost`` and ``lightgbm`` require the OpenMP runtime (``libomp``),
+   which is not included by default. Without it, importing CausalML modules that
+   use XGBoost can fail when the XGBoost native library cannot be loaded.
+   Install it via Homebrew:
+
+   .. code-block:: bash
+
+      brew install libomp
+
+   or via conda-forge:
+
+   .. code-block:: bash
+
+      conda install -c conda-forge llvm-openmp
+
 Install using ``conda``
 -----------------------
 


### PR DESCRIPTION
## Proposed changes

Fixes #908 

This PR improves the error message when XGBoost cannot load its native library because of a missing OpenMP/libomp runtime on macOS.

* Shows a clear error message with installation instructions.
* Adds the macOS OpenMP requirement to the documentation.
* Adds a changelog entry.
* Adds a test for the failure case.
* Keeps XGBoost and LightGBM as hard dependencies.

### Before

The error shows a confusing `XGBoostError`.

<img width="1580" height="872" alt="1" src="https://github.com/user-attachments/assets/5b9d1904-1bbd-4332-8fe7-c977ce1d3702" />


### After

<img width="1585" height="1165" alt="2" src="https://github.com/user-attachments/assets/601e1835-5370-42d2-8f45-199876636291" />
<img width="1627" height="977" alt="3" src="https://github.com/user-attachments/assets/05598f9f-7f39-4a84-aba2-c03349c03802" />

## Test

### In Windows
```powershell
$shim = "shim_xgboost"
New-Item -ItemType Directory -Force -ErrorAction SilentlyContinue $shim | Out-Null
Set-Content "$shim\xgboost.py" "class XGBoostError(ValueError): pass`nraise XGBoostError('XGBoost Library (libxgboost.dylib) could not be loaded.')"

$env:PYTHONPATH = "$PWD\$shim;$env:PYTHONPATH"

Write-Host "`n=== BEFORE - uber/causalml master (d7aa42d), macOS without libomp ===" -ForegroundColor Cyan
git checkout d7aa42d --quiet
python -c "from causalml.dataset import synthetic_data" 2>&1 | Out-String | Write-Host -ForegroundColor Red

Write-Host "`n=== AFTER - su-jin1425 fix/908-openmp-error (6f0cb58), same machine ===" -ForegroundColor Cyan
git checkout fix/908-openmp-error --quiet
python -c "from causalml.dataset import synthetic_data" 2>&1 | Out-String | Write-Host -ForegroundColor Green

Remove-Item -Recurse -Force $shim
$env:PYTHONPATH = ($env:PYTHONPATH -replace [regex]::Escape("$PWD\$shim;"), "")
```

### In Mac
```bash
shim="shim_xgboost"

mkdir -p "$shim"

cat > "$shim/xgboost.py" <<'EOF'
class XGBoostError(ValueError):
    pass

raise XGBoostError('XGBoost Library (libxgboost.dylib) could not be loaded.')
EOF

export PYTHONPATH="$PWD/$shim${PYTHONPATH:+:$PYTHONPATH}"

echo
echo "=== BEFORE - uber/causalml master (d7aa42d), simulated missing libomp ==="
git checkout d7aa42d --quiet
python -c "from causalml.dataset import synthetic_data" 2>&1

echo
echo "=== AFTER - su-jin1425 fix/908-openmp-error (6f0cb58), same simulation ==="
git checkout fix/908-openmp-error --quiet
python -c "from causalml.dataset import synthetic_data" 2>&1

rm -rf "$shim"
export PYTHONPATH="${PYTHONPATH#"$PWD/$shim:"}"
```

The original error is preserved as the cause, and unrelated errors are not hidden.

## Types of changes

* [x] Bugfix (non-breaking change)
* [ ] New feature
* [ ] Breaking change
* [x] Documentation Update

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/uber/causalml/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/uber/causalml)
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments

The full pytest suite could not be run because the local Windows environment is missing compiled Cython extensions. The specific failure was reproduced and validated using an XGBoost shim.