### PR TITLE
Compute the ATE standard error from its influence function (#1006)

### DIFF
--- a/causalml/inference/tree/causal/causaltree.py
+++ b/causalml/inference/tree/causal/causaltree.py
@@ -418,22 +418,72 @@ class CausalTreeRegressor(SerializableLearner, RegressorMixin, BaseCausalDecisio
         self, X: np.ndarray, treatment: np.ndarray, y: np.ndarray
     ) -> tuple:
         """Estimate the Average Treatment Effect (ATE).
+
         Args:
             X (np.ndarray): a feature matrix
             treatment (np.array): a treatment vector
             y (np.ndarray): an outcome vector
+
         Returns:
             tuple, The mean and confidence interval (LB, UB) of the ATE estimate.
         """
         dhat = self.fit_predict(X, treatment, y)
 
         te = dhat.mean()
-        se = dhat.std() / X.shape[0]
+        se = self._ate_standard_error(X=X, treatment=treatment, y=y)
 
         te_lb = te - se * norm.ppf(1 - self.alpha / 2)
         te_ub = te + se * norm.ppf(1 - self.alpha / 2)
 
         return te, te_lb, te_ub
+
+    def _ate_standard_error(
+        self, X: np.ndarray, treatment: np.ndarray, y: np.ndarray
+    ) -> float:
+        """Standard error of the ATE estimate, from its influence function.
+
+        The predicted effects alone describe how the effect varies across units, not
+        how much the sample mean of that effect would move on another draw, so their
+        spread is not a standard error of the ATE. The influence function adds what
+        the model got wrong on the observed outcomes::
+
+            psi_i = mean_g (yhat_g,i - yhat_0,i)
+                    + (y_i - yhat_g(i),i) / (share_g(i) * n_treatments)   if treated
+                    - (y_i - yhat_0,i) / share_0                          if control
+
+        A control unit enters every treatment group's contrast, so its residual is
+        not divided by the number of them. With one treatment group this is the
+        AIPW influence function, and its variance is the three-term expression the
+        meta-learners use (``BaseTLearner.estimate_ate``).
+
+        Args:
+            X (np.ndarray): a feature matrix
+            treatment (np.array): a treatment vector
+            y (np.ndarray): an outcome vector
+
+        Returns:
+            float, the standard error of the ATE estimate
+        """
+        n_groups = len(self._group2index)
+        yhat = np.atleast_2d(self.predict(X, with_outcomes=True))[:, :n_groups]
+        y = np.asarray(y, dtype=float).ravel()
+        group_idx = np.array([self._group2index[t] for t in treatment])
+
+        n_treatments = n_groups - 1
+        psi = (yhat[:, 1:] - yhat[:, [0]]).mean(axis=1)
+
+        share = np.bincount(group_idx, minlength=n_groups) / group_idx.size
+        is_control = group_idx == 0
+        psi[is_control] -= (y[is_control] - yhat[is_control, 0]) / share[0]
+        for group in range(1, n_groups):
+            in_group = group_idx == group
+            if not in_group.any():
+                continue
+            psi[in_group] += (y[in_group] - yhat[in_group, group]) / (
+                share[group] * n_treatments
+            )
+
+        return psi.std() / np.sqrt(psi.size)
 
     @timeit(exclude_kwargs=("X", "treatment", "y"))
     def bootstrap_pool(

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -91,6 +91,19 @@ New Features
 
 Bug Fixes
 ~~~~~~~~~
+* **`CausalTreeRegressor.estimate_ate` understated the standard error (#1006).** The
+  interval came from ``dhat.std() / n``, which divides by ``n`` rather than ``sqrt(n)``
+  and measures how the predicted effect varies across units instead of the sampling
+  variability of its mean. At a nominal 95% over 100 randomized-trial draws
+  (``n=1000``), the interval contained the true ATE 0 times.
+
+  It is now the standard error of the estimate's influence function, which adds the
+  model's residuals on the observed outcomes to the spread of the predicted effects —
+  the quantity ``BaseTLearner.estimate_ate`` already computes as a three-term
+  variance. Coverage on the same draws is 88%, the remainder being that ``estimate_ate``
+  fits and estimates on the same rows (#517). Point estimates are unchanged; only the
+  interval moves, and it is wider.
+
 * **`UpliftTreeClassifier.prune` left `_node_group_counts` stale (#1003).** ``prune()``
   replaced ``tree_`` without rebuilding the per-node group counts, which are indexed by
   node id and read by the uplift-score p-value and the plot's ``group_size``. The stale

--- a/tests/test_causal_trees.py
+++ b/tests/test_causal_trees.py
@@ -4,9 +4,11 @@ from abc import abstractmethod
 import numpy as np
 import pandas as pd
 import pytest
+from scipy.stats import norm
 from sklearn.base import clone
 from sklearn.model_selection import train_test_split
 
+from causalml.dataset import synthetic_data
 from causalml.inference.tree import CausalTreeRegressor, CausalRandomForestRegressor
 from causalml.metrics import ape
 from causalml.metrics import qini_score
@@ -1127,3 +1129,105 @@ def test_causal_tree_validation_does_not_raise_in_init():
 
     assert model.get_params()["estimation_sample_size"] == 0.0
     assert clone(model).get_params()["estimation_sample_size"] == 0.0
+
+
+def _ate_truth_data(seed, n=2000):
+    """Randomized-trial draw with the individual effects known."""
+    np.random.seed(seed)
+    y, X, w, tau, _, _ = synthetic_data(mode=2, n=n, p=5, sigma=1.0)
+    return X, w, y, tau
+
+
+def test_causal_tree_ate_standard_error_matches_the_meta_learner_formula():
+    """The interval's width is an influence-function standard error, not a spread.
+
+    `BaseTLearner.estimate_ate` computes the same quantity as a three-term
+    variance; the two agree to within a percent, the difference being cross terms
+    that vanish when the residuals are mean-zero. Asserting against it pins the
+    scale, which the previous `dhat.std() / n` missed by a factor of ~n / sqrt(n).
+    """
+    X, treatment, y, _ = _ate_truth_data(RANDOM_SEED)
+    model = CausalTreeRegressor(control_name=0, random_state=RANDOM_SEED).fit(
+        X=X, treatment=treatment, y=y
+    )
+
+    out = model.predict(X, with_outcomes=True)
+    yhat_c, yhat_t = out[:, 0], out[:, 1]
+    prob_treatment = (treatment == 1).mean()
+    expected = np.sqrt(
+        (
+            (y[treatment == 0] - yhat_c[treatment == 0]).var() / (1 - prob_treatment)
+            + (y[treatment == 1] - yhat_t[treatment == 1]).var() / prob_treatment
+            + (yhat_t - yhat_c).var()
+        )
+        / X.shape[0]
+    )
+
+    assert model._ate_standard_error(X=X, treatment=treatment, y=y) == pytest.approx(
+        expected, rel=0.05
+    )
+
+
+def test_causal_tree_ate_interval_narrows_with_sqrt_n():
+    """Quadrupling the sample halves the interval, rather than quartering it.
+
+    Dividing by `n` instead of `sqrt(n)` is invisible at a single sample size --
+    the interval is simply too narrow -- but shows up in how it scales.
+    """
+    widths = []
+    for n in (1000, 4000):
+        X, treatment, y, _ = _ate_truth_data(RANDOM_SEED, n=n)
+        _, lb, ub = CausalTreeRegressor(
+            control_name=0, random_state=RANDOM_SEED
+        ).estimate_ate(X=X, treatment=treatment, y=y)
+        widths.append(ub - lb)
+
+    assert widths[0] / widths[1] == pytest.approx(2.0, rel=0.25)
+
+
+def test_causal_tree_ate_interval_covers_the_truth():
+    """Coverage over repeated draws is the only thing that pins an interval.
+
+    A single fit cannot tell a correct interval from one 30x too narrow. Measured
+    88 of 100 seeds against a nominal 95%; the shortfall is `estimate_ate` fitting
+    and estimating on the same rows, which makes the residuals optimistic (#517).
+    The threshold is loose enough not to flake and far above the 0 of 20 the
+    previous formula gave.
+    """
+    covered = 0
+    for seed in range(20):
+        X, treatment, y, tau = _ate_truth_data(seed)
+        _, lb, ub = CausalTreeRegressor(control_name=0, random_state=seed).estimate_ate(
+            X=X, treatment=treatment, y=y
+        )
+        covered += lb <= tau.mean() <= ub
+
+    assert covered >= 14
+
+
+def test_causal_tree_ate_standard_error_tracks_the_spread_over_draws_multi_arm():
+    """With several treatment groups, the reported error must match the real one.
+
+    A standard error claims how far the estimate lands from the truth on a fresh
+    draw, so comparing it against that spread over repeated draws is what pins it.
+    Dividing the control residual by the number of treatment groups -- plausible,
+    since each group's contrast is averaged -- is invisible in the binary case and
+    passes every other test here; a control unit enters every contrast, so its
+    residual is not divided. That error takes this ratio from 0.89 to 0.69.
+    """
+    errors, standard_errors = [], []
+    z = norm.ppf(1 - 0.05 / 2)
+    for seed in range(40):
+        X, treatment, y = _make_heterogeneous_effect_data(
+            n=2000, seed=seed, n_treatments=2
+        )
+        truth = np.mean([g + X[:, 1] for g in (1, 2)])
+        te, lb, ub = CausalTreeRegressor(
+            control_name=0, random_state=seed
+        ).estimate_ate(X=X, treatment=treatment, y=y)
+
+        assert lb < te < ub
+        errors.append(te - truth)
+        standard_errors.append((ub - lb) / (2 * z))
+
+    assert 0.75 <= np.mean(standard_errors) / np.std(errors) <= 1.25


### PR DESCRIPTION
## Proposed changes

`CausalTreeRegressor.estimate_ate` reported a confidence interval far too narrow to be useful. Closes #1006.

The standard error was `dhat.std() / X.shape[0]`, which is wrong twice: the standard error of a mean divides by `sqrt(n)`, not `n`; and `dhat.std()` measures how the predicted effect varies **across units** — real heterogeneity — rather than how far the sample mean of that effect would land from the truth on another draw. The second point matters more: no outcome noise enters it at all, so the interval stays too narrow after fixing the first.

Point estimates do not change. Only the interval moves, and it gets wider.

## The replacement

The standard error now comes from the estimate's influence function, which adds what the model got wrong on the observed outcomes to the spread of the predicted effects:

```
psi_i = mean_g (yhat_g,i - yhat_0,i)
        + (y_i - yhat_g(i),i) / (share_g(i) * n_treatments)   if i is treated
        - (y_i - yhat_0,i) / share_0                          if i is control

se = std(psi) / sqrt(n)
```

With one treatment group this is the AIPW influence function, and its variance is the three-term expression [`BaseTLearner.estimate_ate`](https://github.com/uber/causalml/blob/master/causalml/inference/meta/tlearner.py#L361-L368) already computes. The two agree to within a percent across seeds — the difference is cross terms that vanish when residuals are mean-zero — so this brings the causal tree onto the convention the meta-learners already follow rather than inventing one.

A control unit enters **every** treatment group's contrast, so its residual is not divided by the number of them, while a treated unit's residual affects only its own.

## Measured

20 randomized-trial draws, `synthetic_data(mode=2, n=2000)` split in half, fitted on one half and estimated on the other (n=1000), nominal 95%. Coverage counts the seeds whose interval contains the true ATE, so 19 of 20 is the target:

| standard error | coverage | mean CI width |
| --- | --- | --- |
| `std(dhat) / n` (before) | 0/20 | 0.0033 |
| `std(dhat) / sqrt(n)` | 7/20 | 0.1026 |
| influence function (this PR) | 17/20 | 0.3923 |

Over 100 draws the shipped path covers 88%. The gap to 95% is that `estimate_ate` fits and estimates on the same rows, which makes the residuals optimistic — that is #517, and this PR does not change it.

## Tests

Four, in `tests/test_causal_trees.py`:

- the standard error matches the meta-learners' three-term formula on a binary design (`rel=0.05`);
- the interval narrows by `sqrt(4) = 2`, not 4, when the sample quadruples — the scaling error is invisible at a single sample size;
- coverage over 20 seeds is at least 14, against 0 before;
- with two treatment groups, the reported error tracks the spread of the estimate over 40 draws.

The last one exists because of a mutation that survived everything else: dividing the control residual by `n_treatments` is plausible — each group's contrast is averaged, after all — and is a no-op when there is one treatment group. It takes that ratio from 0.89 to 0.69.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/uber/causalml/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/uber/causalml)
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

The interval has been this way since v0.8.0 (2020-07-17); #522 moved the expression into the current file during the scikit-learn rewrite, so `git blame` points there rather than at the origin.

`CausalRandomForestRegressor` has no `estimate_ate` of its own and is unaffected. `causaltree.py:431` was the only occurrence of the pattern in the package.
