### PR TITLE
Fix S-learner estimate_ate DataFrame handling and return shape (#1026)

### DIFF
--- a/causalml/inference/meta/slearner.py
+++ b/causalml/inference/meta/slearner.py
@@ -44,8 +44,8 @@ class StatsmodelsOLS:
         # Append ones. The first column is for the treatment indicator.
         X = sm.add_constant(X, prepend=False, has_constant="add")
         self.model = sm.OLS(y, X).fit(cov_type=self.cov_type)
-        self.coefficients = self.model.params
-        self.conf_ints = self.model.conf_int(alpha=self.alpha)
+        self.coefficients = np.asarray(self.model.params)
+        self.conf_ints = np.asarray(self.model.conf_int(alpha=self.alpha))
         return self
 
     def predict(self, X):
@@ -233,7 +233,6 @@ class BaseSLearner(BaseLearner):
         treatment,
         y,
         p=None,
-        return_ci=False,
         bootstrap_ci=False,
         n_bootstraps=1000,
         bootstrap_size=10000,
@@ -245,7 +244,6 @@ class BaseSLearner(BaseLearner):
             X (np.matrix, np.array, pd.DataFrame, pl.DataFrame, or pl.LazyFrame): a feature matrix
             treatment (np.array, pd.Series, or pl.Series): a treatment vector
             y (np.array, pd.Series, or pl.Series): an outcome vector
-            return_ci (bool, optional): whether to return confidence intervals
             bootstrap_ci (bool): whether to return confidence intervals
             n_bootstraps (int): number of bootstrap iterations
             bootstrap_size (int): number of samples per bootstrap
@@ -296,9 +294,7 @@ class BaseSLearner(BaseLearner):
             ate_lb[i] = _ate_lb
             ate_ub[i] = _ate_ub
 
-        if not return_ci:
-            return ate
-        elif return_ci and not bootstrap_ci:
+        if not bootstrap_ci:
             return ate, ate_lb, ate_ub
         else:
             t_groups_global = self.t_groups

--- a/docs/examples/feature_interpretations_example.ipynb
+++ b/docs/examples/feature_interpretations_example.ipynb
@@ -156,7 +156,7 @@
     "# base_algo = LinearRegression()\n",
     "\n",
     "slearner = BaseSRegressor(base_algo, control_name='control')\n",
-    "slearner.estimate_ate(X=X, treatment=w_multi, y=y)"
+    "slearner.estimate_ate(X=X, treatment=w_multi, y=y)[0]"
    ]
   },
   {

--- a/docs/examples/meta_learners_with_synthetic_data_multiple_treatment.ipynb
+++ b/docs/examples/meta_learners_with_synthetic_data_multiple_treatment.ipynb
@@ -150,7 +150,7 @@
    ],
    "source": [
     "learner_s = BaseSRegressor(XGBRegressor(), control_name='control')\n",
-    "ate_s = learner_s.estimate_ate(X=X, treatment=treatment, y=y, return_ci=False, bootstrap_ci=False)"
+    "ate_s, _, _ = learner_s.estimate_ate(X=X, treatment=treatment, y=y, bootstrap_ci=False)"
    ]
   },
   {
@@ -212,7 +212,7 @@
    "source": [
     "alpha = 0.05\n",
     "learner_s = BaseSRegressor(XGBRegressor(), ate_alpha=alpha, control_name='control')\n",
-    "ate_s, ate_s_lb, ate_s_ub = learner_s.estimate_ate(X=X, treatment=treatment, y=y, return_ci=True,\n",
+    "ate_s, ate_s_lb, ate_s_ub = learner_s.estimate_ate(X=X, treatment=treatment, y=y,\n",
     "                                                   bootstrap_ci=False)"
    ]
   },
@@ -272,12 +272,12 @@
       "INFO:causalml:    Gini   (Control):     0.8248\n",
       "INFO:causalml:    Gini (Treatment):     0.8156\n",
       "INFO:causalml:Bootstrap Confidence Intervals for ATE\n",
-      "100%|██████████| 100/100 [01:14<00:00,  1.34it/s]\n"
+      "100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 100/100 [01:14<00:00,  1.34it/s]\n"
      ]
     }
    ],
    "source": [
-    "ate_s_b, ate_s_lb_b, ate_s_ub_b = learner_s.estimate_ate(X=X, treatment=treatment, y=y, return_ci=True,\n",
+    "ate_s_b, ate_s_lb_b, ate_s_ub_b = learner_s.estimate_ate(X=X, treatment=treatment, y=y,\n",
     "                                                         bootstrap_ci=True, n_bootstraps=100, bootstrap_size=5000)"
    ]
   },
