### PR TITLE
Docs phase 2: correctness pass over the published pages, and a five-section structure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ CLAUDE.md
 .claude/.worktrees/
 .worktrees/
 .worktrees/
+.gstack/

--- a/causalml/propensity.py
+++ b/causalml/propensity.py
@@ -48,7 +48,9 @@ class PropensityModel(metaclass=ABCMeta):
             X (numpy.ndarray, pd.DataFrame, or pl.DataFrame): a feature matrix.
                 scikit-learn >= 1.6 accepts pandas and Polars DataFrames
                 natively, so no conversion is performed here.
-            y (numpy.ndarray, pd.Series, or pl.Series): a binary target vector
+            y (numpy.ndarray, pd.Series, or pl.Series): the binary treatment
+                indicator, not the outcome. A propensity score is P(W = 1 | X),
+                so this vector must be the treatment assignment.
         """
         self.model.fit(X, y)
         if self.calibrate:
@@ -83,7 +85,9 @@ class PropensityModel(metaclass=ABCMeta):
 
         Args:
             X (numpy.ndarray, pd.DataFrame, or pl.DataFrame): a feature matrix
-            y (numpy.ndarray, pd.Series, or pl.Series): a binary target vector
+            y (numpy.ndarray, pd.Series, or pl.Series): the binary treatment
+                indicator, not the outcome. A propensity score is P(W = 1 | X),
+                so this vector must be the treatment assignment.
 
         Returns:
             (numpy.ndarray): Propensity scores between 0 and 1.
@@ -169,7 +173,9 @@ class GradientBoostedPropensityModel(PropensityModel):
 
         Args:
             X (numpy.ndarray, pd.DataFrame, or pl.DataFrame): a feature matrix
-            y (numpy.ndarray, pd.Series, or pl.Series): a binary target vector
+            y (numpy.ndarray, pd.Series, or pl.Series): the binary treatment
+                indicator, not the outcome. A propensity score is P(W = 1 | X),
+                so this vector must be the treatment assignment.
         """
         if self.early_stop:
             X_train, X_val, y_train, y_val = train_test_split(

--- a/docs/about.rst
+++ b/docs/about.rst
@@ -17,51 +17,10 @@ From the CausalML `Charter <https://github.com/uber/causalml/blob/master/CHARTER
 
     CausalML is committed to democratizing causal machine learning through accessible, innovative, and well-documented open-source tools that empower data scientists, researchers, and organizations. At our core, we embrace inclusivity and foster a vibrant community where members exchange ideas, share knowledge, and collaboratively shape a future where CausalML drives advancements across diverse domains.
 
-Contributing
-------------
-`Contributing.md <https://github.com/uber/causalml/blob/master/CONTRIBUTING.md>`_
+Contributing and Governance
+---------------------------
 
-Governance
-----------
-* `Charter <https://github.com/uber/causalml/blob/master/CHARTER.md>`_
-* `Contributors <https://github.com/uber/causalml/graphs/contributors>`_
-* `Maintainers <https://github.com/uber/causalml/blob/master/MAINTAINERS.md>`_
-
-Intro to Causal Machine Learning
-================================
-
-What is Causal Machine Learning?
---------------------------------
-
-Causal machine learning is a branch of machine learning that focuses on understanding the cause and effect relationships in data. It goes beyond just predicting outcomes based on patterns in the data, and tries to understand how changing one variable can affect an outcome.
-Suppose we are trying to predict a student’s test score based on how many hours they study and how much sleep they get. Traditional machine learning models would find patterns in the data, like students who study more or sleep more tend to get higher scores.
-But what if you want to know what would happen if a student studied an extra hour each day? Or slept an extra hour each night? Modeling these potential outcomes or counterfactuals is where causal machine learning comes in. It tries to understand cause-and-effect relationships - how much changing one variable (like study hours or sleep hours) will affect the outcome (the test score).
-This is useful in many fields, including economics, healthcare, and policy making, where understanding the impact of interventions is crucial.
-While traditional machine learning is great for prediction, causal machine learning helps us understand the difference in outcomes due to interventions.
-
-
-
-Difference from Traditional Machine Learning
---------------------------------------------
-
-Traditional machine learning and causal machine learning are both powerful tools, but they serve different purposes and answer different types of questions.
-Traditional Machine Learning is primarily concerned with prediction. Given a set of input features, it learns a function from the data that can predict an outcome. It’s great at finding patterns and correlations in large datasets, but it doesn’t tell us about the cause-and-effect relationships between variables. It answers questions like “Given a patient’s symptoms, what disease are they likely to have?”
-On the other hand, Causal Machine Learning is concerned with understanding the cause-and-effect relationships between variables. It goes beyond prediction and tries to answer questions about intervention: “What will happen if we change this variable?” For example, in a medical context, it could help answer questions like “What will happen if a patient takes this medication?”
-In essence, while traditional machine learning can tell us “what is”, causal machine learning can help us understand “what if”. This makes causal machine learning particularly useful in fields where we need to make decisions based on data, such as policy making, economics, and healthcare.
-
-
-Measuring Causal Effects
-------------------------
-
-**Randomized Control Trials (RCT)** are the gold standard for causal effect measurements.  Subjects are randomly exposed to a treatment and the Average Treatment Effect (ATE) is measured as the difference between the mean effects in the treatment and control groups.  Random assignment removes the effect of any confounders on the treatment.
-
-If an RCT is available and the treatment effects are heterogeneous across covariates, measuring the conditional average treatment effect(CATE) can be of interest.  The CATE is an estimate of the treatment effect conditioned on all available experiment covariates and confounders.  We call these Heterogeneous Treatment Effects (HTEs).
-
-
-Example Use Cases
------------------
-
-- **Campaign Targeting Optimization**: An important lever to increase ROI in an advertising campaign is to target the ad to the set of customers who will have a favorable response in a given KPI such as engagement or sales. CATE identifies these customers by estimating the effect of ad exposure on the KPI at the individual level from A/B experiment or historical observational data.
-
-- **Personalized Engagement**: A company might have multiple options to interact with its customers such as different product choices in up-sell or different messaging channels for communications. One can use CATE to estimate the heterogeneous treatment effect for each customer and treatment option combination for an optimal personalized engagement experience.
-
+See :doc:`contributing` for how to set up a development environment and open a
+pull request, and for the project's charter, governance and maintainer list.
+`Contributors <https://github.com/uber/causalml/graphs/contributors>`_ are
+listed on GitHub.

--- a/docs/about.rst
+++ b/docs/about.rst
@@ -61,7 +61,7 @@ If an RCT is available and the treatment effects are heterogeneous across covari
 Example Use Cases
 -----------------
 
-- **Campaign Targeting Optimization**: An important lever to increase ROI in an advertising campaign is to target the ad to the set of customers who will have a favorable response in a given KPI such as engagement or sales. CATE identifies these customers by estimating the effect of the KPI from ad exposure at the individual level from A/B experiment or historical observational data.
+- **Campaign Targeting Optimization**: An important lever to increase ROI in an advertising campaign is to target the ad to the set of customers who will have a favorable response in a given KPI such as engagement or sales. CATE identifies these customers by estimating the effect of ad exposure on the KPI at the individual level from A/B experiment or historical observational data.
 
 - **Personalized Engagement**: A company might have multiple options to interact with its customers such as different product choices in up-sell or different messaging channels for communications. One can use CATE to estimate the heterogeneous treatment effect for each customer and treatment option combination for an optimal personalized engagement experience.
 

--- a/docs/causalml.rst
+++ b/docs/causalml.rst
@@ -1,5 +1,6 @@
-causalml package
-================
+=============
+API Reference
+=============
 
 Submodules
 ----------

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -169,9 +169,6 @@ html_theme_options = {
         "alt_text": "CausalML",
     },
     "github_url": "https://github.com/uber/causalml",
-    # index.rst has 11 top-level toctree entries and this theme renders them in
-    # the header; the rest collapse into a "More" dropdown.
-    "header_links_before_dropdown": 6,
     "navigation_depth": 2,
     "navbar_align": "left",
 }

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -1,0 +1,43 @@
+============
+Contributing
+============
+
+CausalML is developed in the open at `github.com/uber/causalml
+<https://github.com/uber/causalml>`_, and contributions are welcome — bug
+reports, documentation, new estimators, and reviews of open pull requests.
+
+Setting up a development environment
+------------------------------------
+
+Follow :ref:`Install from source <installation:Install from source>`. The
+editable install compiles the package's Cython extensions, so no separate build
+step is needed. Then run the test suite as described in
+:ref:`Running Tests <installation:Running Tests>`.
+
+After editing any ``.pyx`` or ``.pxd`` file, reinstall so the extension is
+rebuilt::
+
+    pip install -e . --no-deps
+
+Before opening a pull request
+-----------------------------
+
+* Format the diff with `black <https://black.readthedocs.io/>`_. It is the
+  formatting gate CI enforces.
+* Add or update tests covering the behavior you changed.
+* Add an entry under ``Unreleased`` in :doc:`changelog` if the change is
+  user-visible — a new feature, a bug fix, or a change in behavior.
+* If you change an estimator's signature, check
+  :doc:`migration` — the ``fit(X, y, treatment, ...)`` transition is in
+  progress and new methods are expected to follow the target order.
+
+Project documents
+-----------------
+
+* `Contributing guide <https://github.com/uber/causalml/blob/master/CONTRIBUTING.md>`_
+* `Code of conduct <https://github.com/uber/causalml/blob/master/CODE_OF_CONDUCT.md>`_
+* `Charter <https://github.com/uber/causalml/blob/master/CHARTER.md>`_
+* `Governance <https://github.com/uber/causalml/blob/master/GOVERNANCE.md>`_
+* `Maintainers <https://github.com/uber/causalml/blob/master/MAINTAINERS.md>`_
+* `Steering committee <https://github.com/uber/causalml/blob/master/STEERING_COMMITTEE.md>`_
+* `Security policy <https://github.com/uber/causalml/blob/master/SECURITY.md>`_

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -1,0 +1,14 @@
+===============
+Getting Started
+===============
+
+What CausalML is, an introduction to causal machine learning for readers new to
+it, how to install the package, and a tour of the API in runnable snippets.
+
+.. toctree::
+    :maxdepth: 2
+
+    about
+    intro
+    installation
+    quickstart

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,23 +1,14 @@
 Welcome to Causal ML's documentation
 ====================================
 
