### PR TITLE
Benchmark datasets, ground-truth metrics and a leaderboard (v1.0 M3)

### DIFF
--- a/causalml/dataset/__init__.py
+++ b/causalml/dataset/__init__.py
@@ -1,3 +1,5 @@
+from ._base import get_data_home, clear_data_dir
+from ._benchmarks import fetch_lalonde, fetch_ihdp, fetch_twins
 from .regression import synthetic_data
 from .regression import simulate_nuisance_and_easy_treatment
 from .regression import simulate_randomized_trial

--- a/causalml/dataset/_base.py
+++ b/causalml/dataset/_base.py
@@ -1,0 +1,128 @@
+"""Cache and download helpers shared by the ``fetch_*`` benchmark loaders.
+
+The benchmark datasets are fetched from their original sources at first use and
+cached on disk; none of them are redistributed with CausalML. See
+``docs/datasets.rst`` for where each one comes from and on what terms.
+"""
+
+import hashlib
+import logging
+import os
+import shutil
+from pathlib import Path
+from urllib.request import urlretrieve
+
+logger = logging.getLogger("causalml")
+
+DATA_HOME_ENV = "CAUSALML_DATA"
+DEFAULT_DATA_HOME = "~/causalml-data"
+_CHUNK = 1 << 20
+
+
+def get_data_home(data_home=None) -> Path:
+    """Return the directory the benchmark loaders cache datasets in.
+
+    Resolution order: the ``data_home`` argument, then the ``CAUSALML_DATA``
+    environment variable, then ``~/causalml-data``. The directory is created if
+    it does not exist.
+
+    Args:
+        data_home (str or Path, optional): an explicit cache directory
+
+    Returns:
+        pathlib.Path, the cache directory
+    """
+    if data_home is None:
+        data_home = os.environ.get(DATA_HOME_ENV, DEFAULT_DATA_HOME)
+    data_home = Path(data_home).expanduser()
+    data_home.mkdir(parents=True, exist_ok=True)
+    return data_home
+
+
+def clear_data_dir(data_home=None) -> None:
+    """Delete the cache directory, so a bad download can be recovered from.
+
+    Args:
+        data_home (str or Path, optional): an explicit cache directory
+    """
+    shutil.rmtree(get_data_home(data_home))
+
+
+def _sha256(path: Path) -> str:
+    """Return the SHA256 hex digest of a file, read in chunks."""
+    digest = hashlib.sha256()
+    with open(path, "rb") as f:
+        for chunk in iter(lambda: f.read(_CHUNK), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def fetch_remote(
+    url: str,
+    filename: str,
+    sha256: str,
+    data_home=None,
+    download_if_missing: bool = True,
+    dataset_name: str = "dataset",
+) -> Path:
+    """Return the local path to a cached dataset file, downloading it if needed.
+
+    The digest is verified on download and on every cache hit. A benchmark file
+    that has been truncated, replaced or served from a redirect page would
+    otherwise be read as data and reported as a result; the digest is what makes
+    that an error instead of a wrong number.
+
+    Args:
+        url (str): where to download the file from
+        filename (str): the name to cache it under
+        sha256 (str): the expected hex digest
+        data_home (str or Path, optional): an explicit cache directory
+        download_if_missing (bool): if False, raise instead of downloading
+        dataset_name (str): used in error messages
+
+    Returns:
+        pathlib.Path, the path to the verified local file
+
+    Raises:
+        OSError: if the file is absent and ``download_if_missing`` is False
+        OSError: if the digest does not match after downloading
+    """
+    path = get_data_home(data_home) / filename
+
+    if path.exists():
+        if _sha256(path) == sha256:
+            return path
+        logger.warning(
+            f"cached {dataset_name} at {path} does not match its expected digest; "
+            "re-downloading"
+        )
+        path.unlink()
+
+    if not download_if_missing:
+        raise OSError(
+            f"{dataset_name} is not cached at {path} and download_if_missing=False. "
+            f"Call with download_if_missing=True, or place the file there yourself "
+            f"(source: {url})."
+        )
+
+    logger.info(f"downloading {dataset_name} from {url}")
+    try:
+        urlretrieve(url, path)
+    except Exception as exc:
+        if path.exists():
+            path.unlink()
+        raise OSError(
+            f"failed to download {dataset_name} from {url}. The benchmark datasets "
+            f"are fetched from their original hosts, which do move; see "
+            f"docs/datasets.rst for the current source."
+        ) from exc
+
+    digest = _sha256(path)
+    if digest != sha256:
+        path.unlink()
+        raise OSError(
+            f"{dataset_name} downloaded from {url} has SHA256 {digest}, expected "
+            f"{sha256}. The file at that URL has changed, so it is not the version "
+            f"these results were produced with."
+        )
+    return path

--- a/causalml/dataset/_benchmarks.py
+++ b/causalml/dataset/_benchmarks.py
@@ -1,0 +1,253 @@
+"""Loaders for the standard causal-inference benchmark datasets.
+
+Each dataset is downloaded from its original source at first use and cached; none
+is redistributed with CausalML. ``docs/datasets.rst`` records where each comes
+from, on what terms, and which of the benchmarks are not shipped here.
+
+Which metrics apply depends on how the data was made:
+
+- ``fetch_ihdp`` and ``fetch_twins`` carry per-unit ground truth, so
+  :func:`causalml.metrics.pehe` and :func:`causalml.metrics.ate_error` are defined.
+- ``fetch_lalonde`` is a randomized experiment with no per-unit ground truth; its
+  experimental ATE is the yardstick, so only :func:`causalml.metrics.ate_error`
+  against that number applies.
+"""
+
+import numpy as np
+import pandas as pd
+from sklearn.utils import Bunch
+
+from ._base import fetch_remote
+
+# Pinned to a commit rather than a branch, so the digest below stays valid.
+LALONDE_URL = (
+    "https://raw.githubusercontent.com/NickCH-K/causaldata/"
+    "94e0c05b394597b65fd7b3722b3fbd62f7a6c113/Python/causaldata/nsw_mixtape/"
+    "nsw_mixtape.dta"
+)
+LALONDE_SHA256 = "e4a64e4436c2c178f47d6c82a371d20f1596b82b44862ce24bf13c71ac797339"
+
+IHDP_URLS = {
+    "train": "https://www.fredjo.com/files/ihdp_npci_1-100.train.npz",
+    "test": "https://www.fredjo.com/files/ihdp_npci_1-100.test.npz",
+}
+IHDP_SHA256 = {
+    "train": "750697c71b4f8d7a3aafff771b56a4ac4cd83ec649bf69afb04f8a5aee41a240",
+    "test": "a70a8acbcc4e8deb677cc9bf9e9dabeb17caaa37cdbb1d7ba06be7ffb929c41c",
+}
+IHDP_N_REPLICATIONS = 100
+
+TWINS_URL = (
+    "https://bitbucket.org/mvdschaar/mlforhealthlabpub/raw/"
+    "0b0190bcd38a76c405c805f1ca774971fcd85233/data/twins/Twin_Data.csv.gz"
+)
+TWINS_SHA256 = "0128e5dfdeb468e85fd2818330beff49d4d433b7f7d56d3eb678f87ab15b00a9"
+# The outcome columns hold days survived, with 9999 standing for "did not die
+# within the year". Read as a number the column means nothing; read as this
+# indicator it reproduces the 17.7% mortality Louizos et al. (2017) report.
+TWINS_SURVIVED = 9999
+
+
+def _return(bunch: Bunch, return_X_y_t: bool):
+    """Return the Bunch, or the (X, y, treatment) triple callers usually want."""
+    if return_X_y_t:
+        return bunch.data, bunch.target, bunch.treatment
+    return bunch
+
+
+def fetch_lalonde(data_home=None, download_if_missing=True, return_X_y_t=False):
+    """Load the LaLonde National Supported Work experiment.
+
+    A randomized job-training experiment: 445 rows, 185 treated, outcome ``re78``
+    (1978 earnings in dollars). Its experimental estimate is the yardstick
+    observational estimators are judged against (LaLonde 1986; Dehejia and Wahba
+    1999). The sample here is the Dehejia-Wahba one, taken from the MIT-licensed
+    ``causaldata`` package at a pinned revision.
+
+    There is no per-unit ground truth, so PEHE is not defined on it. The
+    experimental difference in means, about 1794 dollars, is what an estimate is
+    compared against.
+
+    Args:
+        data_home (str or Path, optional): cache directory
+        download_if_missing (bool): if False, raise rather than download
+        return_X_y_t (bool): return ``(X, y, treatment)`` instead of a Bunch
+
+    Returns:
+        sklearn.utils.Bunch with ``data``, ``target``, ``treatment``,
+        ``feature_names`` and ``DESCR``; or the triple if ``return_X_y_t``
+    """
+    path = fetch_remote(
+        url=LALONDE_URL,
+        filename="lalonde_nsw_mixtape.dta",
+        sha256=LALONDE_SHA256,
+        data_home=data_home,
+        download_if_missing=download_if_missing,
+        dataset_name="LaLonde NSW",
+    )
+    df = pd.read_stata(path)
+    feature_names = ["age", "educ", "black", "hisp", "marr", "nodegree", "re74", "re75"]
+
+    return _return(
+        Bunch(
+            data=df[feature_names].to_numpy(dtype=float),
+            target=df["re78"].to_numpy(dtype=float),
+            treatment=df["treat"].to_numpy(dtype=int),
+            feature_names=feature_names,
+            frame=df,
+            DESCR=fetch_lalonde.__doc__,
+        ),
+        return_X_y_t,
+    )
+
+
+def fetch_ihdp(
+    replication=0,
+    split="train",
+    data_home=None,
+    download_if_missing=True,
+    return_X_y_t=False,
+):
+    """Load one replication of the IHDP benchmark.
+
+    Covariates from the Infant Health and Development Program randomized trial,
+    with outcomes simulated on response surface B (Hill 2011). The file holds 100
+    replications of the same 747-unit sample: each one simulates its own outcomes
+    **and draws its own 672 / 75 train-test split**, so row ``i`` is a different
+    unit in each replication and the number of treated rows varies with it. Only
+    the pooled 747 covariate rows are common to all of them.
+
+    Results on IHDP are reported as a mean and standard error **across**
+    replications, so ``replication`` selects one and the caller loops. A single
+    replication is not comparable to a published IHDP number.
+
+    Both potential outcome surfaces are returned, so the individual effect
+    ``tau = mu1 - mu0`` is known and PEHE is defined.
+
+    Args:
+        replication (int): which replication to load, 0 to 99
+        split (str): ``"train"`` (672 rows) or ``"test"`` (75 rows)
+        data_home (str or Path, optional): cache directory
+        download_if_missing (bool): if False, raise rather than download
+        return_X_y_t (bool): return ``(X, y, treatment)`` instead of a Bunch
+
+    Returns:
+        sklearn.utils.Bunch with ``data``, ``target`` (the factual outcome),
+        ``treatment``, ``tau``, ``mu0``, ``mu1``, ``y_cf``, ``feature_names`` and
+        ``DESCR``; or the triple if ``return_X_y_t``
+
+    Raises:
+        ValueError: if ``split`` is not train/test or ``replication`` is out of range
+    """
+    if split not in IHDP_URLS:
+        raise ValueError(f"split must be 'train' or 'test', got {split!r}")
+    if not 0 <= replication < IHDP_N_REPLICATIONS:
+        raise ValueError(
+            f"replication must be in [0, {IHDP_N_REPLICATIONS}), got {replication!r}"
+        )
+
+    path = fetch_remote(
+        url=IHDP_URLS[split],
+        filename=f"ihdp_npci_1-100.{split}.npz",
+        sha256=IHDP_SHA256[split],
+        data_home=data_home,
+        download_if_missing=download_if_missing,
+        dataset_name=f"IHDP ({split})",
+    )
+    with np.load(path) as npz:
+        # every array indexes the replication on its last axis
+        x = npz["x"][:, :, replication]
+        t = npz["t"][:, replication]
+        yf = npz["yf"][:, replication]
+        ycf = npz["ycf"][:, replication]
+        mu0 = npz["mu0"][:, replication]
+        mu1 = npz["mu1"][:, replication]
+
+    return _return(
+        Bunch(
+            data=x.astype(float),
+            target=yf.astype(float),
+            treatment=t.astype(int),
+            tau=(mu1 - mu0).astype(float),
+            mu0=mu0.astype(float),
+            mu1=mu1.astype(float),
+            y_cf=ycf.astype(float),
+            feature_names=[f"x{i}" for i in range(x.shape[1])],
+            replication=replication,
+            DESCR=fetch_ihdp.__doc__,
+        ),
+        return_X_y_t,
+    )
+
+
+def fetch_twins(
+    data_home=None,
+    download_if_missing=True,
+    return_X_y_t=False,
+    random_state=None,
+):
+    """Load the Twins benchmark.
+
+    Same-sex twin births from the NBER linked birth / infant death records, 11400
+    pairs and 30 covariates. Treatment is being the heavier twin and the outcome
+    is one-year mortality. Because both twins are observed, **both potential
+    outcomes are measured rather than simulated** — the only dataset here where
+    the ground truth is not a modelling assumption. Introduced as a causal
+    benchmark by Louizos et al. (2017).
+
+    The raw outcome columns hold days survived with 9999 standing for "survived
+    the year", so mortality is ``outcome < 9999``. That reproduces the 17.7%
+    mortality for the lighter twin reported in the paper; reading the column as a
+    number instead gives a mean near 8000 and no meaning.
+
+    One twin per pair is revealed, which makes this an observational dataset. The
+    assignment here is **randomized** (a fair coin per pair), so the design is an
+    RCT with known counterfactuals. The confounded variants in the literature
+    assign treatment from a covariate, and they differ between papers; both
+    potential outcomes are returned so a caller can build their own and say which.
+
+    Args:
+        data_home (str or Path, optional): cache directory
+        download_if_missing (bool): if False, raise rather than download
+        return_X_y_t (bool): return ``(X, y, treatment)`` instead of a Bunch
+        random_state (int or np.random.RandomState, optional): seeds which twin
+            of each pair is revealed
+
+    Returns:
+        sklearn.utils.Bunch with ``data``, ``target`` (the revealed twin's
+        mortality), ``treatment``, ``tau``, ``y0``, ``y1``, ``feature_names`` and
+        ``DESCR``; or the triple if ``return_X_y_t``
+    """
+    path = fetch_remote(
+        url=TWINS_URL,
+        filename="twins.csv.gz",
+        sha256=TWINS_SHA256,
+        data_home=data_home,
+        download_if_missing=download_if_missing,
+        dataset_name="Twins",
+    )
+    df = pd.read_csv(path)
+    # the shipped header quotes every name, and the outcome columns close with a
+    # typographic apostrophe rather than the one they open with
+    df.columns = [c.strip().strip("'’") for c in df.columns]
+
+    y0 = (df["outcome(t=0)"].to_numpy() < TWINS_SURVIVED).astype(int)
+    y1 = (df["outcome(t=1)"].to_numpy() < TWINS_SURVIVED).astype(int)
+    feature_names = [c for c in df.columns if not c.startswith("outcome(")]
+
+    rng = np.random.RandomState(random_state) if random_state is not None else np.random
+    treatment = rng.binomial(1, 0.5, size=len(df)).astype(int)
+
+    return _return(
+        Bunch(
+            data=df[feature_names].to_numpy(dtype=float),
+            target=np.where(treatment == 1, y1, y0),
+            treatment=treatment,
+            tau=(y1 - y0).astype(float),
+            y0=y0,
+            y1=y1,
+            feature_names=feature_names,
+            DESCR=fetch_twins.__doc__,
+        ),
+        return_X_y_t,
+    )

--- a/causalml/metrics/__init__.py
+++ b/causalml/metrics/__init__.py
@@ -1,3 +1,4 @@
+from .ground_truth import pehe, ate_error, policy_risk  # noqa
 from .classification import roc_auc_score, logloss, classification_metrics  # noqa
 from .regression import (
     ape,

--- a/causalml/metrics/ground_truth.py
+++ b/causalml/metrics/ground_truth.py
@@ -1,0 +1,123 @@
+"""Metrics that score a CATE estimate against a known ground truth.
+
+The rest of :mod:`causalml.metrics` scores how well a model *ranks* units — AUUC,
+Qini, RATE — because on real data the individual effect is never observed. Where
+it is observed, by simulation or by a design like Twins where both twins are seen,
+these compare the estimate against it directly.
+
+Each one names what it needs, and none of them can be computed on ordinary
+observational data:
+
+- :func:`pehe` and :func:`ate_error` need the per-unit effect ``tau``.
+- :func:`policy_risk` needs randomized treatment.
+"""
+
+import numpy as np
+
+__all__ = ["pehe", "ate_error", "policy_risk"]
+
+
+def pehe(tau, tau_hat, squared=True):
+    """Precision in estimating heterogeneous effects (Hill, 2011).
+
+    The mean squared error of the individual treatment effect::
+
+        PEHE = mean((tau_hat - tau) ** 2)
+
+    Papers report both this and its square root; the root is on the same scale as
+    the effect itself, which makes it the easier one to read.
+
+    Only defined where ``tau`` is known per unit, which means simulated or
+    semi-synthetic data. Computing it against another model's predictions
+    measures agreement between two models, not accuracy.
+
+    Args:
+        tau (np.ndarray): the true individual treatment effect
+        tau_hat (np.ndarray): the estimated individual treatment effect
+        squared (bool): if False, return the root
+
+    Returns:
+        float, the (root) mean squared error of the individual effect
+    """
+    tau, tau_hat = np.asarray(tau).ravel(), np.asarray(tau_hat).ravel()
+    if tau.shape != tau_hat.shape:
+        raise ValueError(
+            f"tau and tau_hat must have the same length, got {tau.shape} and "
+            f"{tau_hat.shape}"
+        )
+    error = np.mean((tau_hat - tau) ** 2)
+    return float(error if squared else np.sqrt(error))
+
+
+def ate_error(tau, tau_hat):
+    """Absolute error in the average treatment effect, usually written eps_ATE.
+
+    ``abs(mean(tau_hat) - mean(tau))``. A model can order units well and still be
+    biased on the average, and vice versa, so this is not implied by PEHE or by
+    AUUC.
+
+    On an experiment with no per-unit ground truth, pass the experimental
+    estimate as ``tau``: the comparison is then against the number the experiment
+    licenses rather than against a per-unit truth that does not exist.
+
+    Args:
+        tau (np.ndarray or float): the true individual effects, or the true ATE
+        tau_hat (np.ndarray or float): the estimated individual effects, or the
+            estimated ATE
+
+    Returns:
+        float, the absolute difference of the two averages
+    """
+    return float(abs(np.mean(tau_hat) - np.mean(tau)))
+
+
+def policy_risk(y, treatment, tau_hat, control_name=0):
+    """Expected loss of the treat-if-``tau_hat``-is-positive policy.
+
+    Following Shalit, Johansson and Sontag (2017)::
+
+        R_pol = 1 - (E[Y(1) | pi = 1] P(pi = 1) + E[Y(0) | pi = 0] P(pi = 0))
+
+    where ``pi`` treats a unit when its estimated effect is positive. Each
+    conditional expectation is estimated from the units that were actually
+    assigned that way, which is why the treatment has to be **randomized**: on
+    observational data those subgroups differ for reasons the policy did not
+    choose, and the number stops describing the policy.
+
+    The outcome is assumed to be a benefit in [0, 1], as employment is on Jobs.
+    For a cost, or a scale other than [0, 1], the complement to 1 is not
+    meaningful and the policy value itself is the quantity to report.
+
+    Args:
+        y (np.ndarray): the observed outcome
+        treatment (np.ndarray): the treatment assignment
+        tau_hat (np.ndarray): the estimated individual treatment effect
+        control_name: the value of ``treatment`` marking a control unit
+
+    Returns:
+        float, one minus the value of the policy
+
+    Raises:
+        ValueError: if either arm of the policy has no units to estimate from
+    """
+    y, treatment, tau_hat = (
+        np.asarray(y).ravel(),
+        np.asarray(treatment).ravel(),
+        np.asarray(tau_hat).ravel(),
+    )
+    treat = tau_hat > 0
+    is_control = treatment == control_name
+
+    treated_and_recommended = treat & ~is_control
+    control_and_not_recommended = ~treat & is_control
+    if not treated_and_recommended.any() or not control_and_not_recommended.any():
+        raise ValueError(
+            "policy_risk needs units assigned the way the policy recommends in "
+            "both arms; one of them is empty, so its outcome cannot be estimated"
+        )
+
+    p_treat = treat.mean()
+    value = y[treated_and_recommended].mean() * p_treat + y[
+        control_and_not_recommended
+    ].mean() * (1 - p_treat)
+    return float(1 - value)

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -10,6 +10,26 @@ Unreleased
 
 New Features
 ~~~~~~~~~~~~
+* **Benchmark dataset loaders and ground-truth metrics (v1.0 M3).** ``fetch_lalonde``,
+  ``fetch_ihdp`` and ``fetch_twins`` download a benchmark from its original source on
+  first use and cache it under ``~/causalml-data`` (``CAUSALML_DATA`` overrides), with
+  SHA256 verification so a file that has moved or been truncated raises instead of
+  being parsed as data. ``download_if_missing=False`` stays offline, and
+  ``clear_data_dir()`` empties the cache. None of the datasets are redistributed with
+  CausalML; :doc:`datasets` records where each comes from and on what terms, including
+  the four benchmarks that are documented rather than shipped.
+
+  ``causalml.metrics`` gains the three metrics that need a known truth: ``pehe``
+  (Hill's precision in estimating heterogeneous effects, with ``squared=False`` for the
+  root), ``ate_error`` for the absolute error in the average effect, and
+  ``policy_risk`` for the expected loss of the treat-if-positive policy on randomized
+  data. Each docstring names what it requires — the ranking metrics stay the only ones
+  computable on ordinary observational data.
+
+  ``docs/examples/benchmark_leaderboard.ipynb`` is the leaderboard itself: running it
+  end to end regenerates every published number. It reports three tables rather than
+  one, because what is measurable is a property of how each dataset was made.
+
 * **`CausalTreeRegressor` and `CausalRandomForestRegressor` accept** ``ccp_alpha="cv"``
   **(#584).** ``honesty=True`` supplies held-out leaf estimation; this setting adds the
   two remaining pieces of :cite:`athey2016recursive`. The splitting objective's variance penalty is scaled by

--- a/docs/datasets.rst
+++ b/docs/datasets.rst
@@ -1,0 +1,149 @@
+==================
+Benchmark Datasets
+==================
+
+CausalML ships loaders for three standard causal-inference benchmarks. Each is
+downloaded from its original source the first time it is used and cached on disk;
+none is redistributed with the package.
+
+.. code-block:: python
+
+    from causalml.dataset import fetch_lalonde, fetch_ihdp, fetch_twins
+
+    lalonde = fetch_lalonde()                       # Bunch
+    X, y, treatment = fetch_ihdp(replication=0, return_X_y_t=True)
+
+Files are cached in ``~/causalml-data``, overridable with the ``CAUSALML_DATA``
+environment variable or the ``data_home`` argument. Every download is verified
+against a SHA256 digest, so a file that has been replaced or truncated raises
+instead of being parsed as data. ``download_if_missing=False`` refuses to reach
+the network, and ``causalml.dataset.clear_data_dir()`` empties the cache.
+
+Which metric applies to which dataset
+=====================================
+
+What can be measured is a property of how the data was made, not a choice:
+
+.. list-table::
+   :header-rows: 1
+
+   * - Dataset
+     - Ground truth
+     - Metrics that apply
+   * - ``synthetic_data``, ``make_uplift_classification``
+     - simulated per-unit ``tau``
+     - :func:`~causalml.metrics.pehe`, :func:`~causalml.metrics.ate_error`
+   * - IHDP
+     - simulated ``mu0`` / ``mu1``
+     - :func:`~causalml.metrics.pehe`, :func:`~causalml.metrics.ate_error`
+   * - Twins
+     - both twins observed
+     - :func:`~causalml.metrics.pehe`, :func:`~causalml.metrics.ate_error`
+   * - LaLonde
+     - experimental ATE only
+     - :func:`~causalml.metrics.ate_error` against that estimate
+   * - Criteo, Hillstrom
+     - none
+     - AUUC, Qini, RATE
+
+PEHE is only computable where the counterfactual was constructed. A ranking of
+estimators on simulated outcomes is a statement about that simulation.
+
+Datasets with a loader
+======================
+
+LaLonde (National Supported Work)
+---------------------------------
+
+A randomized job-training experiment: 445 rows, 185 treated, outcome ``re78``
+(1978 earnings in dollars). Its experimental difference in means, about $1,794,
+is the yardstick observational estimators are judged against
+:cite:`lalonde1986evaluating`. The sample is the Dehejia-Wahba one
+:cite:`dehejia1999causal`.
+
+Source: the `causaldata <https://pypi.org/project/causaldata/>`_ package (MIT),
+read at a pinned revision.
+
+IHDP
+----
+
+Covariates from the Infant Health and Development Program randomized trial with
+outcomes simulated on response surface B :cite:`hill2011bayesian`. The file holds
+100 replications of the same 747 units. Each replication simulates its own
+outcomes **and draws its own 672 / 75 train-test split**, so row ``i`` is a
+different unit in each one and the treated count varies with it.
+
+Results on IHDP are reported as a mean and standard error across replications::
+
+    scores = [pehe(fetch_ihdp(replication=r).tau, predict(r)) for r in range(100)]
+
+A single replication is not comparable to a published IHDP number.
+
+Source: the `clinicalml/cfrnet <https://github.com/clinicalml/cfrnet>`_ lineage
+(MIT), files hosted at ``fredjo.com``.
+
+Twins
+-----
+
+Same-sex twin births from the NBER linked birth / infant death records: 11,400
+pairs, 30 covariates. Treatment is being the heavier twin and the outcome is
+one-year mortality. Because both twins are observed, **both potential outcomes
+are measured rather than simulated** — the only dataset here whose ground truth
+is not a modelling assumption :cite:`louizos2017causal`.
+
+Two things to know before using it. The raw outcome columns hold days survived
+with ``9999`` standing for "survived the year", so mortality is
+``outcome < 9999``; read as a number instead, the column averages about 8,000 and
+means nothing. And revealing one twin per pair is what makes this observational —
+``fetch_twins`` assigns at random, giving a trial with known counterfactuals,
+while the confounded variants in the literature assign from a covariate and
+differ between papers. Both potential outcomes are returned as ``y0`` and ``y1``
+so a caller can construct their own and say which.
+
+Source: NBER linked birth / infant death data (US federal, public domain), via
+the van der Schaar lab mirror at a pinned revision.
+
+Datasets without a loader
+=========================
+
+The remaining benchmarks named in the v1.0 roadmap are not shipped. The rule the
+loaders follow is to ship one where the source carries an explicit permissive
+license or is public-domain government data, fetch it at runtime, and never
+vendor or mirror it. These do not meet that bar today:
+
+.. list-table::
+   :header-rows: 1
+
+   * - Dataset
+     - Source
+     - Status
+   * - ACIC (2016-2019 competitions)
+     - `vdorie/aciccomp <https://github.com/vdorie/aciccomp>`_
+     - No license file. Available through the R packages in that repository.
+   * - Jobs
+     - LaLonde lineage, distributed with the Shalit et al. code
+     - No license file. The experimental subset overlaps ``fetch_lalonde``.
+   * - Criteo-Uplift
+     - `Criteo AI Lab <https://ailab.criteo.com/criteo-uplift-prediction-dataset/>`_
+     - Non-commercial license. ``scikit-uplift`` ships ``fetch_criteo``.
+   * - Hillstrom
+     - `MineThatData <https://blog.minethatdata.com/2008/03/minethatdata-e-mail-analytics-and-data.html>`_
+     - No license file. ``scikit-uplift`` ships ``fetch_hillstrom``.
+
+No license is not the same as no permission, and these files have been
+redistributed in the literature for years. It does mean CausalML does not
+redistribute them. For Criteo and Hillstrom,
+`scikit-uplift <https://github.com/maks-sh/scikit-uplift>`_ provides loaders.
+
+Loading one yourself takes the same shape as the built-in loaders:
+
+.. code-block:: python
+
+    import pandas as pd
+
+    df = pd.read_csv("your_download.csv")
+    X = df[feature_columns].to_numpy()
+    y = df["outcome"].to_numpy()
+    treatment = df["treatment"].to_numpy()
+
+    learner.fit(X=X, treatment=treatment, y=y)

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -34,3 +34,4 @@ Follow the below links for an approximate ordering of example tutorials from int
     examples/qini_curves_for_costly_treatment_arms
     examples/calibration
     examples/benchmark_semi_synthetic_simulation_studies
+    examples/benchmark_leaderboard

--- a/docs/examples/benchmark_leaderboard.ipynb
+++ b/docs/examples/benchmark_leaderboard.ipynb
@@ -1,0 +1,580 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "a624e511",
+   "metadata": {},
+   "source": [
+    "# Benchmark Leaderboard\n",
+    "\n",
+    "This notebook **is** the leaderboard: every number the docs publish is produced by\n",
+    "running it end to end, so the table cannot drift from something nobody can\n",
+    "reproduce.\n",
+    "\n",
+    "The estimators are scored on three families of data, and the family decides which\n",
+    "metric exists:\n",
+    "\n",
+    "| family | ground truth | metrics |\n",
+    "| --- | --- | --- |\n",
+    "| simulated (`synthetic_data`) | per-unit `tau` | PEHE, root PEHE, `ate_error` |\n",
+    "| semi-synthetic (IHDP) | simulated `mu0` / `mu1` | PEHE, root PEHE, `ate_error` |\n",
+    "| experiment (LaLonde) | experimental ATE only | `ate_error` against that estimate |\n",
+    "\n",
+    "A ranking on simulated outcomes is a statement about that simulation, not about\n",
+    "which estimator is best on your data. The point of the table is to make the\n",
+    "comparison reproducible, not to crown a winner.\n",
+    "\n",
+    "The simulated section needs no download. The IHDP and LaLonde sections fetch from\n",
+    "their original sources and skip themselves cleanly when that is unavailable — see\n",
+    "[Benchmark Datasets](../datasets.rst) for where each comes from."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "101dcbe7",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-14T07:04:29.092944Z",
+     "iopub.status.busy": "2026-08-14T07:04:29.092843Z",
+     "iopub.status.idle": "2026-08-14T07:04:31.426091Z",
+     "shell.execute_reply": "2026-08-14T07:04:31.425774Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/jeong/dev/causalml/.venv/lib/python3.12/site-packages/tqdm/auto.py:21: TqdmWarning: IProgress not found. Please update jupyter and ipywidgets. See https://ipywidgets.readthedocs.io/en/stable/user_install.html\n",
+      "  from .autonotebook import tqdm as notebook_tqdm\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Failed to import duecredit due to No module named 'duecredit'\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "causalml 0.17.0\n"
+     ]
+    }
+   ],
+   "source": [
+    "import warnings\n",
+    "\n",
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "from sklearn.linear_model import LinearRegression\n",
+    "from sklearn.model_selection import train_test_split\n",
+    "from xgboost import XGBRegressor\n",
+    "\n",
+    "from importlib.metadata import version\n",
+    "\n",
+    "from causalml.dataset import fetch_ihdp, fetch_lalonde, synthetic_data\n",
+    "from causalml.inference.meta import BaseSRegressor, BaseTRegressor, BaseXRegressor\n",
+    "from causalml.inference.tree import CausalTreeRegressor\n",
+    "from causalml.metrics import ate_error, pehe\n",
+    "\n",
+    "warnings.filterwarnings(\"ignore\")\n",
+    "\n",
+    "SEED = 42\n",
+    "print(\"causalml\", version(\"causalml\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d0172283",
+   "metadata": {},
+   "source": [
+    "## The estimators\n",
+    "\n",
+    "One representative of each family, all with the same base learner so the\n",
+    "comparison is between the meta-learner designs rather than between boosting\n",
+    "configurations. `CausalTreeRegressor` is included as the tree-based contrast."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "1f578189",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-14T07:04:31.427781Z",
+     "iopub.status.busy": "2026-08-14T07:04:31.427575Z",
+     "iopub.status.idle": "2026-08-14T07:04:31.430646Z",
+     "shell.execute_reply": "2026-08-14T07:04:31.430373Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "def make_learners(seed=SEED):\n",
+    "    \"\"\"A fresh, unfitted estimator per name -- fitted models must not be reused.\"\"\"\n",
+    "    base = lambda: XGBRegressor(n_estimators=100, max_depth=3, random_state=seed, verbosity=0)\n",
+    "    return {\n",
+    "        \"S-learner\": BaseSRegressor(learner=base()),\n",
+    "        \"T-learner\": BaseTRegressor(learner=base()),\n",
+    "        \"X-learner\": BaseXRegressor(learner=base()),\n",
+    "        \"Causal tree\": CausalTreeRegressor(control_name=0, random_state=seed),\n",
+    "    }\n",
+    "\n",
+    "\n",
+    "def cate(learner, X_train, t_train, y_train, X_test):\n",
+    "    \"\"\"Fit on the training rows and predict the effect on held-out rows.\"\"\"\n",
+    "    learner.fit(X=X_train, treatment=t_train, y=y_train)\n",
+    "    return np.asarray(learner.predict(X_test)).ravel()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1f5f49d8",
+   "metadata": {},
+   "source": [
+    "## Simulated data\n",
+    "\n",
+    "`synthetic_data` returns the individual effect `tau`, so PEHE is defined. Every\n",
+    "estimator is fitted on half the draw and scored on the other half, over several\n",
+    "seeds, and the table reports the mean."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "d2413bd1",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-14T07:04:31.431812Z",
+     "iopub.status.busy": "2026-08-14T07:04:31.431709Z",
+     "iopub.status.idle": "2026-08-14T07:04:35.503056Z",
+     "shell.execute_reply": "2026-08-14T07:04:35.502807Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>root PEHE</th>\n",
+       "      <th>ate_error</th>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>estimator</th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>S-learner</th>\n",
+       "      <td>0.2974</td>\n",
+       "      <td>0.1275</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>Causal tree</th>\n",
+       "      <td>0.4158</td>\n",
+       "      <td>0.3081</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>X-learner</th>\n",
+       "      <td>0.6537</td>\n",
+       "      <td>0.0814</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>T-learner</th>\n",
+       "      <td>0.8035</td>\n",
+       "      <td>0.1254</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "             root PEHE  ate_error\n",
+       "estimator                        \n",
+       "S-learner       0.2974     0.1275\n",
+       "Causal tree     0.4158     0.3081\n",
+       "X-learner       0.6537     0.0814\n",
+       "T-learner       0.8035     0.1254"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "def simulated_scores(mode=1, n=2000, sigma=1.0, seeds=range(5)):\n",
+    "    rows = []\n",
+    "    for seed in seeds:\n",
+    "        np.random.seed(seed)\n",
+    "        y, X, w, tau, _, _ = synthetic_data(mode=mode, n=n, p=5, sigma=sigma)\n",
+    "        X_tr, X_te, w_tr, w_te, y_tr, y_te, _, tau_te = train_test_split(\n",
+    "            X, w, y, tau, test_size=0.5, random_state=seed\n",
+    "        )\n",
+    "        for name, learner in make_learners(seed).items():\n",
+    "            tau_hat = cate(learner, X_tr, w_tr, y_tr, X_te)\n",
+    "            rows.append(\n",
+    "                {\n",
+    "                    \"estimator\": name,\n",
+    "                    \"seed\": seed,\n",
+    "                    \"root PEHE\": pehe(tau_te, tau_hat, squared=False),\n",
+    "                    \"ate_error\": ate_error(tau_te, tau_hat),\n",
+    "                }\n",
+    "            )\n",
+    "    return pd.DataFrame(rows)\n",
+    "\n",
+    "\n",
+    "simulated = simulated_scores()\n",
+    "simulated.groupby(\"estimator\")[[\"root PEHE\", \"ate_error\"]].mean().sort_values(\"root PEHE\").round(4)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ae50f8f8",
+   "metadata": {},
+   "source": [
+    "## IHDP\n",
+    "\n",
+    "100 replications of the same 747 units, each with its own simulated outcomes and\n",
+    "its own train/test split. The literature reports a mean and standard error\n",
+    "**across** replications, so a single one is not comparable to a published number;\n",
+    "the loop below is the unit of comparison.\n",
+    "\n",
+    "Ten replications are used here to keep the notebook runnable. Published tables\n",
+    "use all 100 — raise `N_REPLICATIONS` to reproduce one."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "fdd51f9c",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-14T07:04:35.504639Z",
+     "iopub.status.busy": "2026-08-14T07:04:35.504543Z",
+     "iopub.status.idle": "2026-08-14T07:04:47.179885Z",
+     "shell.execute_reply": "2026-08-14T07:04:47.179609Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead tr th {\n",
+       "        text-align: left;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead tr:last-of-type th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr>\n",
+       "      <th></th>\n",
+       "      <th colspan=\"2\" halign=\"left\">root PEHE</th>\n",
+       "      <th colspan=\"2\" halign=\"left\">ate_error</th>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th></th>\n",
+       "      <th>mean</th>\n",
+       "      <th>sem</th>\n",
+       "      <th>mean</th>\n",
+       "      <th>sem</th>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>estimator</th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>Causal tree</th>\n",
+       "      <td>5.4714</td>\n",
+       "      <td>3.3433</td>\n",
+       "      <td>0.4125</td>\n",
+       "      <td>0.1641</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>S-learner</th>\n",
+       "      <td>2.9277</td>\n",
+       "      <td>1.9351</td>\n",
+       "      <td>0.2899</td>\n",
+       "      <td>0.1653</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>T-learner</th>\n",
+       "      <td>2.6523</td>\n",
+       "      <td>1.5387</td>\n",
+       "      <td>0.3119</td>\n",
+       "      <td>0.1772</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>X-learner</th>\n",
+       "      <td>3.0879</td>\n",
+       "      <td>1.9151</td>\n",
+       "      <td>0.2576</td>\n",
+       "      <td>0.1141</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "            root PEHE         ate_error        \n",
+       "                 mean     sem      mean     sem\n",
+       "estimator                                      \n",
+       "Causal tree    5.4714  3.3433    0.4125  0.1641\n",
+       "S-learner      2.9277  1.9351    0.2899  0.1653\n",
+       "T-learner      2.6523  1.5387    0.3119  0.1772\n",
+       "X-learner      3.0879  1.9151    0.2576  0.1141"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "N_REPLICATIONS = 10\n",
+    "\n",
+    "def ihdp_scores(n_replications=N_REPLICATIONS):\n",
+    "    rows = []\n",
+    "    for replication in range(n_replications):\n",
+    "        train = fetch_ihdp(replication=replication, split=\"train\")\n",
+    "        test = fetch_ihdp(replication=replication, split=\"test\")\n",
+    "        for name, learner in make_learners(replication).items():\n",
+    "            tau_hat = cate(learner, train.data, train.treatment, train.target, test.data)\n",
+    "            rows.append(\n",
+    "                {\n",
+    "                    \"estimator\": name,\n",
+    "                    \"replication\": replication,\n",
+    "                    \"root PEHE\": pehe(test.tau, tau_hat, squared=False),\n",
+    "                    \"ate_error\": ate_error(test.tau, tau_hat),\n",
+    "                }\n",
+    "            )\n",
+    "    return pd.DataFrame(rows)\n",
+    "\n",
+    "\n",
+    "try:\n",
+    "    ihdp = ihdp_scores()\n",
+    "    summary = ihdp.groupby(\"estimator\")[[\"root PEHE\", \"ate_error\"]].agg([\"mean\", \"sem\"])\n",
+    "    display(summary.round(4))\n",
+    "except OSError as exc:\n",
+    "    print(f\"IHDP unavailable, skipping: {exc}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c0330a82",
+   "metadata": {},
+   "source": [
+    "## LaLonde\n",
+    "\n",
+    "A randomized experiment with no per-unit ground truth. What it licenses is a\n",
+    "comparison against the experimental difference in means, about $1,794: an\n",
+    "estimator run on the same experimental sample should recover it.\n",
+    "\n",
+    "This is the weakest of the three tests — it says nothing about the individual\n",
+    "effects — but it is the only one here computed on real outcomes."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "67b5d6ef",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-14T07:04:47.181676Z",
+     "iopub.status.busy": "2026-08-14T07:04:47.181394Z",
+     "iopub.status.idle": "2026-08-14T07:04:48.100455Z",
+     "shell.execute_reply": "2026-08-14T07:04:48.100186Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "experimental ATE: 1,794.34\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>estimator</th>\n",
+       "      <th>ATE</th>\n",
+       "      <th>ate_error</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>X-learner</td>\n",
+       "      <td>1630.16</td>\n",
+       "      <td>164.18</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>T-learner</td>\n",
+       "      <td>1611.82</td>\n",
+       "      <td>182.52</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>S-learner</td>\n",
+       "      <td>1151.27</td>\n",
+       "      <td>643.07</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>Causal tree</td>\n",
+       "      <td>775.59</td>\n",
+       "      <td>1018.75</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "     estimator      ATE  ate_error\n",
+       "2    X-learner  1630.16     164.18\n",
+       "1    T-learner  1611.82     182.52\n",
+       "0    S-learner  1151.27     643.07\n",
+       "3  Causal tree   775.59    1018.75"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "try:\n",
+    "    lalonde = fetch_lalonde()\n",
+    "    experimental_ate = (\n",
+    "        lalonde.target[lalonde.treatment == 1].mean()\n",
+    "        - lalonde.target[lalonde.treatment == 0].mean()\n",
+    "    )\n",
+    "    print(f\"experimental ATE: {experimental_ate:,.2f}\")\n",
+    "\n",
+    "    rows = []\n",
+    "    for name, learner in make_learners().items():\n",
+    "        learner.fit(X=lalonde.data, treatment=lalonde.treatment, y=lalonde.target)\n",
+    "        tau_hat = np.asarray(learner.predict(lalonde.data)).ravel()\n",
+    "        rows.append(\n",
+    "            {\n",
+    "                \"estimator\": name,\n",
+    "                \"ATE\": tau_hat.mean(),\n",
+    "                \"ate_error\": ate_error(experimental_ate, tau_hat.mean()),\n",
+    "            }\n",
+    "        )\n",
+    "    display(pd.DataFrame(rows).sort_values(\"ate_error\").round(2))\n",
+    "except OSError as exc:\n",
+    "    print(f\"LaLonde unavailable, skipping: {exc}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d35d56e1",
+   "metadata": {},
+   "source": [
+    "## Reading this table\n",
+    "\n",
+    "Three things it does not say.\n",
+    "\n",
+    "It does not say which estimator is best. Every ranking above is conditional on\n",
+    "one data-generating process, one base learner and one hyperparameter setting;\n",
+    "IHDP in particular is a single simulation design that the literature has tuned\n",
+    "against for a decade.\n",
+    "\n",
+    "It does not say the differences are significant. The IHDP section reports a\n",
+    "standard error across replications; the simulated section reports a mean over\n",
+    "five seeds and no more.\n",
+    "\n",
+    "And it says nothing about datasets with no ground truth, which is most real work.\n",
+    "There, AUUC, Qini and RATE are what the library offers, and\n",
+    "[Validation](../validation.rst) covers them.\n",
+    "\n",
+    "## Regenerating\n",
+    "\n",
+    "Run this notebook top to bottom. It is refreshed each minor release and whenever\n",
+    "an estimator's defaults change — `honesty=True` becoming the causal-tree default\n",
+    "moved every number in the tree row, which is exactly the kind of change that\n",
+    "makes a stale table wrong rather than merely old."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.8"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -11,6 +11,7 @@ Contents:
     quickstart
     migration
     examples
+    datasets
     methodology
     interpretation
     validation

--- a/docs/refs.bib
+++ b/docs/refs.bib
@@ -518,3 +518,33 @@ doi = {10.1007/978-1-4419-9782-1}
       archivePrefix={arXiv},
       primaryClass={stat.ML}
 }
+
+@article{lalonde1986evaluating,
+  title={Evaluating the econometric evaluations of training programs with experimental data},
+  author={LaLonde, Robert J},
+  journal={The American Economic Review},
+  volume={76},
+  number={4},
+  pages={604--620},
+  year={1986}
+}
+
+@article{dehejia1999causal,
+  title={Causal effects in nonexperimental studies: Reevaluating the evaluation of training programs},
+  author={Dehejia, Rajeev H and Wahba, Sadek},
+  journal={Journal of the American Statistical Association},
+  volume={94},
+  number={448},
+  pages={1053--1062},
+  year={1999}
+}
+
+@article{hill2011bayesian,
+  title={Bayesian nonparametric modeling for causal inference},
+  author={Hill, Jennifer L},
+  journal={Journal of Computational and Graphical Statistics},
+  volume={20},
+  number={1},
+  pages={217--240},
+  year={2011}
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,6 +77,12 @@ requires = [
 homepage = "https://github.com/uber/causalml"
 
 [tool.pytest.ini_options]
+markers = [
+    # The benchmark dataset loaders fetch from their original hosts. Tests that
+    # touch the network are opt-in (`pytest -m network`) so the ordinary suite
+    # stays offline and a source URL moving cannot redden an unrelated PR.
+    "network: needs a benchmark dataset, downloaded or already cached",
+]
 filterwarnings = [
     # CausalML's own #854 argument-order deprecation must never fire during the
     # suite: it means the library called a shimmed method positionally, and a

--- a/tests/test_benchmark_loaders.py
+++ b/tests/test_benchmark_loaders.py
@@ -1,0 +1,153 @@
+"""Tests for the benchmark dataset loaders, against the real files.
+
+Marked ``network`` and skipped unless the dataset is already cached, so the
+ordinary suite never downloads anything. Run them with the cache warm, or on the
+schedule that exists to catch the source URLs moving::
+
+    pytest tests/test_benchmark_loaders.py -m network
+
+Each assertion is a published property of the dataset rather than a snapshot of
+whatever the file happens to contain, so a source that changes underneath us
+fails here rather than propagating into a benchmark table.
+"""
+
+import numpy as np
+import pytest
+
+from causalml.dataset import fetch_ihdp, fetch_lalonde, fetch_twins
+from causalml.metrics import ate_error, pehe
+
+pytestmark = pytest.mark.network
+
+
+def _cached(loader, **kwargs):
+    """Load with downloads disabled, skipping the test when the cache is cold."""
+    try:
+        return loader(download_if_missing=False, **kwargs)
+    except OSError as exc:
+        pytest.skip(f"dataset not cached: {exc}")
+
+
+def test_fetch_lalonde_reproduces_the_experimental_estimate():
+    """445 rows, 185 treated, and the ~1794 dollar experimental difference."""
+    lalonde = _cached(fetch_lalonde)
+
+    assert lalonde.data.shape == (445, 8)
+    assert lalonde.treatment.sum() == 185
+    assert lalonde.feature_names[:2] == ["age", "educ"]
+
+    treated = lalonde.target[lalonde.treatment == 1].mean()
+    control = lalonde.target[lalonde.treatment == 0].mean()
+    assert treated - control == pytest.approx(1794.34, abs=1.0)
+
+
+def test_fetch_ihdp_replications_differ_and_carry_ground_truth():
+    """672 x 25 per replication, with mu0/mu1 giving the individual effect.
+
+    The replication axis is asserted because selecting the wrong one is silent:
+    every replication is the same 747 units re-split and re-simulated, so any of
+    them yields a plausible-looking dataset of the right shape.
+    """
+    first = _cached(fetch_ihdp, replication=0)
+    seventh = _cached(fetch_ihdp, replication=7)
+
+    assert first.data.shape == (672, 25)
+    assert first.treatment.sum() == 123
+    assert first.tau.mean() == pytest.approx(4.012, abs=0.01)
+    assert np.allclose(first.tau, first.mu1 - first.mu0)
+
+    # Each replication draws its own train/test split of the same 747 units, so
+    # the rows are not aligned across replications -- only the pooled covariate
+    # set is. Asserting row-wise equality would look reasonable and be false.
+    assert not np.allclose(first.data, seventh.data)
+    assert not np.allclose(first.tau, seventh.tau)
+    assert first.treatment.sum() != seventh.treatment.sum()
+
+    test_split = _cached(fetch_ihdp, split="test")
+    assert test_split.data.shape == (75, 25)
+    pooled_first = np.unique(np.vstack([first.data, test_split.data]), axis=0)
+    pooled_seventh = np.unique(
+        np.vstack(
+            [seventh.data, _cached(fetch_ihdp, replication=7, split="test").data]
+        ),
+        axis=0,
+    )
+    assert pooled_first.shape == (747, 25)
+    assert np.array_equal(pooled_first, pooled_seventh)
+
+
+def test_fetch_ihdp_validates_its_arguments():
+    """A replication outside the file, or an unknown split, says so."""
+    with pytest.raises(ValueError, match="replication"):
+        fetch_ihdp(replication=100, download_if_missing=False)
+    with pytest.raises(ValueError, match="split"):
+        fetch_ihdp(split="validation", download_if_missing=False)
+
+
+def test_fetch_twins_mortality_matches_the_published_rate():
+    """The 9999 sentinel decides whether this dataset means anything.
+
+    Read as a number the outcome column averages about 8000; read as
+    `outcome < 9999` it gives the 17.7% mortality for the lighter twin that
+    Louizos et al. (2017) report. Asserting the rate pins the interpretation.
+    """
+    twins = _cached(fetch_twins, random_state=42)
+
+    assert twins.data.shape == (11400, 30)
+    assert twins.y0.mean() == pytest.approx(0.1769, abs=0.001)
+    assert twins.y1.mean() == pytest.approx(0.1608, abs=0.001)
+    assert set(np.unique(twins.y0)) <= {0, 1}
+
+
+def test_fetch_twins_reveals_the_twin_the_assignment_picks():
+    """The observed outcome is the assigned twin's, and `tau` keeps both."""
+    twins = _cached(fetch_twins, random_state=42)
+
+    assert np.array_equal(
+        twins.target, np.where(twins.treatment == 1, twins.y1, twins.y0)
+    )
+    assert np.array_equal(twins.tau, twins.y1 - twins.y0)
+    assert twins.tau.mean() == pytest.approx(-0.0161, abs=0.001)
+
+
+def test_fetch_twins_assignment_is_seeded():
+    """The same seed reveals the same twins; a different one does not."""
+    a = _cached(fetch_twins, random_state=1)
+    b = _cached(fetch_twins, random_state=1)
+    c = _cached(fetch_twins, random_state=2)
+
+    assert np.array_equal(a.treatment, b.treatment)
+    assert not np.array_equal(a.treatment, c.treatment)
+
+
+@pytest.mark.parametrize("loader", [fetch_lalonde, fetch_twins])
+def test_return_X_y_t_matches_the_bunch(loader):
+    """The triple is the same arrays the Bunch carries.
+
+    Twins needs the seed: its assignment is random per call by design, so an
+    unseeded pair of calls would differ for a reason that is not a bug.
+    """
+    seed = {} if loader is fetch_lalonde else {"random_state": 0}
+    bunch = _cached(loader, **seed)
+    X, y, treatment = _cached(loader, return_X_y_t=True, **seed)
+
+    assert np.array_equal(X, bunch.data)
+    assert np.array_equal(y, bunch.target)
+    assert X.shape[0] == y.shape[0] == treatment.shape[0]
+
+
+def test_ground_truth_metrics_run_on_the_datasets_that_have_it():
+    """PEHE needs per-unit truth; the experiment only licenses an ATE error."""
+    ihdp = _cached(fetch_ihdp, replication=0)
+
+    assert pehe(ihdp.tau, ihdp.tau) == 0.0
+    assert pehe(ihdp.tau, np.full_like(ihdp.tau, ihdp.tau.mean())) == pytest.approx(
+        ihdp.tau.var()
+    )
+
+    lalonde = _cached(fetch_lalonde)
+    experimental = (
+        lalonde.target[lalonde.treatment == 1].mean()
+        - lalonde.target[lalonde.treatment == 0].mean()
+    )
+    assert ate_error(experimental, experimental) == 0.0

--- a/tests/test_dataset_fetch.py
+++ b/tests/test_dataset_fetch.py
@@ -1,0 +1,135 @@
+"""Tests for the benchmark dataset cache and loaders.
+
+The tests here never reach the network: the cache, the digest check and the
+offline path are exercised against files written into ``tmp_path``. The loaders
+themselves are covered by ``test_benchmark_loaders.py``, which is marked
+``network`` and skipped unless the datasets are already cached.
+"""
+
+import hashlib
+
+import pytest
+
+from causalml.dataset import clear_data_dir, get_data_home
+from causalml.dataset._base import DATA_HOME_ENV, DEFAULT_DATA_HOME, fetch_remote
+
+CONTENT = b"benchmark,data\n1,2\n"
+DIGEST = hashlib.sha256(CONTENT).hexdigest()
+
+
+@pytest.fixture
+def data_home(tmp_path, monkeypatch):
+    """Point the cache at a temporary directory for the duration of a test."""
+    monkeypatch.setenv(DATA_HOME_ENV, str(tmp_path / "cache"))
+    return tmp_path / "cache"
+
+
+def _seed(path, content=CONTENT):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(content)
+    return path
+
+
+def test_get_data_home_prefers_the_argument_then_the_environment(tmp_path, monkeypatch):
+    """Resolution order is argument, then CAUSALML_DATA, then the default.
+
+    The default itself is asserted on the constant rather than by calling with no
+    environment set, which would create a directory in the developer's home.
+    """
+    monkeypatch.setenv(DATA_HOME_ENV, str(tmp_path / "from_env"))
+
+    assert get_data_home() == tmp_path / "from_env"
+    assert get_data_home(tmp_path / "explicit") == tmp_path / "explicit"
+    assert (tmp_path / "explicit").is_dir()
+    assert DEFAULT_DATA_HOME == "~/causalml-data"
+
+
+def test_fetch_remote_returns_the_cached_file_without_downloading(data_home):
+    """A cached file whose digest matches is used as is."""
+    _seed(data_home / "cached.csv")
+
+    path = fetch_remote(
+        url="https://example.invalid/cached.csv",
+        filename="cached.csv",
+        sha256=DIGEST,
+        download_if_missing=False,
+    )
+
+    assert path.read_bytes() == CONTENT
+
+
+def test_fetch_remote_raises_when_missing_and_offline(data_home):
+    """`download_if_missing=False` names the file it wanted and the source."""
+    with pytest.raises(OSError, match="download_if_missing=False"):
+        fetch_remote(
+            url="https://example.invalid/absent.csv",
+            filename="absent.csv",
+            sha256=DIGEST,
+            download_if_missing=False,
+            dataset_name="Absent",
+        )
+
+
+def test_fetch_remote_rejects_a_cached_file_with_the_wrong_digest(data_home):
+    """A corrupted cache entry is not silently used.
+
+    The digest is the whole point of the check: a truncated download, or an HTML
+    error page saved under the dataset's name, is still a readable file. Without
+    verification it would be parsed and reported as a benchmark result.
+    """
+    _seed(data_home / "corrupt.csv", b"not the data you wanted")
+
+    with pytest.raises(OSError):
+        fetch_remote(
+            url="https://example.invalid/corrupt.csv",
+            filename="corrupt.csv",
+            sha256=DIGEST,
+            download_if_missing=False,
+            dataset_name="Corrupt",
+        )
+
+
+def test_fetch_remote_verifies_the_digest_after_downloading(data_home, monkeypatch):
+    """A download whose digest does not match is deleted rather than returned."""
+
+    def fake_urlretrieve(url, path):
+        with open(path, "wb") as f:
+            f.write(b"something else entirely")
+
+    monkeypatch.setattr("causalml.dataset._base.urlretrieve", fake_urlretrieve)
+
+    with pytest.raises(OSError, match="expected"):
+        fetch_remote(
+            url="https://example.invalid/wrong.csv",
+            filename="wrong.csv",
+            sha256=DIGEST,
+            dataset_name="Wrong",
+        )
+
+    assert not (data_home / "wrong.csv").exists()
+
+
+def test_fetch_remote_keeps_a_download_whose_digest_matches(data_home, monkeypatch):
+    """The happy path writes the file to the cache and returns it."""
+
+    def fake_urlretrieve(url, path):
+        with open(path, "wb") as f:
+            f.write(CONTENT)
+
+    monkeypatch.setattr("causalml.dataset._base.urlretrieve", fake_urlretrieve)
+
+    path = fetch_remote(
+        url="https://example.invalid/good.csv", filename="good.csv", sha256=DIGEST
+    )
+
+    assert path == data_home / "good.csv"
+    assert path.read_bytes() == CONTENT
+
+
+def test_clear_data_dir_removes_the_cache(data_home):
+    """A bad cache is one call away from being recoverable."""
+    _seed(data_home / "cached.csv")
+
+    clear_data_dir()
+
+    assert not (data_home / "cached.csv").exists()

--- a/tests/test_ground_truth_metrics.py
+++ b/tests/test_ground_truth_metrics.py
@@ -1,0 +1,99 @@
+"""Tests for the metrics that score against a known ground truth.
+
+These need no dataset: `synthetic_data` returns the individual effect `tau`, and
+the properties asserted here are exact ones the definitions imply.
+"""
+
+import numpy as np
+import pytest
+
+from causalml.dataset import synthetic_data
+from causalml.metrics import ate_error, pehe, policy_risk
+
+from .const import RANDOM_SEED
+
+
+@pytest.fixture
+def tau():
+    np.random.seed(RANDOM_SEED)
+    _, _, _, tau, _, _ = synthetic_data(mode=1, n=1000, p=5, sigma=1.0)
+    return tau
+
+
+def test_pehe_of_the_truth_is_zero(tau):
+    """A perfect estimate has no error, squared or not."""
+    assert pehe(tau, tau) == 0.0
+    assert pehe(tau, tau, squared=False) == 0.0
+
+
+def test_pehe_of_a_constant_predictor_is_the_variance_of_tau(tau):
+    """Predicting the mean effect everywhere leaves exactly the heterogeneity.
+
+    This is the property that makes PEHE worth reporting next to an ATE error: a
+    model can get the average exactly right and still score the full variance of
+    the individual effects.
+    """
+    constant = np.full_like(tau, tau.mean())
+
+    assert pehe(tau, constant) == pytest.approx(tau.var())
+    assert pehe(tau, constant, squared=False) == pytest.approx(tau.std())
+    assert ate_error(tau, constant) == pytest.approx(0.0, abs=1e-12)
+
+
+def test_pehe_root_is_the_square_root_of_the_squared_form(tau):
+    """`squared=False` is the root, on the same scale as the effect."""
+    noisy = tau + np.random.RandomState(RANDOM_SEED).normal(size=tau.shape)
+
+    assert pehe(tau, noisy, squared=False) == pytest.approx(np.sqrt(pehe(tau, noisy)))
+
+
+def test_pehe_rejects_mismatched_lengths(tau):
+    """Comparing different numbers of units is a caller error, not a mean."""
+    with pytest.raises(ValueError, match="same length"):
+        pehe(tau, tau[:-1])
+
+
+def test_ate_error_is_the_shift_of_a_shifted_estimate(tau):
+    """Shifting every prediction by a constant moves the ATE error by exactly it."""
+    assert ate_error(tau, tau + 0.75) == pytest.approx(0.75)
+    assert ate_error(tau, tau - 0.75) == pytest.approx(0.75)
+
+
+def test_ate_error_accepts_scalars(tau):
+    """An experiment gives one number, not a per-unit truth."""
+    assert ate_error(2.0, 2.5) == pytest.approx(0.5)
+
+
+def test_policy_risk_prefers_the_oracle_policy_to_a_random_one():
+    """Targeting by the true effect beats targeting at random.
+
+    The outcome is constructed so treating a unit with a positive effect helps and
+    treating one with a negative effect hurts, which is the ordering the metric
+    exists to detect.
+    """
+    rng = np.random.RandomState(RANDOM_SEED)
+    n = 4000
+    tau = rng.choice([-0.4, 0.4], size=n)
+    treatment = rng.binomial(1, 0.5, size=n)
+    baseline = 0.5
+    y = np.clip(baseline + treatment * tau + rng.normal(scale=0.01, size=n), 0, 1)
+
+    oracle = policy_risk(y, treatment, tau)
+    random_policy = policy_risk(y, treatment, rng.normal(size=n))
+
+    assert oracle < random_policy
+    # The oracle treats the half it helps and leaves the rest alone, so its value
+    # is 0.5 * (baseline + 0.4) + 0.5 * baseline rather than baseline + 0.4: the
+    # untreated half still contributes its own outcome to the policy's value.
+    expected_value = 0.5 * (baseline + 0.4) + 0.5 * baseline
+    assert oracle == pytest.approx(1 - expected_value, abs=0.02)
+
+
+def test_policy_risk_raises_when_an_arm_is_empty():
+    """With nobody assigned as the policy recommends, there is nothing to average."""
+    y = np.array([1.0, 0.0, 1.0, 0.0])
+    treatment = np.zeros(4, dtype=int)
+    tau_hat = np.ones(4)
+
+    with pytest.raises(ValueError, match="both arms"):
+        policy_risk(y, treatment, tau_hat)


### PR DESCRIPTION
## Proposed changes

The whole of v1.0 M3 — Benchmarks & Evaluation. Closes #1009. Closes #1010. Closes #1011. Closes #1012. Closes #1013.

`causalml.dataset` was synthetic-only and `causalml.metrics` scored only rankings (AUUC, Qini, RATE), so there was no way to ask how close an estimate is to a known effect.

| | added |
| --- | --- |
| `causalml.dataset` | `fetch_lalonde`, `fetch_ihdp`, `fetch_twins`, `get_data_home`, `clear_data_dir` |
| `causalml.metrics` | `pehe`, `ate_error`, `policy_risk` |
| docs | `datasets.rst`, `examples/benchmark_leaderboard.ipynb` |

## Fetching

Datasets download from their original source on first use and cache under `~/causalml-data` (`CAUSALML_DATA` or `data_home` override). **No dataset is redistributed here.**

```python
from causalml.dataset import fetch_lalonde, fetch_ihdp, fetch_twins

lalonde = fetch_lalonde()                                       # Bunch
X, y, treatment = fetch_ihdp(replication=0, return_X_y_t=True)
```

The signature copies [`scikit-uplift`](https://github.com/maks-sh/scikit-uplift)'s `(data_home, download_if_missing, return_X_y_t)` so code moves between the two libraries unchanged, with scikit-learn's `Bunch` return.

Every download is **SHA256-verified**, which `scikit-uplift` does not do — it checks `Content-Length`. Benchmark files move hosts, and a redirect page or a truncated file saved under the dataset's name is still readable; without the digest it would be parsed and reported as a benchmark result rather than raising.

**Which datasets ship, and why only three.** The rule: an explicit permissive license or public-domain provenance, fetched at runtime, never vendored. LaLonde comes from the MIT-licensed `causaldata`; IHDP from the [`clinicalml/cfrnet`](https://github.com/clinicalml/cfrnet) lineage (MIT); Twins from NBER federal records. ACIC, Jobs, Criteo and Hillstrom do not meet that bar — Criteo carries a non-commercial clause and the rest have no license file — so `docs/datasets.rst` documents them with load-it-yourself instructions and points at `scikit-uplift` for the two it already re-hosts.

## Two file properties that are easy to get wrong

Both are pinned by tests, because both produce plausible-looking numbers when read wrong.

**Twins encodes survival as `9999`.** Read as a number the outcome column averages about 8,000; read as `outcome < 9999` it gives **17.69% mortality for the lighter twin**, matching the 17.7% Louizos et al. report. The test asserts the rate, not the parsing.

**IHDP replications are not row-aligned.** Each of the 100 replications simulates its own outcomes *and draws its own 672/75 train-test split of the same 747 units*, so row `i` is a different unit in each and the treated count varies (123, 129, 122, ...). Only the pooled 747 covariate rows are common. I had assumed the covariates were shared and the test caught it; the loader's docstring now says so, since selecting a replication is otherwise silent.

## Metrics

`pehe(tau, tau_hat, squared=False)` for the root, `ate_error` for `eps_ATE`, `policy_risk` for the treat-if-positive policy. All three are testable against `synthetic_data`'s `tau` with exact properties — PEHE of a constant predictor is the variance of `tau`, a shifted estimate's `ate_error` is the shift — so they need no download.

Each docstring names what it requires. PEHE and `ate_error` need per-unit truth; `policy_risk` needs randomized treatment. The failure mode is someone computing PEHE against a fitted model's output and reporting it as accuracy.

## The leaderboard

`docs/examples/benchmark_leaderboard.ipynb` **is** the leaderboard — running it end to end regenerates every number, so the published table cannot drift from something nobody can reproduce. Executed output is committed. Three tables, because the metric available is a property of how each dataset was made, and the notebook says plainly what a ranking on simulated outcomes does and does not mean.

## Tests

24 new tests. The ordinary suite **never touches the network**: the cache, the digest mismatch and the offline error run against `tmp_path`, and the loader tests are marked `network` and skip when the cache is cold. A scheduled job running `pytest -m network` is what catches a source URL moving, rather than a red PR for an unrelated change.

Full suite **548 passed / 18 skipped**, exit 0. Docs build exit 0 with `datasets.html` written and no warnings on the new page; the three new citations resolve in `references.html`.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/uber/causalml/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/uber/causalml)
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

No new dependency: downloads use `urllib.request` from the standard library, as scikit-learn's fetchers do.

The scheduled `-m network` job is not added here — it wants a decision about which CI workflow owns it, and the marker plus the skip-when-cold behaviour is what makes it schedulable.
