### PR TITLE
Skip non-numeric covariates when computing standardized differences

### DIFF
--- a/causalml/metrics/visualize.py
+++ b/causalml/metrics/visualize.py
@@ -1092,12 +1092,19 @@ def _get_numeric_vars(X, threshold=5):
     is set to 5 by default.
     """
 
+    # Only numeric columns can be averaged, and a non-numeric column that
+    # happened to have enough distinct values used to be classified as
+    # continuous and then failed in the mean with a numpy type error.
+    numeric = [pd.api.types.is_numeric_dtype(X.iloc[:, i]) for i in range(X.shape[1])]
+
     cont = [
-        (not hasattr(X.iloc[:, i], "cat")) and (X.iloc[:, i].nunique() >= threshold)
+        numeric[i]
+        and (not hasattr(X.iloc[:, i], "cat"))
+        and (X.iloc[:, i].nunique() >= threshold)
         for i in range(X.shape[1])
     ]
 
-    prop = [X.iloc[:, i].nunique() == 2 for i in range(X.shape[1])]
+    prop = [numeric[i] and X.iloc[:, i].nunique() == 2 for i in range(X.shape[1])]
 
     cont_cols = list(X.loc[:, cont].columns)
     prop_cols = list(X.loc[:, prop].columns)
@@ -1106,7 +1113,7 @@ def _get_numeric_vars(X, threshold=5):
 
     if dropped:
         logger.info(
-            'Some non-binary variables were dropped because they had fewer than {} unique values or were of the \
+            'Some variables were dropped because they were not numeric, had fewer than {} unique values, or were of the \
                      dtype "cat". The dropped variables are: {}'.format(
                 threshold, dropped
             )

--- a/tests/test_visualize.py
+++ b/tests/test_visualize.py
@@ -71,3 +71,45 @@ def test_plot_tmlegain(generate_regression_data, monkeypatch):
         cv=kf,
         ci=False,
     )
+
+
+def test_get_std_diffs_skips_non_numeric_covariates():
+    """A string covariate has no mean, so it belongs in the dropped set.
+
+    Before, any column with enough distinct values was classified as
+    continuous whatever its dtype, and the diagnostic died inside numpy with
+    "ufunc 'divide' not supported for the input types" rather than reporting
+    the balance of the columns it could measure.
+    """
+    from causalml.metrics.visualize import _get_numeric_vars, get_std_diffs
+
+    rng = np.random.RandomState(42)
+    n = 50
+    X = pd.DataFrame(
+        {
+            "age": rng.normal(size=n),
+            "group": rng.choice(list("abcdef"), size=n),
+            "flag": rng.randint(0, 2, size=n),
+        }
+    )
+    w = pd.Series(rng.randint(0, 2, size=n))
+
+    cont_cols, prop_cols = _get_numeric_vars(X)
+    assert cont_cols == ["age"]
+    assert prop_cols == ["flag"]
+
+    std_diffs = get_std_diffs(X, w)
+    assert list(std_diffs.index) == ["age", "flag"]
+    assert np.isfinite(std_diffs.values).all()
+
+
+def test_get_std_diffs_errors_when_no_covariate_is_usable():
+    from causalml.metrics.visualize import get_std_diffs
+
+    rng = np.random.RandomState(42)
+    n = 20
+    X = pd.DataFrame({"group": rng.choice(list("abcdef"), size=n)})
+    w = pd.Series(rng.randint(0, 2, size=n))
+
+    with pytest.raises(ValueError):
+        get_std_diffs(X, w)


### PR DESCRIPTION
`_get_numeric_vars` is documented as working out which covariates are numeric, but it never looks at the dtype. A string column with at least `threshold` distinct values passes the continuous test, and the standardized difference then dies inside numpy:

```python
X = pd.DataFrame({'age': ..., 'group': rng.choice(list('abcdef'), size=n), 'flag': ...})
_get_numeric_vars(X)     # (['age', 'group'], ['flag'])
get_std_diffs(X, w)      # TypeError: ufunc 'divide' not supported for the input types
```

That reaches users through `plot_ps_diagnostics`, which takes whatever covariate columns the caller names, and categorical covariates are a normal thing to have in a propensity model. The function already has the right behaviour for columns it cannot use: it drops them and logs which ones. Non-numeric columns now take that path, so the diagnostic reports balance for the covariates it can measure instead of failing outright.

The dropped-variables message was only describing two of its three reasons, so it now mentions the non-numeric case too.

Two tests: a frame with a string covariate classifies as `['age']` continuous and `['flag']` binary and produces finite differences, and a frame whose only covariate is non-numeric still raises the existing `ValueError` for having nothing to measure. The first fails on master with `assert ['age', 'group'] == ['age']` and then the `TypeError` above.

`pytest tests/test_visualize.py tests/test_visualize_score_ci.py` is 33 passing, and black is clean.
