### PR TITLE
Fix #1029: Thread random_state to BaseRLearner bootstraps

### DIFF
--- a/causalml/inference/meta/rlearner.py
+++ b/causalml/inference/meta/rlearner.py
@@ -4,6 +4,7 @@ import numpy as np
 from tqdm import tqdm
 from scipy.stats import norm
 from sklearn.model_selection import cross_val_predict, KFold, train_test_split
+from sklearn.utils import check_random_state
 
 try:
     from xgboost import XGBRegressor, XGBClassifier
@@ -312,12 +313,15 @@ class BaseRLearner(BaseLearner):
             )
 
             logger.info("Bootstrap Confidence Intervals")
+            rng = check_random_state(self.random_state)
             for i in tqdm(range(n_bootstraps)):
                 if p is None:
                     p = self.propensity
                 else:
                     p = self._format_p(p, self.t_groups)
-                te_b = self.bootstrap(X, treatment_np, y_np, p, size=bootstrap_size)
+                te_b = self.bootstrap(
+                    X, treatment_np, y_np, p, size=bootstrap_size, rng=rng
+                )
                 te_bootstraps[:, :, i] = te_b
 
             te_lower = np.percentile(te_bootstraps, (self.ate_alpha / 2) * 100, axis=2)
@@ -414,12 +418,15 @@ class BaseRLearner(BaseLearner):
             logger.info("Bootstrap Confidence Intervals for ATE")
             ate_bootstraps = np.zeros(shape=(self.t_groups.shape[0], n_bootstraps))
 
+            rng = check_random_state(self.random_state)
             for n in tqdm(range(n_bootstraps)):
                 if p is None:
                     p = self.propensity
                 else:
                     p = self._format_p(p, self.t_groups)
-                cate_b = self.bootstrap(X, treatment_np, y_np, p, size=bootstrap_size)
+                cate_b = self.bootstrap(
+                    X, treatment_np, y_np, p, size=bootstrap_size, rng=rng
+                )
                 ate_bootstraps[:, n] = cate_b.mean(axis=0)
 
             ate_lower = np.percentile(

--- a/tests/test_meta_learners.py
+++ b/tests/test_meta_learners.py
@@ -2316,3 +2316,58 @@ def test_dr_learner_pretrain_before_fit_raises():
         BaseDRRegressor(learner=_DT_REG).estimate_ate(
             X=_X, treatment=_TREATMENT, y=_Y_CONT, pretrain=True
         )
+
+
+def test_base_rlearner_bootstrap_reproducibility(generate_regression_data):
+    y, X, treatment, tau, b, e = generate_regression_data()
+
+    np.random.seed(RANDOM_SEED)
+    learner1 = BaseRRegressor(learner=LinearRegression(), random_state=42)
+    ate1, lb1_ate, ub1_ate = learner1.estimate_ate(
+        X, treatment=treatment, y=y, bootstrap_ci=True, n_bootstraps=5
+    )
+    te1, lb1_te, ub1_te = learner1.fit_predict(
+        X, treatment=treatment, y=y, return_ci=True, n_bootstraps=5
+    )
+
+    np.random.rand(100)
+
+    learner2 = BaseRRegressor(learner=LinearRegression(), random_state=42)
+    ate2, lb2_ate, ub2_ate = learner2.estimate_ate(
+        X, treatment=treatment, y=y, bootstrap_ci=True, n_bootstraps=5
+    )
+    te2, lb2_te, ub2_te = learner2.fit_predict(
+        X, treatment=treatment, y=y, return_ci=True, n_bootstraps=5
+    )
+
+    learner3 = BaseRRegressor(
+        learner=LinearRegression(), random_state=np.random.RandomState(42)
+    )
+    ate3, lb3_ate, ub3_ate = learner3.estimate_ate(
+        X, treatment=treatment, y=y, bootstrap_ci=True, n_bootstraps=5
+    )
+    te3, lb3_te, ub3_te = learner3.fit_predict(
+        X, treatment=treatment, y=y, return_ci=True, n_bootstraps=5
+    )
+
+    np.random.rand(100)
+
+    learner4 = BaseRRegressor(
+        learner=LinearRegression(), random_state=np.random.RandomState(42)
+    )
+    ate4, lb4_ate, ub4_ate = learner4.estimate_ate(
+        X, treatment=treatment, y=y, bootstrap_ci=True, n_bootstraps=5
+    )
+    te4, lb4_te, ub4_te = learner4.fit_predict(
+        X, treatment=treatment, y=y, return_ci=True, n_bootstraps=5
+    )
+
+    np.testing.assert_array_equal(lb1_ate, lb2_ate)
+    np.testing.assert_array_equal(ub1_ate, ub2_ate)
+    np.testing.assert_array_equal(lb1_te, lb2_te)
+    np.testing.assert_array_equal(ub1_te, ub2_te)
+
+    np.testing.assert_array_equal(lb3_ate, lb4_ate)
+    np.testing.assert_array_equal(ub3_ate, ub4_ate)
+    np.testing.assert_array_equal(lb3_te, lb4_te)
+    np.testing.assert_array_equal(ub3_te, ub4_te)


### PR DESCRIPTION
## Proposed changes

Fixes #1029.

`BaseRLearner` bootstrap confidence intervals could depend on unrelated global NumPy RNG state even when `random_state` was provided.

This change:
- Creates a local NumPy RNG from `BaseRLearner.random_state`.
- Passes the RNG to the bootstrap sampling in `fit_predict()` and `estimate_ate()`.
- Adds a regression test covering both public bootstrap paths and verifying reproducibility after unrelated global NumPy RNG consumption.

The metric functions are unchanged because they already use their provided `random_state` for bootstrap sampling.

## Before & After
<img width="1764" height="929" alt="1029" src="https://github.com/user-attachments/assets/cdeef035-52ad-4c46-b809-7695770cbc8e" />

## Test

```powershell
$S="$env:TEMP\causalml-1029-review\test_1029.py";$B="$env:TEMP\causalml-1029-review\before";$A="$env:TEMP\causalml-1029-review\after";@'
import sys
import numpy as np
from sklearn.linear_model import LinearRegression
sys.path.insert(0, sys.argv[1])
from causalml.inference.meta.rlearner import BaseRRegressor

rng=np.random.RandomState(123)
X=rng.randn(160,4)
t=rng.binomial(1,.5,160)
y=1.5*X[:,0]-.8*X[:,1]+2*t+rng.randn(160)*.5

def run(noise):
    np.random.seed(2026)
    np.random.rand(noise)
    m=BaseRRegressor(learner=LinearRegression(),n_fold=3,random_state=42)
    _,lo,hi=m.fit_predict(X,y=y,treatment=t,return_ci=True,n_bootstraps=20,bootstrap_size=120,verbose=False)
    return lo,hi

a=run(0)
b=run(1000)
print("same lower:",np.array_equal(a[0],b[0]))
print("same upper:",np.array_equal(a[1],b[1]))
print("RESULT:","PASS" if np.array_equal(a[0],b[0]) and np.array_equal(a[1],b[1]) else "FAIL")
'@|Set-Content $S -Encoding UTF8;"BEFORE 35f6e734";python $S $B;"AFTER 52fd2734";python $S $A
```

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/uber/causalml/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/uber/causalml)
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments

The regression test verifies that identical seeded `BaseRRegressor` runs produce identical confidence intervals regardless of unrelated global NumPy RNG consumption.