@@ -404,7 +404,7 @@
       "INFO:causalml:    Gini   (Control):     0.8248\n",
       "INFO:causalml:    Gini (Treatment):     0.8156\n",
       "INFO:causalml:Bootstrap Confidence Intervals\n",
-      "100%|██████████| 100/100 [01:02<00:00,  1.59it/s]\n"
+      "100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 100/100 [01:02<00:00,  1.59it/s]\n"
      ]
     }
    ],
@@ -607,7 +607,7 @@
       "INFO:causalml:    Gini   (Control):     0.9216\n",
       "INFO:causalml:    Gini (Treatment):     0.8988\n",
       "INFO:causalml:Bootstrap Confidence Intervals for ATE\n",
-      "100%|██████████| 100/100 [01:00<00:00,  1.66it/s]\n"
+      "100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 100/100 [01:00<00:00,  1.66it/s]\n"
      ]
     }
    ],
@@ -739,7 +739,7 @@
       "INFO:causalml:    Gini   (Control):     0.9216\n",
       "INFO:causalml:    Gini (Treatment):     0.8988\n",
       "INFO:causalml:Bootstrap Confidence Intervals\n",
-      "100%|██████████| 100/100 [00:59<00:00,  1.68it/s]\n"
+      "100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 100/100 [00:59<00:00,  1.68it/s]\n"
      ]
     }
    ],
@@ -1053,7 +1053,7 @@
       "INFO:causalml:    Gini   (Control):     0.9216\n",
       "INFO:causalml:    Gini (Treatment):     0.8988\n",
       "INFO:causalml:Bootstrap Confidence Intervals for ATE\n",
-      "100%|██████████| 100/100 [01:55<00:00,  1.15s/it]\n"
+      "100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 100/100 [01:55<00:00,  1.15s/it]\n"
      ]
     }
    ],
@@ -1120,7 +1120,7 @@
       "INFO:causalml:    Gini   (Control):     0.9216\n",
       "INFO:causalml:    Gini (Treatment):     0.8988\n",
       "INFO:causalml:Bootstrap Confidence Intervals for ATE\n",
-      "100%|██████████| 100/100 [01:56<00:00,  1.17s/it]\n"
+      "100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 100/100 [01:56<00:00,  1.17s/it]\n"
      ]
     }
    ],
@@ -1334,7 +1334,7 @@
       "INFO:causalml:    Gini   (Control):     0.9216\n",
       "INFO:causalml:    Gini (Treatment):     0.8988\n",
       "INFO:causalml:Bootstrap Confidence Intervals\n",
-      "100%|██████████| 100/100 [01:14<00:00,  1.34it/s]\n"
+      "100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 100/100 [01:14<00:00,  1.34it/s]\n"
      ]
     }
    ],
@@ -1468,7 +1468,7 @@
       "INFO:causalml:    Gini   (Control):     0.9216\n",
       "INFO:causalml:    Gini (Treatment):     0.8988\n",
       "INFO:causalml:Bootstrap Confidence Intervals\n",
-      "100%|██████████| 100/100 [01:16<00:00,  1.31it/s]\n"
+      "100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 100/100 [01:16<00:00,  1.31it/s]\n"
      ]
     }
    ],
@@ -1764,7 +1764,7 @@
       "INFO:causalml:generating out-of-fold CV outcome estimates\n",
       "INFO:causalml:training the treatment effect model for treatment_a with R-loss\n",
       "INFO:causalml:Bootstrap Confidence Intervals for ATE\n",
-      "100%|██████████| 100/100 [01:56<00:00,  1.17s/it]\n"
+      "100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 100/100 [01:56<00:00,  1.17s/it]\n"
      ]
     }
    ],
@@ -1826,7 +1826,7 @@
       "INFO:causalml:generating out-of-fold CV outcome estimates\n",
       "INFO:causalml:training the treatment effect model for treatment_a with R-loss\n",
       "INFO:causalml:Bootstrap Confidence Intervals for ATE\n",
-      "100%|██████████| 100/100 [02:42<00:00,  1.63s/it]\n"
+      "100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 100/100 [02:42<00:00,  1.63s/it]\n"
      ]
     }
    ],
@@ -2025,7 +2025,7 @@
       "INFO:causalml:generating out-of-fold CV outcome estimates\n",
       "INFO:causalml:training the treatment effect model for treatment_a with R-loss\n",
       "INFO:causalml:Bootstrap Confidence Intervals\n",