-Contents:
-
 .. toctree::
     :maxdepth: 2
 
-    about
-    installation
-    quickstart
-    migration
-    examples
-    datasets
-    methodology
-    interpretation
-    validation
+    getting_started
+    user_guide
     causalml
-    references
-    changelog
+    contributing
+    release_notes
 
 
 Indices and tables

--- a/docs/interpretation.rst
+++ b/docs/interpretation.rst
@@ -23,7 +23,7 @@ Meta-Learner Feature Importances
     # Using the feature_importances_ method in the base learner (LGBMRegressor() in this example)
     slearner.plot_importance(X=X, tau=slearner_tau, normalize=True, method='auto')
 
-    # Using eli5's PermutationImportance
+    # Using scikit-learn's permutation_importance
     slearner.plot_importance(X=X, tau=slearner_tau, normalize=True, method='permutation')
 
     # Using SHAP

--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -1,0 +1,37 @@
+================================
+Intro to Causal Machine Learning
+================================
+
+What is Causal Machine Learning?
+--------------------------------
+
+Causal machine learning is a branch of machine learning that focuses on understanding the cause and effect relationships in data. It goes beyond just predicting outcomes based on patterns in the data, and tries to understand how changing one variable can affect an outcome.
+Suppose we are trying to predict a student's test score based on how many hours they study and how much sleep they get. Traditional machine learning models would find patterns in the data, like students who study more or sleep more tend to get higher scores.
+But what if you want to know what would happen if a student studied an extra hour each day? Or slept an extra hour each night? Modeling these potential outcomes or counterfactuals is where causal machine learning comes in. It tries to understand cause-and-effect relationships - how much changing one variable (like study hours or sleep hours) will affect the outcome (the test score).
+This is useful in many fields, including economics, healthcare, and policy making, where understanding the impact of interventions is crucial.
+While traditional machine learning is great for prediction, causal machine learning helps us understand the difference in outcomes due to interventions.
+
+
+Difference from Traditional Machine Learning
+--------------------------------------------
+
+Traditional machine learning and causal machine learning are both powerful tools, but they serve different purposes and answer different types of questions.
+Traditional Machine Learning is primarily concerned with prediction. Given a set of input features, it learns a function from the data that can predict an outcome. It's great at finding patterns and correlations in large datasets, but it doesn't tell us about the cause-and-effect relationships between variables. It answers questions like "Given a patient's symptoms, what disease are they likely to have?"
+On the other hand, Causal Machine Learning is concerned with understanding the cause-and-effect relationships between variables. It goes beyond prediction and tries to answer questions about intervention: "What will happen if we change this variable?" For example, in a medical context, it could help answer questions like "What will happen if a patient takes this medication?"
+In essence, while traditional machine learning can tell us "what is", causal machine learning can help us understand "what if". This makes causal machine learning particularly useful in fields where we need to make decisions based on data, such as policy making, economics, and healthcare.
+
+
+Measuring Causal Effects
+------------------------
+
+**Randomized Control Trials (RCT)** are the gold standard for causal effect measurements.  Subjects are randomly exposed to a treatment and the Average Treatment Effect (ATE) is measured as the difference between the mean effects in the treatment and control groups.  Random assignment removes the effect of any confounders on the treatment.
+
+If an RCT is available and the treatment effects are heterogeneous across covariates, measuring the conditional average treatment effect (CATE) can be of interest.  The CATE is an estimate of the treatment effect conditioned on the available covariates.  We call these Heterogeneous Treatment Effects (HTEs).
+
+
+Example Use Cases
+-----------------
+
+- **Campaign Targeting Optimization**: An important lever to increase ROI in an advertising campaign is to target the ad to the set of customers who will have a favorable response in a given KPI such as engagement or sales. CATE identifies these customers by estimating the effect of ad exposure on the KPI at the individual level from A/B experiment or historical observational data.
+
+- **Personalized Engagement**: A company might have multiple options to interact with its customers such as different product choices in up-sell or different messaging channels for communications. One can use CATE to estimate the heterogeneous treatment effect for each customer and treatment option combination for an optimal personalized engagement experience.

