### PR TITLE
Add pretrain to CausalTreeRegressor and BaseDRIVLearner estimate_ate (#517)

### DIFF
--- a/causalml/inference/iv/drivlearner.py
+++ b/causalml/inference/iv/drivlearner.py
@@ -453,6 +453,7 @@ class BaseDRIVLearner(SerializableLearner):
         bootstrap_size=10000,
         seed=None,
         calibrate=True,
+        pretrain=False,
     ):
         """Estimate the Average Treatment Effect (ATE) for compliers.
 
@@ -474,19 +475,38 @@ class BaseDRIVLearner(SerializableLearner):
             n_bootstraps (int): number of bootstrap iterations
             bootstrap_size (int): number of samples per bootstrap
             seed (int): random seed for cross-fitting
+            pretrain (bool): whether a model has been fit, default False. When True
+                the fitted models are reused instead of being refit, so these rows
+                can be ones they never saw. ``p`` is required in that case: the
+                propensity :meth:`fit` stored belongs to the rows it was fit on, and
+                the standard error needs the propensity of the rows estimated here.
+                ``assignment`` and ``pZ`` are only used to fit, so they go unused.
         Returns:
             The mean and confidence interval (LB, UB) of the ATE estimate.
         """
-        te, yhat_cs, yhat_ts = self.fit_predict(
-            X,
-            assignment,
-            treatment,
-            y,
-            p,
-            return_components=True,
-            seed=seed,
-            calibrate=calibrate,
-        )
+        if pretrain:
+            if not hasattr(self, "t_groups"):
+                raise ValueError(
+                    "No fitted model found. Call fit() before estimate_ate(pretrain=True)."
+                )
+            if p is None:
+                raise ValueError(
+                    "estimate_ate(pretrain=True) requires p, the propensity of the rows "
+                    "passed here. The propensity stored by fit() belongs to the rows it "
+                    "was fit on, and the standard error indexes it by these rows."
+                )
+            te, yhat_cs, yhat_ts = self.predict(X, treatment, y, return_components=True)
+        else:
+            te, yhat_cs, yhat_ts = self.fit_predict(
+                X,
+                assignment,
+                treatment,
+                y,
+                p,
+                return_components=True,
+                seed=seed,
+                calibrate=calibrate,
+            )
         X, assignment, treatment, y = convert_pd_to_np(X, assignment, treatment, y)
 
         if p is None:

