### PR TITLE
Apply clip_bounds to a user-supplied propensity model

### DIFF
--- a/causalml/propensity.py
+++ b/causalml/propensity.py
@@ -243,7 +243,11 @@ def compute_propensity_score(
         logger.info("predict_proba not available, using predict instead")
         p = p_model.predict(X_pred)
 
-    return p, p_model
+    # PropensityModel.predict already clips, but a user-supplied classifier
+    # does not, and a score of exactly 0 or 1 divides by zero in the DR-learner
+    # and TMLE, and trips check_p_conditions. Clip whatever the model returned
+    # so clip_bounds holds for every model.
+    return np.clip(p, *clip_bounds), p_model
 
 
 def compute_r_residuals(

--- a/tests/test_propensity.py
+++ b/tests/test_propensity.py
@@ -84,3 +84,47 @@ def test_propensity_models_imbalanced_1027():
     pm_en = ElasticNetPropensityModel(random_state=RANDOM_SEED)
     pm_en.fit_predict(X, treatment)
     assert pm_en.model.C_[0] > 1e-4
+
+
+def test_compute_propensity_score_clips_a_user_supplied_model():
+    """clip_bounds has to hold for any model, not only the built-in ones.
+
+    ``PropensityModel.predict`` clips, but a plain scikit-learn classifier does
+    not, and a score of exactly 0 or 1 divides by zero in the DR-learner and in
+    TMLE, and fails ``check_p_conditions``.
+    """
+    from sklearn.linear_model import LogisticRegression
+
+    from causalml.propensity import compute_propensity_score
+
+    rng = np.random.RandomState(RANDOM_SEED)
+    n = 400
+    X = rng.normal(size=(n, 3))
+    # perfectly separable, so an unregularised classifier saturates at 0 and 1
+    treatment = (X[:, 0] > 0).astype(int)
+
+    clip_bounds = (1e-3, 1 - 1e-3)
+    p, _ = compute_propensity_score(
+        X=X,
+        treatment=treatment,
+        p_model=LogisticRegression(C=1e9, max_iter=1000),
+        clip_bounds=clip_bounds,
+    )
+
+    assert p.min() >= clip_bounds[0]
+    assert p.max() <= clip_bounds[1]
+
+
+def test_compute_propensity_score_honors_custom_clip_bounds():
+    from causalml.propensity import compute_propensity_score
+
+    rng = np.random.RandomState(RANDOM_SEED)
+    n = 400
+    X = rng.normal(size=(n, 3))
+    treatment = (X[:, 0] > 0).astype(int)
+
+    clip_bounds = (0.2, 0.8)
+    p, _ = compute_propensity_score(X=X, treatment=treatment, clip_bounds=clip_bounds)
+
+    assert p.min() >= clip_bounds[0]
+    assert p.max() <= clip_bounds[1]


### PR DESCRIPTION
`compute_propensity_score` documents `clip_bounds` as keeping the score away from 0 and 1 so later steps do not divide by zero, but the bound only applies when the default model is used. `PropensityModel.predict` clips internally; a user-supplied classifier goes through `predict_proba` and its output is returned untouched.

On a separable treatment that saturates:

```python
p_user, _ = compute_propensity_score(X=X, treatment=w, p_model=LogisticRegression(C=1e9, max_iter=1000))
p_def, _ = compute_propensity_score(X=X, treatment=w)
p_user.min(), p_user.max()   # 0.0, 1.0
p_def.min(), p_def.max()     # 0.001, 0.999
```

Feeding the first one back into the library rejects it, which is what the bound was there to prevent:

```python
BaseDRRegressor(learner=LinearRegression()).fit_predict(X=X, treatment=w, y=y, p=p_user)
AssertionError: The values of p should lie within the (0, 1) interval.
```

The DR-learner divides by both `p_filt` and `1 - p_filt`, and TMLE by `p` and `1 - p`, so the guard is the only thing standing between a saturated propensity model and an infinity.

The returned score is now clipped whichever model produced it. For the built-in models this is a no-op, since `predict` has already clipped to the same bounds. `BaseRLearner(propensity_learner=...)` reaches the unclipped path through `self.model_p`, so it is covered too.

Two tests: a user-supplied `LogisticRegression` on separable data has to come back inside the default bounds, which fails on master with `assert np.float64(0.0) >= 0.001`, and custom bounds have to hold as well.

`pytest tests/test_propensity.py tests/test_cate_scoring.py` is 39 passing, and black is clean on both files.