--- a/docs/methodology.rst
+++ b/docs/methodology.rst
@@ -13,7 +13,7 @@ CausalML currently supports the following methods:
 
 - Tree-based algorithms
     - :ref:`Uplift Random Forests <methodology:Uplift Tree>` on KL divergence, Euclidean Distance, and Chi-Square
-    - :ref:`Uplift Random Forests <methodology:Uplift Tree>` on Contextual Treatment Selection
+    - :ref:`Uplift Random Forests <methodology:CTS>` on Contextual Treatment Selection
     - :ref:`Uplift Random Forests <methodology:DDP>` on delta-delta-p (:math:`\Delta\Delta P`) criterion (only for binary trees and two-class problems)
     - :ref:`Uplift Random Forests <methodology:IDDP>` on IDDP (only for binary trees and two-class problems)
     - :ref:`Interaction Tree <methodology:IT>` (only for binary trees and two-class problems)
@@ -35,12 +35,6 @@ CausalML currently supports the following methods:
     - :ref:`Counterfactual Value Estimator <methodology:Counterfactual Value Estimator>`
 
 
-Decision Guide
---------------
-
-See image in: https://github.com/uber/causalml/issues/677#issuecomment-1712088558
-
-
 Meta-Learner Algorithms
 -----------------------
 
@@ -48,7 +42,7 @@ A meta-algorithm (or meta-learner) is a framework to estimate the Conditional Av
 
 A meta-algorithm uses either a single base learner while having the treatment indicator as a feature (e.g. S-learner), or multiple base learners separately for each of the treatment and control groups (e.g. T-learner, X-learner and R-learner).
 
-Confidence intervals of average treatment effect estimates are calculated based on the lower bound formular (7) from :cite:`imbens2009recent`.
+Confidence intervals of average treatment effect estimates are calculated based on the lower bound formula (7) from :cite:`imbens2009recent`.
 
 S-Learner
 ~~~~~~~~~
@@ -169,7 +163,7 @@ with :math:`\{Y^3, X^3, W^3\}`
 
 **Stage 3**
 
-Repeat Stage 1 and Stage 2 again twice. First use :math:`\{Y^2, X^2, W^2\}`, :math:`\{Y^3, X^3, W^3\}`, and :math:`\{Y^1, X^1, W^1\}` for the propensity score model, the outcome models, and the CATE model. Then use :math:`\{Y^3, X^3, W^3\}`, :math:`\{Y^2, X^2, W^2\}`, and :math:`\{Y^1, X^1, W^1\}` for the propensity score model, the outcome models, and the CATE model. The final CATE model is the average of the 3 CATE models.
+Repeat Stage 1 and Stage 2 again twice, rotating the three partitions so that each one trains the CATE model exactly once. First use :math:`\{Y^2, X^2, W^2\}`, :math:`\{Y^3, X^3, W^3\}`, and :math:`\{Y^1, X^1, W^1\}` for the propensity score model, the outcome models, and the CATE model. Then use :math:`\{Y^3, X^3, W^3\}`, :math:`\{Y^1, X^1, W^1\}`, and :math:`\{Y^2, X^2, W^2\}` for the propensity score model, the outcome models, and the CATE model. The final CATE model is the average of the 3 CATE models.
 
 Doubly Robust Instrumental Variable (DRIV) learner
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -178,7 +172,7 @@ We combine the idea from DR-learner :cite:`kennedy2020optimal` with the doubly r
 
 **Stage 1**
 
-Fit propensity score models :math:`\hat{e}_0(x)` and :math:`\hat{e}_1(x)` for assigned and unassigned users using :math:`\{X^1, W^1, Z^1\}`, and fit outcome regression models :math:`\hat{m}_0(x)` and :math:`\hat{m}_1(x)` for assigned and unassigned users with machine learning using :math:`\{Y^2, X^2, Z^2\}`. Assignment probabiliy, :math:`p_Z`, can either be user provided or come from a simple model, since in most use cases assignment is random by design.
+Fit propensity score models :math:`\hat{e}_0(x)` and :math:`\hat{e}_1(x)` for assigned and unassigned users using :math:`\{X^1, W^1, Z^1\}`, and fit outcome regression models :math:`\hat{m}_0(x)` and :math:`\hat{m}_1(x)` for assigned and unassigned users with machine learning using :math:`\{Y^2, X^2, Z^2\}`. Assignment probability, :math:`p_Z`, can either be user provided or come from a simple model, since in most use cases assignment is random by design.
 
 **Stage 2**
 
@@ -314,21 +308,30 @@ The Uplift Tree approach consists of a set of methods that use a tree-based algo
 
 where :math:`D` measures the divergence and :math:`P^T` and :math:`P^C` refer to the probability distribution of the outcome of interest in the treatment and control groups, respectively. Three different ways to quantify the divergence, KL, ED and Chi, are implemented in the package.
 
+Throughout this subsection the outcome is binary, so :math:`P^T` and :math:`P^C`
+are each described by a single number: let :math:`p` be the sample mean of the
+outcome in the treatment group and :math:`q` the sample mean in the control
+group, both computed within the node being scored. Each divergence below sums
+over the two outcome classes :math:`\{1, 0\}` -- which is where the second term
+in each expression comes from -- and :math:`D_{gain}` then combines the parent's
+divergence with its children's as above :cite:`Gutierrez2016-co`.
+
 KL
 ~~~
 The Kullback-Leibler (KL) divergence is given by:
 
 .. math::
-   KL(P : Q) = \sum_{k=left, right}p_klog\frac{p_k}{q_k}
+   KL(P^T : P^C) = p\log\frac{p}{q} + (1-p)\log\frac{1-p}{1-q}
 
-where :math:`p` is the sample mean in the treatment group, :math:`q` is the sample mean in the control group and :math:`k` indicates the leaf in which :math:`p` and :math:`q` are computed :cite:`Gutierrez2016-co`
+At :math:`p = 0` and :math:`p = 1` the expression is taken at its limit,
+:math:`-\log(1-q)` and :math:`-\log q` respectively.
 
 ED
 ~~~
 The Euclidean Distance is given by:
 
 .. math::
-   ED(P : Q) = \sum_{k=left, right}(p_k - q_k)^2
+   ED(P^T : P^C) = (p - q)^2 + \big((1-p) - (1-q)\big)^2 = 2(p - q)^2
 
 where the notation is the same as above.
 
@@ -337,7 +340,7 @@ Chi
 Finally, the :math:`\chi^2`-divergence is given by:
 
 .. math::