--- a/causalml/inference/tree/causal/causaltree.py
+++ b/causalml/inference/tree/causal/causaltree.py
@@ -415,7 +415,11 @@ class CausalTreeRegressor(SerializableLearner, RegressorMixin, BaseCausalDecisio
             return te
 
     def estimate_ate(
-        self, X: np.ndarray, treatment: np.ndarray, y: np.ndarray
+        self,
+        X: np.ndarray,
+        treatment: np.ndarray,
+        y: np.ndarray,
+        pretrain: bool = False,
     ) -> tuple:
         """Estimate the Average Treatment Effect (ATE).
 
@@ -423,11 +427,20 @@ class CausalTreeRegressor(SerializableLearner, RegressorMixin, BaseCausalDecisio
             X (np.ndarray): a feature matrix
             treatment (np.array): a treatment vector
             y (np.ndarray): an outcome vector
+            pretrain (bool): whether a model has been fit, default False. When True
+                the fitted tree is reused instead of being refit, so these rows can
+                be ones it never saw. The default refits on ``X`` and estimates from
+                the same rows, which leaves the estimate carrying whatever the tree
+                overfit.
 
         Returns:
             tuple, The mean and confidence interval (LB, UB) of the ATE estimate.
         """
-        dhat = self.fit_predict(X, treatment, y)
+        if pretrain:
+            check_is_fitted(self, "tree_")
+            dhat = self.predict(X)
+        else:
+            dhat = self.fit_predict(X, treatment, y)
 
         te = dhat.mean()
         se = self._ate_standard_error(X=X, treatment=treatment, y=y)
@@ -467,6 +480,13 @@ class CausalTreeRegressor(SerializableLearner, RegressorMixin, BaseCausalDecisio
         n_groups = len(self._group2index)
         yhat = np.atleast_2d(self.predict(X, with_outcomes=True))[:, :n_groups]
         y = np.asarray(y, dtype=float).ravel()
+
+        unknown = set(np.unique(treatment)) - set(self._group2index)
+        if unknown:
+            raise ValueError(
+                "treatment contains groups the model was not fit on: "
+                f"{sorted(str(group) for group in unknown)}"
+            )
         group_idx = np.array([self._group2index[t] for t in treatment])
 
         n_treatments = n_groups - 1

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -66,6 +66,22 @@ New Features
   ``ccp_alpha="cv"`` requires ``honesty=True`` and raises otherwise, since the
   cross-validation scores candidate subtrees with the honest objective.
 
+* **`CausalTreeRegressor.estimate_ate` and `BaseDRIVLearner.estimate_ate` accept**
+  ``pretrain`` **(#517).** ``pretrain=True`` estimates from the already-fitted model
+  instead of refitting on ``X``, so the rows passed in can be held out from the fit.
+  The default refits on the rows it then estimates from, which leaves the estimate
+  carrying whatever the model overfit. Fitting on half a randomized draw and
+  estimating on the other half gave a mean absolute ATE error of 0.099 against 0.114
+  in-sample, over 20 seeds on ``CausalTreeRegressor``.
+
+  This completes the parameter across the package: the meta-learners have had it
+  since #511. ``TMLELearner.estimate_ate`` is the remaining one without it and stays
+  that way, since the class has no ``fit`` and so no fitted model to reuse.
+
+  ``BaseDRIVLearner`` requires ``p`` when ``pretrain=True``: the propensity stored by
+  ``fit`` is indexed by the rows it was fit on, while the standard error indexes it by
+  the rows passed here. ``assignment`` and ``pZ`` are only used to fit and go unused.
+
 * **`UpliftTreeClassifier` can prune inside** ``fit`` **(#1003).** ``prune_fraction``
   (default ``None``, off) holds out that fraction of the rows stratified on
   (treatment, outcome), grows the tree on the rest, and runs the existing ``prune()``

--- a/tests/test_causal_trees.py
+++ b/tests/test_causal_trees.py
@@ -6,6 +6,8 @@ import pandas as pd
 import pytest
 from scipy.stats import norm
 from sklearn.base import clone
+from numpy.testing import assert_array_almost_equal
+from sklearn.exceptions import NotFittedError
 from sklearn.model_selection import train_test_split
 
 from causalml.dataset import synthetic_data
@@ -1231,3 +1233,60 @@ def test_causal_tree_ate_standard_error_tracks_the_spread_over_draws_multi_arm()
         standard_errors.append((ub - lb) / (2 * z))
 
     assert 0.75 <= np.mean(standard_errors) / np.std(errors) <= 1.25
+
+
+def test_causal_tree_estimate_ate_pretrain_reuses_the_fitted_tree():
+    """`pretrain=True` estimates from the fitted tree instead of refitting on X.
+
+    The default path refits on the rows it then estimates from, so the estimate
+    carries whatever the tree overfit; this is the fit-on-train, estimate-on-held-out
+    workflow #517 asks for. The tree is asserted untouched because a refit would be
+    invisible in the returned numbers alone.
+    """
+    X, treatment, y, tau = _ate_truth_data(RANDOM_SEED)
+    Xtr, Xva, wtr, wva, ytr, yva = train_test_split(
+        X, treatment, y, test_size=0.5, random_state=RANDOM_SEED
+    )
+    model = CausalTreeRegressor(control_name=0, random_state=RANDOM_SEED).fit(
+        X=Xtr, treatment=wtr, y=ytr
+    )
+    before, n_nodes = model.predict(Xva).copy(), model.tree_.node_count
+
+    te, lb, ub = model.estimate_ate(X=Xva, treatment=wva, y=yva, pretrain=True)
+
+    assert_array_almost_equal(model.predict(Xva), before)
+    assert model.tree_.node_count == n_nodes
+    assert lb < te < ub
+    assert te == pytest.approx(model.predict(Xva).mean())
+
+
+def test_causal_tree_estimate_ate_pretrain_matches_the_refit_on_the_same_rows():
+    """On the rows the model was just fit on, both paths give the same answer."""
+    X, treatment, y, _ = _ate_truth_data(RANDOM_SEED)
+    model = CausalTreeRegressor(control_name=0, random_state=RANDOM_SEED)
+
+    refit = model.estimate_ate(X=X, treatment=treatment, y=y)
+    pretrained = model.estimate_ate(X=X, treatment=treatment, y=y, pretrain=True)
+
+    assert refit == pretrained
+
+
+def test_causal_tree_estimate_ate_pretrain_requires_a_fitted_model():
+    """Without a fit there is nothing to reuse."""
+    X, treatment, y, _ = _ate_truth_data(RANDOM_SEED, n=200)
+
+    with pytest.raises(NotFittedError):
+        CausalTreeRegressor(control_name=0).estimate_ate(
+            X=X, treatment=treatment, y=y, pretrain=True
+        )
+
+
+def test_causal_tree_estimate_ate_rejects_unseen_treatment_groups():
+    """A group absent from the fit has no column to read, so say which one."""
+    X, treatment, y, _ = _ate_truth_data(RANDOM_SEED, n=500)
+    model = CausalTreeRegressor(control_name=0, random_state=RANDOM_SEED).fit(
+        X=X, treatment=treatment, y=y
+    )
+
+    with pytest.raises(ValueError, match="groups the model was not fit on"):
+        model.estimate_ate(X=X, treatment=np.full(X.shape[0], 9), y=y, pretrain=True)

--- a/tests/test_ivlearner.py
+++ b/tests/test_ivlearner.py
@@ -1,4 +1,5 @@
 import pandas as pd
+import pytest
 import numpy as np
 from sklearn.linear_model import LinearRegression
 from xgboost import XGBRegressor
@@ -80,3 +81,61 @@ def test_drivlearner():
         normalize=True,
     )
     assert auuc["cate_p"] > 0.5
+
+
+def _driv_data(n=1000, p=8, sigma=1.0):
+    """Compliance design with a known effect, matching `test_drivlearner`."""
+    np.random.seed(RANDOM_SEED)
+    X = np.random.uniform(size=n * p).reshape((n, -1))
+    b = (
+        np.sin(np.pi * X[:, 0] * X[:, 1])
+        + 2 * (X[:, 2] - 0.5) ** 2
+        + X[:, 3]
+        + 0.5 * X[:, 4]
+    )
+    assignment = (np.random.uniform(size=n) > 0.5).astype(int)
+    eta = 0.1
+    e_raw = np.maximum(
+        np.repeat(eta, n),
+        np.minimum(np.sin(np.pi * X[:, 0] * X[:, 1]), np.repeat(1 - eta, n)),
+    )
+    e = e_raw.copy()
+    e[assignment == 0] = 0
+    tau = (X[:, 0] + X[:, 1]) / 2
+    treatment = np.random.binomial(1, e, size=n)
+    y = b + (treatment - 0.5) * tau + sigma * np.random.normal(size=n)
+    return X, assignment, treatment, y, (np.ones(n) * 1e-6, e_raw)
+
+
+def test_drivlearner_estimate_ate_pretrain():
+    """`pretrain=True` estimates from the fitted models instead of refitting.
+
+    The propensity has to be passed: the one `fit` stored is indexed by the rows it
+    was fit on, and the standard error indexes `p` by the rows passed here, so
+    reusing it on held-out rows would silently read the wrong values.
+    """
+    X, assignment, treatment, y, p = _driv_data()
+    learner = BaseDRIVLearner(
+        learner=XGBRegressor(), treatment_effect_learner=LinearRegression()
+    )
+
+    refit = learner.estimate_ate(
+        X=X, assignment=assignment, treatment=treatment, y=y, p=p
+    )
+    pretrained = learner.estimate_ate(
+        X=X, assignment=assignment, treatment=treatment, y=y, p=p, pretrain=True
+    )
+
+    assert all(np.allclose(a, b) for a, b in zip(refit, pretrained))
+
+    with pytest.raises(ValueError, match="requires p"):
+        learner.estimate_ate(
+            X=X, assignment=assignment, treatment=treatment, y=y, pretrain=True
+        )
+
+    with pytest.raises(ValueError, match="No fitted model found"):
+        BaseDRIVLearner(
+            learner=XGBRegressor(), treatment_effect_learner=LinearRegression()
+        ).estimate_ate(
+            X=X, assignment=assignment, treatment=treatment, y=y, p=p, pretrain=True
+        )


### PR DESCRIPTION
## Proposed changes

`estimate_ate` refits on the rows it then estimates from, so the estimate carries whatever the model overfit on them. `pretrain=True` reuses the already-fitted model instead, which is the fit-on-train, estimate-on-held-out workflow #517 asks for. Closes #517.

```python
learner.fit(X=X_train, treatment=w_train, y=y_train)
ate, lb, ub = learner.estimate_ate(X=X_valid, treatment=w_valid, y=y_valid, pretrain=True)
```

The meta-learners have had this since #511. This adds it to the two classes that were missing it:

| | before | now |
| --- | --- | --- |
| 22 meta-learner classes | `pretrain` | unchanged |
| `CausalTreeRegressor.estimate_ate` | refit only | `pretrain` |
| `BaseDRIVLearner.estimate_ate` | refit only | `pretrain` |
| `TMLELearner.estimate_ate` | refit only | unchanged, see below |

`TMLELearner` stays without it: the class has no `fit`, so there is no fitted model to reuse. Those four were every `estimate_ate` in the package, enumerated from the classes rather than from a list.

On `CausalTreeRegressor`, fitting on half a randomized draw and estimating on the other half gives a mean absolute ATE error of **0.099 against 0.114** in-sample, over 20 seeds of `synthetic_data(mode=2, n=2000)`.

## `BaseDRIVLearner` requires `p` when `pretrain=True`

The standard error indexes `p` by the rows passed to `estimate_ate`, while the propensity `fit` stores is indexed by the rows it was fit on — and `fit` leaves it `None` when `p` was supplied. Passing held-out rows without `p` would therefore read the wrong propensity, or raise `TypeError: 'NoneType' object is not subscriptable` from inside the standard-error loop. It now raises with the reason instead.

`assignment` and `pZ` are only used to fit, so they go unused on this path.

## Details

`pretrain` goes last on both signatures: `estimate_ate` carries the #854 argument-order shim on all three classes, so a new parameter placed earlier would land inside the reordered block.

`CausalTreeRegressor.estimate_ate(pretrain=True)` on an unfitted model raises `NotFittedError`, and a treatment group absent from the fit now raises `ValueError` naming it — with `pretrain` the estimation rows can come from anywhere, so a group with no column in the fitted tree is reachable in a way it was not before.

## Tests

Five. Per class: `pretrain=True` matches the refit path on the rows the model was fit on (the convention `tests/test_meta_learners.py` already uses), and on held-out rows it leaves the fitted model untouched — predictions and `tree_.node_count` identical across the call, since a silent refit would not show up in the returned numbers. Plus the two guards on each class.

Mutation-checked: making `estimate_ate` ignore `pretrain` fails 3 of the causal-tree tests, and dropping the DRIV `p` guard fails its test with the `TypeError` described above.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/uber/causalml/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/uber/causalml)
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

Based on #1007, which fixes the causal tree's standard error, and targeted at that branch so the diff here is only the `pretrain` work. Without it `pretrain=True` would move an interval that covers the true ATE 0 times out of 20. Retarget to `master` once #1007 merges.
