### PR TITLE
Fix #1045: seed and stratify the GBM propensity early-stopping split

### DIFF
--- a/causalml/propensity.py
+++ b/causalml/propensity.py
@@ -179,8 +179,17 @@ class GradientBoostedPropensityModel(PropensityModel):
                 so this vector must be the treatment assignment.
         """
         if self.early_stop:
+            # Seed the split with the same random_state the underlying
+            # XGBClassifier resolves to, so that early stopping -- and
+            # therefore the fitted model -- is reproducible. Stratify on the
+            # treatment indicator so the validation set retains both arms,
+            # matching how the rest of the library splits on treatment.
             X_train, X_val, y_train, y_val = train_test_split(
-                X, y, test_size=stop_val_size
+                X,
+                y,
+                test_size=stop_val_size,
+                random_state=self.model_kwargs.get("random_state", 42),
+                stratify=y,
             )
 
             self.model.fit(

--- a/tests/test_propensity.py
+++ b/tests/test_propensity.py
@@ -1,5 +1,7 @@
 import numpy as np
+import pytest
 
+from causalml import propensity
 from causalml.propensity import (
     ElasticNetPropensityModel,
     GradientBoostedPropensityModel,
@@ -69,6 +71,45 @@ def test_gradientboosted_propensity_model_earlystopping(generate_regression_data
     ps = pm.fit_predict(X, treatment)
 
     assert roc_auc_score(treatment, ps) > 0.5
+
+
+def test_gradientboosted_propensity_model_earlystopping_reproducible(
+    generate_regression_data,
+):
+    """Early stopping is reproducible: the validation split is seeded (#1045)."""
+    y, X, treatment, tau, b, e = generate_regression_data()
+
+    def fit_predict(random_state):
+        pm = GradientBoostedPropensityModel(random_state=random_state, early_stop=True)
+        return pm.fit_predict(X, treatment)
+
+    np.testing.assert_array_equal(fit_predict(RANDOM_SEED), fit_predict(RANDOM_SEED))
+    # A different seed must still move the split; otherwise the seed would be
+    # ignored in a different way (e.g. a hard-coded constant).
+    assert not np.array_equal(fit_predict(RANDOM_SEED), fit_predict(RANDOM_SEED + 1))
+
+
+def test_gradientboosted_propensity_model_earlystopping_stratified(monkeypatch):
+    """The early-stopping validation split keeps both treatment arms (#1045)."""
+    rng = np.random.RandomState(RANDOM_SEED)
+    X = rng.normal(size=(400, 10))
+    treatment = (rng.uniform(size=400) < 0.1).astype(int)
+
+    captured = {}
+    train_test_split = propensity.train_test_split
+
+    def spy(*args, **kwargs):
+        split = train_test_split(*args, **kwargs)
+        captured["y_val"] = split[3]
+        return split
+
+    monkeypatch.setattr(propensity, "train_test_split", spy)
+
+    pm = GradientBoostedPropensityModel(random_state=RANDOM_SEED, early_stop=True)
+    pm.fit(X, treatment)
+
+    # Stratification preserves the treatment rate up to rounding.
+    assert captured["y_val"].mean() == pytest.approx(treatment.mean(), abs=0.01)
 
 
 def test_propensity_models_imbalanced_1027():


### PR DESCRIPTION
Fixes #1045.

`GradientBoostedPropensityModel.fit()` drew its early-stopping validation set with neither a `random_state` nor `stratify`, so a model constructed with an explicit seed still produced a different fit on every call.

### The change

One call, in `causalml/propensity.py`:

```python
X_train, X_val, y_train, y_val = train_test_split(
    X,
    y,
    test_size=stop_val_size,
    random_state=self.model_kwargs.get("random_state", 42),
    stratify=y,
)
```

**`random_state`** — `_model` resolves the `XGBClassifier` seed as `self.model_kwargs.get("random_state", 42)`; reusing that expression puts the split and the classifier on the same seed. The R-learner's own early-stopping split already does this (`rlearner.py:830`), so this brings the last unseeded split in the library into line. `random_state=None` stays genuinely random, per the scikit-learn convention.

**`stratify`** — `y` here is the binary treatment indicator, and every other treatment split in the library stratifies on it (`compute_r_residuals`, whose docstring promises "every fold retains both arms"; `LogisticRegressionPropensityModel`'s `StratifiedKFold`). Without it the validation set's treated count swings by an order of magnitude on imbalanced data, and at small n can reach zero, which makes the early-stopping metric meaningless.

### Effect

Same seed, same data, three consecutive fits:

| | before | after |
|---|---|---|
| `early_stop=True` | not identical, max abs diff **0.5466** | identical |
| `early_stop=False` | identical | identical |

`early_stop=False` was already reproducible and is unchanged — it is the control that isolates the split as the source of the nondeterminism.

### Tests

Two regression tests in `tests/test_propensity.py`:

- `..._earlystopping_reproducible` — same seed gives bit-identical scores, and a *different* seed still gives different scores, so the test cannot be satisfied by hard-coding a constant.
- `..._earlystopping_stratified` — on 10%-treated data, asserts the validation split preserves the treatment rate.

Both fail on master and pass with the change. Verified the fix under numpy, pandas and polars inputs, which all produce identical scores.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