-   \chi^2(P : Q) = \sum_{k=left, right}\frac{(p_k - q_k)^2}{q_k}
+   \chi^2(P^T : P^C) = \frac{(p - q)^2}{q} + \frac{(p - q)^2}{1 - q}
 
 where the notation is again the same as above.
 
@@ -360,7 +363,7 @@ criterion is defined as follows:
 .. math::
     IDDP = \frac{\Delta\Delta P^*}{I(\phi, \phi_l, \phi_r)}
 
-where :math:`\Delta\Delta P^*` is defined as :math:`\Delta\Delta P - |E[Y(1) - Y(0)]| X \epsilon \phi|` and
+where :math:`\Delta\Delta P^*` is defined as :math:`\Delta\Delta P - |E[Y(1) - Y(0) \mid X \in \phi]|` and
 :math:`I(\phi, \phi_l, \phi_r)` is defined as:
 
 .. math::
@@ -379,16 +382,16 @@ Further, the package implements the Interaction Tree (IT) proposed by :cite:`su2
 maximizes the G statistic among all permissible splits:
 
 .. math::
-    G(s^*) = max G(s)
+    G(s^*) = \max_s G(s)
 
 where :math:`G(s)=t^2(s)` and :math:`t(s)` is defined as:
 
 .. math::
-    t(s) = \frac{(y^L_1 - y^L_0) - (y^R_1 - y^R_0)}{\sigma * (1/n_1 + 1/n_2 + 1/n_3 + 1/n_4)}
+    t(s) = \frac{(y^L_1 - y^L_0) - (y^R_1 - y^R_0)}{\sigma \sqrt{1/n_1 + 1/n_2 + 1/n_3 + 1/n_4}}
 
-where :math:`\sigma=\sum_{i=4}^4w_is_i^2` is a pooled estimator of the constant variance, and :math:`w_i=(n_i-1)/\sum_{j=1}^4(n_j-1)`.
-Further, :math:`y^L_1`, :math:`s^2_1`, and :math:`n_1` are the the sample mean, the sample variance, and the sample size
-for the treatment group in the left child node ,respectively. Similar notation applies to the other quantities.
+where :math:`\sigma=\sqrt{\sum_{i=1}^4 w_i s_i^2}` is a pooled estimator of the constant standard deviation, and :math:`w_i=(n_i-1)/\sum_{j=1}^4(n_j-1)`.
+Further, :math:`y^L_1`, :math:`s^2_1`, and :math:`n_1` are the sample mean, the sample variance, and the sample size
+for the treatment group in the left child node, respectively. Similar notation applies to the other quantities.
 
 Note that this implementation deviates from the original implementation in that (1) the pruning techniques and (2) the validation method
 for determining the best tree size are different.
@@ -408,7 +411,7 @@ the number of observations in node :math:`\tau` that are assigned to the control
 that are assigned to the treatment group, respectively. :math:`SSE_{\tau}` is defined as:
 
 .. math::
-    SSE_{\tau} = \sum_{i \epsilon \tau: t_i=1}(y_i - \hat{y_{t1}})^2 + \sum_{i \epsilon \tau: t_i=0}(y_i - \hat{y_{t0}})^2
+    SSE_{\tau} = \sum_{i \in \tau: t_i=1}(y_i - \hat{y_{t1}})^2 + \sum_{i \in \tau: t_i=0}(y_i - \hat{y_{t0}})^2
 
 and :math:`\hat{y_{t0}}` and :math:`\hat{y_{t1}}` are the sample average responses of the control and treatment groups in node
 :math:`\tau`, respectively.
@@ -526,35 +529,35 @@ a JAX/``flax.nnx`` backend.
 Value optimization methods
 --------------------------
 
-The package supports methods for assigning treatment groups when treatments are costly. To understand the problem, it is helpful to divide populations into the following four categories:
+The package supports methods for assigning treatment groups when treatments are costly. To understand the problem, it is helpful to divide the population into four categories according to how a unit's *outcome* responds to being treated:
 
-* **Compliers**. Those who will have a favourable outcome if and only if they are treated.
-* **Always-takers**. Those who will have a favourable outcome whether or not they are treated.
-* **Never-takers**. Those who will never have a favourable outcome whether or not they are treated.
-* **Defiers**. Those who will have a favourable outcome if and only if they are not treated.
+* **Persuadables**. Those who will have a favourable outcome if and only if they are treated.
+* **Sure things**. Those who will have a favourable outcome whether or not they are treated.
+* **Lost causes**. Those who will never have a favourable outcome whether or not they are treated.
+* **Sleeping dogs**. Those who will have a favourable outcome if and only if they are not treated.
 
-For a more detailed discussion see e.g. :cite:`angrist2008mostly`.
+These four response types are also referred to as compliers, always-takers, never-takers and defiers. Note that those names are standard in the instrumental variables literature for a **different** partition of the population -- one defined by whether a unit *takes* the treatment in response to its *assignment*, which is the sense used in the :ref:`LATE <methodology:LATE>` section below (see :cite:`angrist2008mostly` for that one). The two partitions do not coincide, so the uplift names are used here.
 
 Counterfactual Unit Selection
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 :cite:`ijcai2019-248` propose a method for selecting units for treatments using counterfactual logic. Suppose the following benefits for selecting units belonging to the different categories above:
 
-* Compliers: :math:`\beta`
-* Always-takers: :math:`\gamma`
-* Never-takers: :math:`\theta`
-* Defiers: :math:`\delta`
+* Persuadables: :math:`\beta`
+* Sure things: :math:`\gamma`
+* Lost causes: :math:`\theta`
+* Sleeping dogs: :math:`\delta`
 
 If :math:`X` denotes the set of individual's features, the unit selection problem can be formulated as follows:
 
 .. math::
-   argmax_X \beta P(\text{complier} \mid X) + \gamma P(\text{always-taker} \mid X) + \theta P(\text{never-taker} \mid X) + \delta P(\text{defier} \mid X)
+   \operatorname*{argmax}_X \beta P(\text{persuadable} \mid X) + \gamma P(\text{sure thing} \mid X) + \theta P(\text{lost cause} \mid X) + \delta P(\text{sleeping dog} \mid X)
 
 The problem can be reformulated using counterfactual logic. Suppose :math:`W = w` indicates that an individual is treated and :math:`W = w'` indicates he or she is untreated. Similarly, let :math:`F = f` denote a favourable outcome for the individual and :math:`F = f'` an unfavourable outcome. Then the optimization problem becomes:
 
 .. math::
-   argmax_X \beta P(f_w, f'_{w'} \mid X) + \gamma P(f_w, f_{w'} \mid X) + \theta P(f'_w, f'_{w'} \mid X) + \delta P(f_{w'}, f'_{w} \mid X)
+   \operatorname*{argmax}_X \beta P(f_w, f'_{w'} \mid X) + \gamma P(f_w, f_{w'} \mid X) + \theta P(f'_w, f'_{w'} \mid X) + \delta P(f_{w'}, f'_{w} \mid X)
 
-Note that the above simply follows from the definitions of the relevant users segments. :cite:`ijcai2019-248` then use counterfactual logic (:cite:`pearl2009causality`) to solve the above optimization problem under certain conditions.
+Note that the above simply follows from the definitions of the relevant user segments. :cite:`ijcai2019-248` then use counterfactual logic (:cite:`pearl2009causality`) to solve the above optimization problem under certain conditions.
 
 N.B. The current implementation in the package is highly experimental.
 
@@ -606,15 +609,15 @@ In bounding the above three quantities, we utilize observational data in additio
 
 Given this, :cite:`tian2000probabilities` use the program developed in :cite:`balke1995probabilistic` to obtain sharp bounds of the above three quantities. The main idea in this program is to turn the bounding task into a linear programming problem (for a modern implementation of their approach see `here <https://cran.r-project.org/web/packages/causaloptim/vignettes/vertexenum-speed.html>`_).
 