-      "100%|██████████| 100/100 [00:46<00:00,  2.15it/s]\n"
+      "100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 100/100 [00:46<00:00,  2.15it/s]\n"
      ]
     }
    ],
@@ -2154,7 +2154,7 @@
       "INFO:causalml:generating out-of-fold CV outcome estimates\n",
       "INFO:causalml:training the treatment effect model for treatment_a with R-loss\n",
       "INFO:causalml:Bootstrap Confidence Intervals\n",
-      "100%|██████████| 100/100 [00:31<00:00,  3.14it/s]\n"
+      "100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 100/100 [00:31<00:00,  3.14it/s]\n"
      ]
     }
    ],
@@ -2427,7 +2427,7 @@
    ],
    "source": [
     "learner_s = BaseSRegressor(XGBRegressor(), control_name='control')\n",
-    "ate_s = learner_s.estimate_ate(X=X, treatment=treatment, y=y, return_ci=False, bootstrap_ci=False)"
+    "ate_s, _, _ = learner_s.estimate_ate(X=X, treatment=treatment, y=y, bootstrap_ci=False)"
    ]
   },
   {
@@ -2521,7 +2521,7 @@
    "source": [
     "alpha = 0.05\n",
     "learner_s = BaseSRegressor(XGBRegressor(), ate_alpha=alpha, control_name='control')\n",
-    "ate_s, ate_s_lb, ate_s_ub = learner_s.estimate_ate(X=X, treatment=treatment, y=y, return_ci=True,\n",
+    "ate_s, ate_s_lb, ate_s_ub = learner_s.estimate_ate(X=X, treatment=treatment, y=y,\n",
     "                                                   bootstrap_ci=False)"
    ]
   },
@@ -2588,12 +2588,12 @@
       "INFO:causalml:    Gini   (Control):     0.8921\n",
       "INFO:causalml:    Gini (Treatment):     0.9227\n",
       "INFO:causalml:Bootstrap Confidence Intervals for ATE\n",
-      "100%|██████████| 100/100 [01:40<00:00,  1.00s/it]\n"
+      "100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 100/100 [01:40<00:00,  1.00s/it]\n"
      ]
     }
    ],
    "source": [
-    "ate_s_b, ate_s_lb_b, ate_s_ub_b = learner_s.estimate_ate(X=X, treatment=treatment, y=y, return_ci=True,\n",
+    "ate_s_b, ate_s_lb_b, ate_s_ub_b = learner_s.estimate_ate(X=X, treatment=treatment, y=y,\n",
     "                                                         bootstrap_ci=True, n_bootstraps=100, bootstrap_size=5000)"
    ]
   },
@@ -2734,7 +2734,7 @@
       "INFO:causalml:    Gini   (Control):     0.8921\n",
       "INFO:causalml:    Gini (Treatment):     0.9227\n",
       "INFO:causalml:Bootstrap Confidence Intervals\n",
-      "100%|██████████| 100/100 [01:03<00:00,  1.58it/s]\n"
+      "100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 100/100 [01:03<00:00,  1.58it/s]\n"
      ]
     }
    ],
@@ -2953,7 +2953,7 @@
       "INFO:causalml:    Gini   (Control):     0.9280\n",
       "INFO:causalml:    Gini (Treatment):     0.9984\n",
       "INFO:causalml:Bootstrap Confidence Intervals for ATE\n",
-      "100%|██████████| 100/100 [01:32<00:00,  1.08it/s]\n"
+      "100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 100/100 [01:32<00:00,  1.08it/s]\n"
      ]
     }
    ],
@@ -3099,7 +3099,7 @@
       "INFO:causalml:    Gini   (Control):     0.9280\n",
       "INFO:causalml:    Gini (Treatment):     0.9984\n",
       "INFO:causalml:Bootstrap Confidence Intervals\n",
-      "100%|██████████| 100/100 [01:06<00:00,  1.51it/s]\n"
+      "100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 100/100 [01:06<00:00,  1.51it/s]\n"
      ]
     }
    ],
@@ -3401,7 +3401,7 @@
       "INFO:causalml:    Gini   (Control):     0.9280\n",
       "INFO:causalml:    Gini (Treatment):     0.9984\n",
       "INFO:causalml:Bootstrap Confidence Intervals for ATE\n",
