### PR TITLE
Fail loudly in mape and define smape's 0/0 term

### DIFF
--- a/causalml/metrics/regression.py
+++ b/causalml/metrics/regression.py
@@ -55,7 +55,10 @@ def smape(y, p):
     # Where the target and the prediction are both zero the prediction is exact,
     # and the 0 / 0 term is defined as 0 rather than propagating a NaN.
     ratio = np.divide(
-        np.abs(y - p), denominator, out=np.zeros_like(denominator, dtype=float), where=denominator > EPS
+        np.abs(y - p),
+        denominator,
+        out=np.zeros_like(denominator, dtype=float),
+        where=denominator > EPS,
     )
     return 2.0 * np.mean(ratio)
 

--- a/causalml/metrics/regression.py
+++ b/causalml/metrics/regression.py
@@ -34,6 +34,11 @@ def mape(y, p):
     """
 
     filt = np.abs(y) > EPS
+    if not filt.any():
+        raise ValueError(
+            "MAPE is undefined when every target is zero or smaller than EPS "
+            f"({EPS}); no element survives the filter."
+        )
     return np.mean(np.abs(1 - p[filt] / y[filt]))
 
 
@@ -46,7 +51,13 @@ def smape(y, p):
     Returns:
         e (numpy.float64): sMAPE
     """
-    return 2.0 * np.mean(np.abs(y - p) / (np.abs(y) + np.abs(p)))
+    denominator = np.abs(y) + np.abs(p)
+    # Where the target and the prediction are both zero the prediction is exact,
+    # and the 0 / 0 term is defined as 0 rather than propagating a NaN.
+    ratio = np.divide(
+        np.abs(y - p), denominator, out=np.zeros_like(denominator, dtype=float), where=denominator > EPS
+    )
+    return 2.0 * np.mean(ratio)
 
 
 def rmse(y, p):

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,7 +1,9 @@
 import numpy as np
 import pandas as pd
+import pytest
 from numpy import isclose
 from causalml.metrics.classification import logloss
+from causalml.metrics.regression import mape, smape
 from causalml.metrics.visualize import qini_score
 
 
@@ -46,3 +48,43 @@ def test_logloss_clips_degenerate_predictions():
     p = np.array([0.0, 1.0])
 
     assert np.isfinite(logloss(y, p))
+
+
+def test_mape_raises_when_every_target_is_zero():
+    y = np.zeros(100)
+    p = np.zeros(100)
+
+    with pytest.raises(ValueError):
+        mape(y, p)
+
+
+def test_mape_ignores_zero_targets_but_keeps_the_rest():
+    y = np.array([0.0, 2.0, 0.0, 8.0])
+    p = np.array([0.0, 1.8, 0.5, 7.0])
+
+    # Only the two non-zero targets contribute: |1 - 1.8/2| and |1 - 7/8|.
+    assert isclose(mape(y, p), 0.1125)
+
+
+def test_smape_is_zero_when_target_and_prediction_are_both_zero():
+    y = np.zeros(100)
+    p = np.zeros(100)
+
+    # A zero prediction for a zero target is exact, not undefined.
+    assert smape(y, p) == 0.0
+
+
+def test_smape_does_not_nan_on_a_single_zero_pair():
+    y = np.array([0.0, 2.0, 0.0, 8.0])
+    p = np.array([0.0, 1.8, 0.5, 7.0])
+
+    result = smape(y, p)
+    assert not np.isnan(result)
+    assert isclose(result, 0.5596491228070176)
+
+
+def test_smape_unchanged_for_non_degenerate_input():
+    y = np.array([1.0, 2.0, 4.0, 8.0])
+    p = np.array([1.1, 1.8, 4.4, 7.0])
+
+    assert isclose(smape(y, p), 0.1072681704260651)


### PR DESCRIPTION
Fixes #1047.

`mape` filtered out near-zero targets and then averaged what was left. When every target is at or below `EPS` the filter selects nothing, and `np.mean` of an empty slice returns NaN with only a RuntimeWarning, which is easy to lose in training logs. The scalar sibling `ape` already asserts against this, so `mape` now raises `ValueError`.

`smape` has the related problem one element along, and it is the more likely one to bite: where target and prediction are both zero the term is `0/0`, so a single such row turns the whole metric into NaN even when every other row is fine. That row is an exact prediction rather than an undefined one, so the term is defined as 0.

The issue was filed from static analysis, so I ran it first. Before:

```
mape(zeros, zeros)   -> nan   ['Mean of empty slice.', 'invalid value encountered in scalar divide']
smape(zeros, zeros)  -> nan
smape([0, 2, 0, 8], [0, 1.8, 0.5, 7])  -> nan
```

After: `mape` raises, `smape(zeros, zeros)` is `0.0`, and the mixed case is `0.5596`. Both metrics are unchanged on non-degenerate input (`mape` 0.10625 and `smape` 0.10727 before and after), and `mape` still ignores zero targets when others are present.

Five tests added to `tests/test_metrics.py`. Three fail on master, the two that pin unchanged behaviour pass either way.