-Using the linear programming approach and given certain constraints together with observational data, :cite:`tian2000probabilities` find that the shar lower bound for PNS is given by
+Using the linear programming approach and given certain constraints together with observational data, :cite:`tian2000probabilities` find that the sharp lower bound for PNS is given by
 
 .. math::
-    max\{0, P(y_t) - P(y_c), P(y) - P(y_c), P(y_t) - P(y)\}
+    \max\{0, P(y_t) - P(y_c), P(y) - P(y_c), P(y_t) - P(y)\}
 
 and the sharp upper bound is given by
 
 .. math::
-    min\{P(y_t), P(y^{\prime}_c), P(t, y) + P(c, y^{\prime}), P(y_t) - P(y_c) + P(t, y^{\prime}) + P(c, y)\}
+    \min\{P(y_t), P(y^{\prime}_c), P(t, y) + P(c, y^{\prime}), P(y_t) - P(y_c) + P(t, y^{\prime}) + P(c, y)\}
 
 They use a similar routine to find the bounds for PS and PN. The `get_pns_bounds()` function calculates the bounds for each of the three probabilities of causation using the results in :cite:`tian2000probabilities`.
 
@@ -668,18 +671,18 @@ The most common method for instrumental variables estimation is the two-stage le
 Here for convenience we let :math:`\Xi=[W, X]` and :math:`\gamma=[\alpha', \beta']'`. Assume that we have instrumental variables :math:`Z` whose number of columns is at least the number of columns of :math:`W`, let :math:`\Omega=[Z, X]`, 2SLS estimator is as follows
 
 .. math::
-   \hat{\gamma}_{2SLS} = \left[\Xi'\Omega (\Omega'\Omega)^{-1} \Omega' \Xi\right]^{-1}\left[\Xi'\Omega'(\Omega'\Omega)^{-1}\Omega'Y\right].
+   \hat{\gamma}_{2SLS} = \left[\Xi'\Omega (\Omega'\Omega)^{-1} \Omega' \Xi\right]^{-1}\left[\Xi'\Omega(\Omega'\Omega)^{-1}\Omega'Y\right].
 
 See :cite:`10.1257/jep.15.4.69` for a detailed discussion of the method.
 
 LATE
 ~~~~
 
-In many situations the treatment :math:`W` may depend on subject's own choice and cannot be administered directly in an experimental setting. However one can randomly assign users into treatment/control groups so that users in the treatment group can be nudged to take the treatment. This is the case of noncompliance, where users may fail to comply with their assignment status, :math:`Z`, as to whether to take treatment or not. Similar to the section of Value optimization methods, in general there are 3 types of users in this situation,
+In many situations the treatment :math:`W` may depend on subject's own choice and cannot be administered directly in an experimental setting. However one can randomly assign users into treatment/control groups so that users in the treatment group can be nudged to take the treatment. This is the case of noncompliance, where users may fail to comply with their assignment status, :math:`Z`, as to whether to take treatment or not. In general there are 3 types of users in this situation, classified by whether they *take* the treatment in response to their assignment:
 
 * **Compliers** Those who will take the treatment if and only if they are assigned to the treatment group.
-* **Always-Taker** Those who will take the treatment regardless which group they are assigned to.
-* **Never-Taker** Those who wil not take the treatment regardless which group they are assigned to.
+* **Always-Takers** Those who will take the treatment regardless of which group they are assigned to.
+* **Never-Takers** Those who will not take the treatment regardless of which group they are assigned to.
 
 However one assumes that there is no Defier for identification purposes, i.e. those who will only take the treatment if they are assigned to the control group.
 
@@ -711,8 +714,8 @@ Scale :math:`Y` into :math:`\tilde{Y}=\frac{Y-\min Y}{\max Y - \min Y}` so that 
 Let :math:`Q=\log(\tilde{m}_W(X)/(1-\tilde{m}_W(X)))`. Maximize the following pseudo log-likelihood function
 
 .. math::