-      "100%|██████████| 100/100 [02:55<00:00,  1.75s/it]\n"
+      "100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 100/100 [02:55<00:00,  1.75s/it]\n"
      ]
     }
    ],
@@ -3476,7 +3476,7 @@
       "INFO:causalml:    Gini   (Control):     0.9280\n",
       "INFO:causalml:    Gini (Treatment):     0.9984\n",
       "INFO:causalml:Bootstrap Confidence Intervals for ATE\n",
-      "100%|██████████| 100/100 [02:54<00:00,  1.74s/it]\n"
+      "100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 100/100 [02:54<00:00,  1.74s/it]\n"
      ]
     }
    ],
@@ -3712,7 +3712,7 @@
       "INFO:causalml:    Gini   (Control):     0.9280\n",
       "INFO:causalml:    Gini (Treatment):     0.9984\n",
       "INFO:causalml:Bootstrap Confidence Intervals\n",
-      "100%|██████████| 100/100 [00:51<00:00,  1.94it/s]\n"
+      "100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 100/100 [00:51<00:00,  1.94it/s]\n"
      ]
     }
    ],
@@ -3879,7 +3879,7 @@
       "INFO:causalml:    Gini   (Control):     0.9280\n",
       "INFO:causalml:    Gini (Treatment):     0.9984\n",
       "INFO:causalml:Bootstrap Confidence Intervals\n",
-      "100%|██████████| 100/100 [00:51<00:00,  1.94it/s]\n"
+      "100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 100/100 [00:51<00:00,  1.94it/s]\n"
      ]
     }
    ],
@@ -4213,7 +4213,7 @@
       "INFO:causalml:training the treatment effect model for treatment_a with R-loss\n",
       "INFO:causalml:training the treatment effect model for treatment_b with R-loss\n",
       "INFO:causalml:Bootstrap Confidence Intervals for ATE\n",
-      "100%|██████████| 100/100 [02:19<00:00,  1.39s/it]\n"
+      "100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 100/100 [02:19<00:00,  1.39s/it]\n"
      ]
     }
    ],
@@ -4277,7 +4277,7 @@
       "INFO:causalml:training the treatment effect model for treatment_a with R-loss\n",
       "INFO:causalml:training the treatment effect model for treatment_b with R-loss\n",
       "INFO:causalml:Bootstrap Confidence Intervals for ATE\n",
-      "100%|██████████| 100/100 [02:19<00:00,  1.39s/it]\n"
+      "100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 100/100 [02:19<00:00,  1.39s/it]\n"
      ]
     }
    ],
@@ -4483,7 +4483,7 @@
       "INFO:causalml:training the treatment effect model for treatment_a with R-loss\n",
       "INFO:causalml:training the treatment effect model for treatment_b with R-loss\n",
       "INFO:causalml:Bootstrap Confidence Intervals\n",
-      "100%|██████████| 100/100 [00:37<00:00,  2.65it/s]\n"
+      "100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 100/100 [00:37<00:00,  2.65it/s]\n"
      ]
     }
    ],
@@ -4611,7 +4611,7 @@
       "INFO:causalml:training the treatment effect model for treatment_a with R-loss\n",
       "INFO:causalml:training the treatment effect model for treatment_b with R-loss\n",
       "INFO:causalml:Bootstrap Confidence Intervals\n",
-      "  2%|▏         | 2/100 [00:00<00:36,  2.69it/s]"
+      "  2%|\u258f         | 2/100 [00:00<00:36,  2.69it/s]"
      ]
     }
    ],

--- a/tests/test_meta_learners.py
+++ b/tests/test_meta_learners.py
@@ -1478,8 +1478,7 @@ def test_multi_treatment_learners():
       - ``fit_predict(..., return_ci=False)`` → CATE ``np.ndarray`` only (not a tuple)
       - ``fit_predict(..., return_ci=True)`` → ``tuple`` ``(te, lb, ub)`` of three ndarrays
       - ``estimate_ate(...)`` → ``tuple`` ``(ate, lb, ub)`` with each vector of shape
