### PR TITLE
Group the example notebooks by topic

### DIFF
--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -3,36 +3,113 @@ Examples
 
 Working example notebooks are available in the `example folder <https://github.com/uber/causalml/tree/master/docs/examples>`_.
 
-Follow the below links for an approximate ordering of example tutorials from introductory to advanced features.
+The notebooks are grouped by topic. Within each group they run from
+introductory to advanced, so a group's first notebook is the place to start.
+
+Getting started
+---------------
+
+The two canonical tours of the package: CATE estimation with the meta-learners,
+and uplift modeling with the tree-based learners.
 
 .. toctree::
     :maxdepth: 1
 
     examples/meta_learners_with_synthetic_data
     examples/uplift_trees_with_synthetic_data
+
+Meta-learners
+-------------
+
+.. toctree::
+    :maxdepth: 1
+
     examples/meta_learners_with_synthetic_data_multiple_treatment
-    examples/uplift_tree_visualization
-    examples/feature_interpretations_example
-    examples/validation_with_tmle
-    examples/dragonnet_example
-    examples/dragonnet_jax_vs_tf
-    examples/iv_nlsym_synthetic_data
-    examples/sensitivity_example_with_synthetic_data
-    examples/counterfactual_unit_selection
-    examples/counterfactual_value_optimization
-    examples/feature_selection
-    examples/binary_policy_learner_example
-    examples/cevae_example
-    examples/cevae_jax_vs_torch
     examples/dr_learner_with_synthetic_data
-    examples/benchmark_simulation_studies
-    examples/necessary_and_sufficient
+
+Uplift and causal trees
+-----------------------
+
+.. toctree::
+    :maxdepth: 1
+
     examples/causal_trees_with_synthetic_data
     examples/causal_trees_with_synthetic_data_multiple_treatment_groups
     examples/causal_trees_interpretation
     examples/causal_tree_honesty_parity
-    examples/logistic_regression_based_data_generation_for_uplift_classification
-    examples/qini_curves_for_costly_treatment_arms
+
+Evaluation and validation
+-------------------------
+
+Validating a CATE model without ground truth: uplift and Qini curves, TMLE-based
+evaluation, calibration, and sensitivity analysis.
+
+.. toctree::
+    :maxdepth: 1
+
+    examples/validation_with_tmle
     examples/calibration
-    examples/benchmark_semi_synthetic_simulation_studies
+    examples/qini_curves_for_costly_treatment_arms
+    examples/sensitivity_example_with_synthetic_data
+
+Interpretation and feature selection
+------------------------------------
+
+.. toctree::
+    :maxdepth: 1
+
+    examples/feature_interpretations_example
+    examples/uplift_tree_visualization
+    examples/feature_selection
+
+Neural models
+-------------
+
+DragonNet and CEVAE, each with a comparison of its available backends. These
+need the optional ``tf``, ``torch`` or ``jax`` extras.
+
+.. toctree::
+    :maxdepth: 1
+
+    examples/dragonnet_example
+    examples/dragonnet_jax_vs_tf
+    examples/cevae_example
+    examples/cevae_jax_vs_torch
+
+Instrumental variables
+----------------------
+
+.. toctree::
+    :maxdepth: 1
+
+    examples/iv_nlsym_synthetic_data
+
+Policy and value optimization
+-----------------------------
+
+Turning effect estimates into treatment decisions: policy learning,
+counterfactual unit selection and value optimization, and probabilities of
+causation.
+
+.. toctree::
+    :maxdepth: 1
+
+    examples/binary_policy_learner_example
+    examples/counterfactual_unit_selection
+    examples/counterfactual_value_optimization
+    examples/necessary_and_sufficient
+
+Datasets and benchmarks
+-----------------------
+
+The benchmark leaderboard regenerates every number published on the
+:doc:`datasets` page; the simulation studies compare estimators on synthetic
+and semi-synthetic data.
+
+.. toctree::
+    :maxdepth: 1
+
     examples/benchmark_leaderboard
+    examples/benchmark_simulation_studies
+    examples/benchmark_semi_synthetic_simulation_studies
+    examples/logistic_regression_based_data_generation_for_uplift_classification


### PR DESCRIPTION
The Examples page listed 28 notebooks as one flat, "approximately ordered" toctree. This groups them into nine topical sections — getting started, meta-learners, trees, evaluation & validation, interpretation & feature selection, neural models, IV, policy & value optimization, datasets & benchmarks — with a one-line lede where the grouping is not self-evident.

Same 28 notebooks, same paths, so no URL changes; only the toctree structure moves. Docs-only; `sphinx -W` clean and the toctree-reachability test passes.

Second of the three P1 items from the docs roadmap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