-   \max_{h_0, h_1} -\frac{1}{N} \sum_i & \left[ \tilde{Y}_i \log \left(1+\exp(-Q_i-h_0 \frac{1-W}{1-\hat{e}(X_i)}-h_1 \frac{W}{\hat{e}(X_i)} \right) \right. \\
-   &\quad\left.+(1-\tilde{Y}_i)\log\left(1+\exp(Q_i+h_0\frac{1-W}{1-\hat{e}(X_i)}+h_1\frac{W}{\hat{e}(X_i)}\right)\right]
+   \max_{h_0, h_1} -\frac{1}{N} \sum_i & \left[ \tilde{Y}_i \log \left(1+\exp\left(-Q_i-h_0 \frac{1-W}{1-\hat{e}(X_i)}-h_1 \frac{W}{\hat{e}(X_i)}\right) \right) \right. \\
+   &\quad\left.+(1-\tilde{Y}_i)\log\left(1+\exp\left(Q_i+h_0\frac{1-W}{1-\hat{e}(X_i)}+h_1\frac{W}{\hat{e}(X_i)}\right)\right)\right]
 
 **Step 4**
 

--- a/docs/methodology.rst
+++ b/docs/methodology.rst
@@ -16,7 +16,7 @@ CausalML currently supports the following methods:
     - :ref:`Uplift Random Forests <methodology:Uplift Tree>` on Contextual Treatment Selection
     - :ref:`Uplift Random Forests <methodology:DDP>` on delta-delta-p (:math:`\Delta\Delta P`) criterion (only for binary trees and two-class problems)
     - :ref:`Uplift Random Forests <methodology:IDDP>` on IDDP (only for binary trees and two-class problems)
-    - Interaction Tree (only for binary trees and two-class problems)
+    - :ref:`Interaction Tree <methodology:IT>` (only for binary trees and two-class problems)
     - :ref:`Causal Inference Tree <methodology:CIT>` (only for binary trees and two-class problems)
 - Meta-learner algorithms
     - :ref:`S-Learner <methodology:S-Learner>`
@@ -206,7 +206,7 @@ S/T/X/R/DR-learners above can be compared and selected among.
 These metrics evaluate *effect-magnitude accuracy* -- how close a model's CATE
 estimate is to the truth -- which is a distinct question from *targeting
 quality* -- whether a model correctly ranks units by benefit -- addressed by
-:ref:`RATE`.
+:ref:`RATE <methodology:RATE>`.
 
 DR (Doubly Robust) pseudo-outcome loss
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -244,6 +244,62 @@ This is biased under a misspecified outcome model, unlike the DR loss above.
 Despite that, :cite:`mahajan2024empirical` found it is never dominated across
 their benchmark datasets, making it a useful complement to DR-based scoring
 rather than a replacement.
+
+RATE
+~~~~
+
+The Rank-Weighted Average Treatment Effect (RATE) of
+:cite:`yadlowsky2021evaluating` scores a model as a *targeting rule*: not how
+close :math:`\hat\tau(x)` is to the truth, but whether the units it ranks
+highest are the ones that benefit most.
+
+Rank units by a prioritization score :math:`\hat\tau(x)`, treat the top
+:math:`q` fraction, and measure the gain over treating everyone. That is the
+Targeting Operator Characteristic (TOC) curve:
+
+.. math::
+   \text{TOC}(q) = E\left[Y(1)-Y(0) \mid \hat\tau(X) \ge F^{-1}_{\hat\tau}(1-q)\right] - E\left[Y(1)-Y(0)\right]
+
+where :math:`F^{-1}_{\hat\tau}(1-q)` is the :math:`(1-q)` quantile of the
+score, so the conditioning set is exactly the top-:math:`q` fraction.
+:math:`\text{TOC}(1) = 0` by construction, since selecting everyone gives back
+the overall ATE, and a curve that is positive at small :math:`q` means the rule
+has found units with above-average benefit. RATE reduces the curve to a single
+number with a weight function :math:`\alpha(q)`:
+
+.. math::
+   \text{RATE} = \int_0^1 \alpha(q)\,\text{TOC}(q)\,dq
+
+Two weightings are implemented, and the choice between them is one of
+statistical power rather than correctness:
+
+- ``weighting="autoc"`` (the default) sets :math:`\alpha(q) = 1/q`. It weights
+  the highest-priority units most heavily and is most powerful when the benefit
+  is concentrated in a small subgroup.
+- ``weighting="qini"`` sets :math:`\alpha(q) = q`, which recovers the Qini
+  coefficient. It is more powerful when treatment effects are diffuse across
+  the population.
+
+``causalml.metrics.rate_score`` returns the scalar;
+``causalml.metrics.get_toc`` and ``causalml.metrics.plot_toc`` return and draw
+the curve behind it. The integral is evaluated on the discrete quantile grid as
+a midpoint-weighted mean whose weights are normalized to sum to one, so the
+absolute scale can differ slightly from the continuous definition above while
+the ordering of models is unchanged.
+
+Passing ``return_ci=True`` adds a standard error, a confidence interval and a
+p-value for :math:`H_0: \text{RATE} = 0` -- the null that the ranking is no
+better than random -- from a half-sample bootstrap that draws :math:`n/2` units
+without replacement, the resampling scheme covered by the functional central
+limit theorem in :cite:`yadlowsky2021evaluating`.
+
+One assumption is easy to miss: without a ground-truth effect column, the
+subset ATE inside the TOC is a plain difference in mean outcomes between the
+treated and control units of each band, which is unbiased under randomization
+but not under confounding. For observational data, pass cross-fit AIPW
+pseudo-outcomes -- the same :math:`\phi` as in the DR loss above -- as
+``treatment_effect_col``, so that the ranking is scored against a
+doubly-robust estimate rather than a raw difference in means.
 
 Tree-Based Algorithms
 ---------------------

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -14,7 +14,9 @@ Propensity Score Estimation
     from causalml.propensity import ElasticNetPropensityModel
 
     pm = ElasticNetPropensityModel(n_fold=5, random_state=42)
-    ps = pm.fit_predict(X, y)
+    # The second argument is the treatment indicator, not the outcome: a
+    # propensity score is P(W = 1 | X).
+    ps = pm.fit_predict(X, treatment)
 
 Propensity Score Matching
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -232,7 +234,7 @@ For more details, please refer to the `sensitivity_example_with_synthetic_data.i
     sens_x = Sensitivity(df=df, inference_features=INFERENCE_FEATURES, p_col='pihat',
                          treatment_col=TREATMENT_COL, outcome_col=OUTCOME_COL, learner=learner_x)
     # Here for Selection Bias method will use default one-sided confounding function and alpha (quantile range of outcome values) input
-    sens_sumary_x = sens_x.sensitivity_analysis(methods=['Placebo Treatment',
+    sens_summary_x = sens_x.sensitivity_analysis(methods=['Placebo Treatment',
                                                          'Random Cause',
                                                          'Subset Data',
                                                          'Random Replace',
@@ -252,7 +254,7 @@ For more details, please refer to the `sensitivity_example_with_synthetic_data.i
 Feature Selection
 ---------------------------
 
-For more details, please refer to the `feature_selection.ipynb notebook <https://github.com/uber/causalml/blob/master/docs/examples/feature_selection.ipynb>`_ and the associated paper reference by Zhao, Zhenyu, et al.
+For more details, please refer to the `feature_selection.ipynb notebook <https://github.com/uber/causalml/blob/master/docs/examples/feature_selection.ipynb>`_ and the associated paper, :cite:`zhao2020feature`.
 
 .. code-block:: python
 

--- a/docs/refs.bib
+++ b/docs/refs.bib
@@ -475,6 +475,15 @@ URL = {https://www.aeaweb.org/articles?id=10.1257/jep.15.4.69}}
   year={2024}
 }
 
+@misc{yadlowsky2021evaluating,
+      title={Evaluating Treatment Prioritization Rules via Rank-Weighted Average Treatment Effects},
+      author={Steve Yadlowsky and Scott Fleming and Nigam Shah and Emma Brunskill and Stefan Wager},
+      year={2021},
+      eprint={2111.07966},
+      archivePrefix={arXiv},
+      primaryClass={stat.ME}
+}
+
 @article{10.1111/ectj.12097,
     author = {Chernozhukov, Victor and Chetverikov, Denis and Demirer, Mert and Duflo, Esther and Hansen, Christian and Newey, Whitney and Robins, James},
     title = "{Double/debiased machine learning for treatment and structural parameters}",

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -1,0 +1,12 @@
+=============
+Release Notes
+=============
+
+What changed in each release, and the guides for transitions that need code
+changes on the caller's side.
+
+.. toctree::
+    :maxdepth: 2
+
+    changelog
+    migration

--- a/docs/user_guide.rst
+++ b/docs/user_guide.rst
@@ -1,0 +1,17 @@
+==========
+User Guide
+==========
+
+The methods CausalML implements and the theory behind them, how to interpret
+and validate what a fitted model produces, the benchmark datasets with known
+ground truth, and worked examples as runnable notebooks.
+
+.. toctree::
+    :maxdepth: 2
+
+    methodology
+    interpretation
+    validation
+    datasets
+    examples
+    references

--- a/docs/validation.rst
+++ b/docs/validation.rst
@@ -37,7 +37,7 @@ Mechanism 1
 | This generates a complex outcome regression model with easy treatment effect with input variables :math:`X_i \sim Unif(0, 1)^d`.
 | The treatment flag is a binomial variable, whose d.g.p. is:
 |
-|   :math:`P(W_i = 1 | X_i) = trim_{0.1}(sin(\pi X_{i1} X_{i2})`
+|   :math:`P(W_i = 1 | X_i) = trim_{0.1}(sin(\pi X_{i1} X_{i2}))`
 |
 | With :
 |   :math:`trim_\eta(x)=\max (\eta,\min (x,1-\eta))`
@@ -86,7 +86,7 @@ Mechanism 4
 |
 | The outcome variable is:
 |
-|   :math:`y_i = \frac{1}{2}\big(max(X_{i1} + X_{i2} + X_{i3}, 0) + max(X_{i4} + X_{i5}, 0)\big) + (W_i - 0.5)(max(X_{i1} + X_{i2} + X_{i3}, 0) - max(X_{i4}, X_{i5}, 0))`
+|   :math:`y_i = \frac{1}{2}\big(max(X_{i1} + X_{i2} + X_{i3}, 0) + max(X_{i4} + X_{i5}, 0)\big) + (W_i - 0.5)(max(X_{i1} + X_{i2} + X_{i3}, 0) - max(X_{i4} + X_{i5}, 0))`
 |
 
 Validation with Uplift Curve (AUUC)
@@ -116,37 +116,37 @@ For data with skewed treatment, it is sometimes advantageous to use :ref:`Target
 
 Validation with Sensitivity Analysis
 ------------------------------------
-Sensitivity analysis aim to check the robustness of the unconfoundeness assumption. If there is hidden bias (unobserved confounders), it determines how severe would have to be to change conclusion by examining the average treatment effect estimation.
+Sensitivity analysis aims to check the robustness of the unconfoundedness assumption. If there is hidden bias (unobserved confounders), it determines how severe that bias would have to be to change the conclusion, by examining the average treatment effect estimation.
 
-We implemented the following methods to conduct sensitivity analysis:
+We implemented the following methods to conduct sensitivity analysis. The heading of each is the string to pass to ``Sensitivity.sensitivity_analysis(methods=[...])``:
 
 Placebo Treatment
 ~~~~~~~~~~~~~~~~~
 
 | Replace treatment with a random variable.
 
-Irrelevant Additional Confounder
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Random Cause
+~~~~~~~~~~~~
 
 | Add a random common cause variable.
 
-Subset validation
-~~~~~~~~~~~~~~~~~
+Subset Data
+~~~~~~~~~~~
 
 | Remove a random subset of the data.
 
 Random Replace
 ~~~~~~~~~~~~~~
 
-| Random replace a covariate with an irrelevant variable.
+| Randomly replace a covariate with an irrelevant variable.
 
 Selection Bias
 ~~~~~~~~~~~~~~
 
-| `Blackwell(2013) <https://www.mattblackwell.org/files/papers/sens.pdf>` introduced an approach to sensitivity analysis for causal effects that directly models confounding or selection bias.
+| `Blackwell (2013) <https://www.mattblackwell.org/files/papers/sens.pdf>`_ introduced an approach to sensitivity analysis for causal effects that directly models confounding or selection bias.
 |
-| One Sided Confounding Function: here as the name implies, this function can detect sensitivity to one-sided selection bias, but it would fail to detect other deviations from ignobility. That is, it can only determine the bias resulting from the treatment group being on average better off or the control group being on average better off.
+| One Sided Confounding Function: here as the name implies, this function can detect sensitivity to one-sided selection bias, but it would fail to detect other deviations from ignorability. That is, it can only determine the bias resulting from the treatment group being on average better off or the control group being on average better off.
 |
 | Alignment Confounding Function: this type of bias is likely to occur when units select into treatment and control based on their predicted treatment effects
 |
-| The sensitivity analysis is rigid in this way because the confounding function is not identified from the data, so that the causal model in the last section is only identified conditional on a specific choice of that function. The goal of the sensitivity analysis is not to choose the “correct” confounding function, since we have no way of evaluating this correctness. By its very nature, unmeasured confounding is unmeasured. Rather, the goal is to identify plausible deviations from ignobility and test sensitivity to those deviations. The main harm that results from the incorrect specification of the confounding function is that hidden biases remain hidden.
+| The sensitivity analysis is rigid in this way because the confounding function is not identified from the data, so that the causal model in the last section is only identified conditional on a specific choice of that function. The goal of the sensitivity analysis is not to choose the “correct” confounding function, since we have no way of evaluating this correctness. By its very nature, unmeasured confounding is unmeasured. Rather, the goal is to identify plausible deviations from ignorability and test sensitivity to those deviations. The main harm that results from the incorrect specification of the confounding function is that hidden biases remain hidden.

--- a/tests/test_fit_arg_order.py
+++ b/tests/test_fit_arg_order.py
@@ -433,10 +433,46 @@ def test_migration_guide_url_matches_the_docs_source():
     )
 
 
+def _toctree_entries(rst):
+    """Document names listed by every ``toctree`` directive in one .rst file."""
+    entries = []
+    in_toctree = False
+    for line in rst.read_text().splitlines():
+        stripped = line.strip()
+        if stripped.startswith(".. toctree::"):
+            in_toctree = True
+        elif in_toctree:
+            if not stripped:
+                continue  # blank lines are allowed inside the directive
+            if not line[:1].isspace():
+                in_toctree = False  # a dedent ends it
+            elif not stripped.startswith(":"):
+                entries.append(stripped)  # not an option, so an entry
+    return entries
+
+
 def test_migration_guide_is_in_the_docs_toctree():
-    """An unlinked page is unreachable by browsing and warns at build time."""
+    """An unlinked page is unreachable by browsing and warns at build time.
+
+    Reachability is walked from ``index.rst`` rather than asserted against it
+    directly, so that regrouping the documentation into sections keeps working
+    while an orphaned page still fails.
+    """
     docs = Path(__file__).resolve().parents[1] / "docs"
-    assert "\n    migration\n" in (docs / "index.rst").read_text()
+    reachable, pending = set(), ["index"]
+    while pending:
+        doc = pending.pop()
+        if doc in reachable:
+            continue
+        reachable.add(doc)
+        page = docs / f"{doc}.rst"
+        if page.exists():
+            pending.extend(_toctree_entries(page))
+
+    assert "migration" in reachable, (
+        "docs/migration.rst is not reachable from docs/index.rst through any "
+        f"toctree; reachable pages are {sorted(reachable)}"
+    )
 
 
 # --- the library's own internal calls must not warn the caller --------------


### PR DESCRIPTION
Closes #1017.

Phase 2 of the documentation review. Phase 1 (#1014, #1016) fixed broken references and swapped the theme without moving any page or changing any prose; this covers content correctness across every published page except the API reference, and the regroup #1014 deferred.

Three commits, reviewable in order and droppable independently.

## `845adba` — RATE and the Interaction Tree reference

`methodology.rst` told the reader that targeting quality is "addressed by ``:ref:`RATE```" and no RATE section existed anywhere in the docs. That dangling reference was the single remaining `undefined label` in the whole build.

The new section is written from `causalml/metrics/rate.py` rather than from the paper alone, so it documents what ships: the Targeting Operator Characteristic (TOC) curve, the `autoc` (α = 1/q) versus `qini` (α = q, which recovers the Qini coefficient) weighting choice framed as a power decision, the discrete midpoint-weighted approximation that preserves model ordering but not the continuous integral's absolute scale, the half-sample bootstrap behind `return_ci=True`, and the assumption that without a ground-truth column the subset ATE is a naive difference in means — unbiased under randomization, not under confounding, so observational use wants AIPW pseudo-outcomes in `treatment_effect_col` ([Yadlowsky et al. 2021](https://arxiv.org/abs/2111.07966), added to `refs.bib`).

Also relinks the Interaction Tree entry in Supported Algorithms to the `IT` section, which sits directly above `CIT`.

## `914f123` — corrections

Six of these are places where the prose disagreed with the code. The implementation is correct in every one.

| Section | Documented | Implemented |
|---|---|---|
| Uplift Tree KL | `Σ_{k=left,right} p_k log(p_k/q_k)` | `p log(p/q) + (1−p) log((1−p)/(1−q))` — `_criterion.pyx:336` |
| Uplift Tree ED | `Σ_{k=left,right} (p_k−q_k)²` | `2(p−q)²` — `_criterion.pyx:360` |
| Uplift Tree Chi | `Σ_{k=left,right} (p_k−q_k)²/q_k` | `(p−q)²/q + (p−q)²/(1−q)` — `_criterion.pyx:368` |
| Interaction Tree | `t = Δ / (σ · Σ1/nᵢ)`, `σ = Σ_{i=4}^4 wᵢsᵢ²` | square root on both, `i=1` — `_criterion.pyx:458` |
| DR-learner stage 3 | 3rd fold: propensity 3, outcome 2, CATE 1 | cyclic shift: propensity 3, outcome 1, CATE 2 — `drlearner.py:159` |
| Synthetic Mechanism 4 | `τ` uses `max(X₄, X₅, 0)` | `max(X₄+X₅, 0)` — `regression.py:171` |

The three divergences sum over the two outcome classes of the binary outcome, not over the child leaves; that is where each missing second term comes from, and the leaf-weighted aggregation into `D_gain` is a separate step. Without its square roots the Interaction Tree statistic scaled with `n` rather than `√n`. The DR-learner rotation as written trained the CATE model on partition 1 twice and on partition 2 never.

Also:

- **The four response types were defined twice, incompatibly.** "Value optimization methods" partitioned the population by how a unit's *outcome* responds to treatment; the LATE section partitions by whether a unit *takes* the treatment in response to assignment, and the first opened with a cross-reference to the second. The outcome partition now uses the uplift names — persuadables, sure things, lost causes, sleeping dogs — with a note that the same four names are standard in the instrumental variables literature for the take-up partition.
- **The Quickstart's first code block passed the outcome to the propensity model**: `pm.fit_predict(X, y)`. A propensity score is P(W = 1 | X), so the second argument is the treatment. `PropensityModel` names that parameter `y`, which is what makes the call legal and silently wrong, so its three docstrings now state which vector is expected.
- **Two sensitivity methods were documented under names the API does not accept.** The `validation.rst` headings are now `Random Cause` and `Subset Data`, the strings `sensitivity_analysis(methods=[...])` takes (`sensitivity.py:188`).
- **`method='permutation'` was credited to eli5**; the explainer imports `sklearn.inspection.permutation_importance` (`explainer.py:5`).
- "ignobility" → "ignorability" (twice); `about.rst` had CATE estimating "the effect of the KPI from ad exposure", where the estimand is the effect of ad exposure on the KPI.
- **Removed the Decision Guide section**, whose entire body was a link to an image in a GitHub issue comment. Nothing referenced it.
- Rendering: the [Blackwell 2013](https://www.mattblackwell.org/files/papers/sens.pdf) reference used a single backtick and no trailing underscore, so the only pointer to the paper behind the Selection Bias method rendered as plain text and emitted no warning; three formulas opened a parenthesis they never closed; `\epsilon` stood in for `\in` twice and IDDP's conditioning bar was typed as a closing absolute-value bar; `argmax`/`max`/`min` were set as italic variables.

## `41ac7bf` — five sections

`index.rst` had eleven top-level toctree entries and the header renders six, so the rest collapsed into a "More" dropdown, the API reference among them. pandas and PyTorch both group into five sections, and both do it with real landing-page documents — a toctree `:caption:` does not group this theme's header, and reordering a flat toctree only changes which page falls into the dropdown.

| Section | Pages |
|---|---|
| Getting Started | about, intro, installation, quickstart |
| User Guide | methodology, interpretation, validation, examples, references |
| API Reference | causalml |
| Contributing | new |
| Release Notes | changelog, migration |

**Nothing moves on disk.** A landing page can toctree documents that stay at the docs root, so every published URL is unchanged and so is every `methodology:`-style `autosectionlabel` prefix — the prefixes #1016 rewrote 27 refs to match.

`Contributing` is new. `CONTRIBUTING.md`, `CHARTER.md`, `GOVERNANCE.md`, `MAINTAINERS.md`, `STEERING_COMMITTEE.md`, `CODE_OF_CONDUCT.md` and `SECURITY.md` all live at the repo root and reached the docs only as outbound links buried in `about.rst`. `source_suffix` is `.rst`, so the page links out to them rather than including them, and adds what a first-time contributor otherwise has to infer from CI: `black` is the formatting gate, a user-visible change wants an `Unreleased` changelog entry, and a `.pyx` edit needs a reinstall.

`about.rst` carried two top-level titles; the second is now `intro.rst` under Getting Started. `causalml.rst` is retitled from "causalml package" to "API Reference" so the header reads as a section name — nothing referenced its old label. `header_links_before_dropdown` is dropped as dead config now that no entry collapses.

## Verification

Full local build (sphinx 9.1.0, pydata-sphinx-theme 0.20.0, pandoc present) after each commit:

| | warnings | `undefined label` |
|---|---|---|
| `master` | 132 | 1 |
| this PR | **131** | **0** |

The one warning removed is the `rate` undefined label. **No warning is introduced by any of the three commits** — verified by diffing the sorted warning sets, not by comparing counts. Every rewritten reference was checked in the rendered HTML: the Interaction Tree entry resolves to `methodology.html#it`, the RATE reference to `#rate`, the Blackwell reference is now an external link, `zhao2020feature` resolves into the bibliography, and all eleven pre-existing pages still build to their original filenames. The header was read out of the built `index.html` and renders exactly the five sections with no page dropdown. `black --check` passes on `causalml/propensity.py`, the only Python file touched.

The remaining 131 warnings are pre-existing and are the subject of the next PR: 87 duplicate labels from headings repeated within a single notebook or within `changelog.rst`, which a document prefix cannot separate, and 18 malformed-docstring errors.

## Note for merge ordering

#1015 also edits `docs/index.rst`, to add `datasets`. Whichever lands second places `datasets` under User Guide.