-        ``(n_treatment_groups,)`` for T/X/R/DR by default; **BaseSLearner** returns only
-        ``ate`` unless ``return_ci=True`` (then same triple as the others).
+        ``(n_treatment_groups,)`` for all meta-learners.
     """
     np.random.seed(RANDOM_SEED)
     n, p, n_groups = 600, 5, 3

--- a/tests/test_meta_learners.py
+++ b/tests/test_meta_learners.py
@@ -109,13 +109,13 @@ def test_BaseSLearner(generate_regression_data):
     learner = BaseSLearner(learner=LinearRegression())
 
     # check the accuracy of the ATE estimation
-    ate_p, lb, ub = learner.estimate_ate(X=X, treatment=treatment, y=y, return_ci=True)
+    ate_p, lb, ub = learner.estimate_ate(X=X, treatment=treatment, y=y)
     assert (ate_p >= lb) and (ate_p <= ub)
     assert ape(tau.mean(), ate_p) < ERROR_THRESHOLD
 
     # check pre-train model
     ate_p_pt, lb_pt, ub_pt = learner.estimate_ate(
-        X=X, treatment=treatment, y=y, return_ci=True, pretrain=True
+        X=X, treatment=treatment, y=y, pretrain=True
     )
     assert (ate_p_pt == ate_p) and (lb_pt == lb) and (ub_pt == ub)
 
@@ -141,15 +141,13 @@ def test_BaseSRegressor(generate_regression_data):
     learner = BaseSRegressor(learner=XGBRegressor())
 
     # check the accuracy of the ATE estimation
-    ate_p, lb, ub = learner.estimate_ate(
-        X=X, treatment=treatment, y=y, return_ci=True, n_bootstraps=10
-    )
+    ate_p, lb, ub = learner.estimate_ate(X=X, treatment=treatment, y=y, n_bootstraps=10)
     assert (ate_p >= lb) and (ate_p <= ub)
     assert ape(tau.mean(), ate_p) < ERROR_THRESHOLD
 
     # check pre-train model
     ate_p_pt, lb_pt, ub_pt = learner.estimate_ate(
-        X=X, treatment=treatment, y=y, return_ci=True, n_bootstraps=10, pretrain=True
+        X=X, treatment=treatment, y=y, n_bootstraps=10, pretrain=True
     )
     assert (ate_p_pt == ate_p) and (lb_pt == lb) and (ub_pt == ub)
 
@@ -193,6 +191,20 @@ def test_LRSRegressor(generate_regression_data):
         X=X, treatment=treatment, y=y, pretrain=True
     )
     assert (ate_p_pt == ate_p) and (lb_pt == lb) and (ub_pt == ub)
+
+
+def test_LRSRegressor_dataframe(generate_regression_data):
+    y, X, treatment, tau, b, e = generate_regression_data()
+    X_df = pd.DataFrame(X, columns=["col_" + str(i) for i in range(X.shape[1])])
+    learner = LRSRegressor()
+    result = learner.estimate_ate(X=X_df, treatment=treatment, y=y)
+
+    assert isinstance(result, tuple) and len(result) == 3
+    ate_p, lb, ub = result
+    assert isinstance(ate_p, np.ndarray) and ate_p.shape == (1,)
+    assert isinstance(lb, np.ndarray) and lb.shape == (1,)
+    assert isinstance(ub, np.ndarray) and ub.shape == (1,)
+    assert (ate_p >= lb) and (ate_p <= ub)
 
 
 def test_BaseTLearner(generate_regression_data):
@@ -1149,9 +1161,7 @@ def test_pandas_input(generate_regression_data):
 
     try:
         learner = BaseSLearner(learner=LinearRegression())
-        ate_p, lb, ub = learner.estimate_ate(
-            X=X, treatment=treatment, y=y, return_ci=True
-        )
+        ate_p, lb, ub = learner.estimate_ate(X=X, treatment=treatment, y=y)
     except AttributeError:
         assert False
     try:
@@ -1710,13 +1720,10 @@ def test_multi_treatment_learners():
         name,
         "fit_predict",
     )
-    ate_only = sl.estimate_ate(X=X, treatment=treatment, y=y, return_ci=False)
-    assert isinstance(ate_only, np.ndarray) and ate_only.shape == (
-        n_groups,
-    ), f"{name}.estimate_ate(return_ci=False) must be shape (n_groups,)"
-    _assert_ate(sl.estimate_ate(X=X, treatment=treatment, y=y, return_ci=True), name)
+
+    _assert_ate(sl.estimate_ate(X=X, treatment=treatment, y=y), name)
     _assert_ate(
-        sl.estimate_ate(X=X, treatment=treatment, y=y, return_ci=True, pretrain=True),
+        sl.estimate_ate(X=X, treatment=treatment, y=y, pretrain=True),
         name,
     )
 
@@ -2241,13 +2248,9 @@ def test_finite_predict_stochastic(Cls, kwargs):
 def test_bit_identical_estimate_ate_s():
     """S-learner estimate_ate() CI triple is bit-identical across clone+refit."""
     m1 = BaseSRegressor(learner=_DT_REG)
-    ate1, lb1, ub1 = m1.estimate_ate(
-        X=_X, treatment=_TREATMENT, y=_Y_CONT, return_ci=True
-    )
+    ate1, lb1, ub1 = m1.estimate_ate(X=_X, treatment=_TREATMENT, y=_Y_CONT)
     m2 = clone(m1)
-    ate2, lb2, ub2 = m2.estimate_ate(
-        X=_X, treatment=_TREATMENT, y=_Y_CONT, return_ci=True
-    )
+    ate2, lb2, ub2 = m2.estimate_ate(X=_X, treatment=_TREATMENT, y=_Y_CONT)
     np.testing.assert_array_equal(ate1, ate2)
     np.testing.assert_array_equal(lb1, lb2)
     np.testing.assert_array_equal(ub1, ub2)

--- a/tests/test_polars_support.py
+++ b/tests/test_polars_support.py
@@ -280,14 +280,11 @@ class TestSLearnerPolars:
 
     def test_estimate_ate_polars(self, synthetic_data_polars):
         X, treatment, y = synthetic_data_polars
-        # BaseSLearner.estimate_ate returns only `ate` when return_ci=False (default)
-        ate = self.learner.estimate_ate(X=X, treatment=treatment, y=y)
+        ate, lb, ub = self.learner.estimate_ate(X=X, treatment=treatment, y=y)
         assert isinstance(ate, np.ndarray)
-        # With return_ci=True it returns (ate, lb, ub)
-        ate, lb, ub = self.learner.estimate_ate(
-            X=X, treatment=treatment, y=y, return_ci=True
-        )
-        assert lb[0] < ate[0] < ub[0]
+        assert isinstance(lb, np.ndarray)
+        assert isinstance(ub, np.ndarray)
+        assert lb[0] <= ate[0] <= ub[0]
 
 
 # X-Learner


### PR DESCRIPTION
## Proposed changes

Fixes #1026.

This PR fixes two issues in `BaseSLearner.estimate_ate`:

- Fixes a `KeyError: (0, 0)` when `LRSRegressor.estimate_ate()` is called with a pandas DataFrame.
- Makes `BaseSLearner.estimate_ate()` consistently return `(ate, lb, ub)`, matching the other meta-learners.

The statsmodels parameters and confidence intervals are converted to NumPy arrays before positional indexing.

Tests were updated to reflect the consistent S-learner return signature, and a regression test was added for DataFrame input.

## Before & After
<img width="1257" height="399" alt="before and after" src="https://github.com/user-attachments/assets/6f812d8a-804a-4bb9-a190-67cba682536e" />

## Test
```powershell
function T($c,$n) {
    git checkout --force $c | Out-Null
    Write-Host "`n========== $n =========="

    @'
import numpy as np
import pandas as pd
from causalml.inference.meta import LRSRegressor, BaseSRegressor
from sklearn.linear_model import LinearRegression

rng = np.random.RandomState(42)
X = pd.DataFrame(rng.normal(size=(200, 5)), columns=list("abcde"))
t = rng.binomial(1, 0.5, 200)
y = 2*t + X["a"].to_numpy() + 0.5*X["b"].to_numpy() + rng.normal(size=200)

try:
    result = LRSRegressor().estimate_ate(X=X, treatment=t, y=y)
    print("DataFrame: PASS ->", result)
except Exception as e:
    print("DataFrame: FAIL ->", type(e).__name__, e)

X = rng.normal(size=(200, 5))
y = 2*t + X[:, 0] + 0.5*X[:, 1] + rng.normal(size=200)

result = BaseSRegressor(learner=LinearRegression()).estimate_ate(
    X=X, treatment=t, y=y
)

print("S-learner:", result)
print("Return type:", type(result).__name__)
print("Return length:", len(result))
'@ | python
}

T "35f6e734a478eea6fdf1cfaf1b85e0f04ae99b83" "BEFORE #1026 — BUG"
T "ef98264f8d7b8cce18666464cabb66b7abc0e402" "AFTER #1026 — FIXED"
```

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/uber/causalml/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/uber/causalml)
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments

The `return_ci` argument for `BaseSLearner.estimate_ate()` was removed so that S-learners follow the same `estimate_ate()` return convention as the other meta-learners.

The original DataFrame failure was reproduced against the parent commit and verified as fixed. CI passes on Python 3.11 and 3.12, and lint checks pass.